### PR TITLE
Ensure contract exists before accessing its member

### DIFF
--- a/src/leases/components/leaseSections/contract/ContractItemEdit.js
+++ b/src/leases/components/leaseSections/contract/ContractItemEdit.js
@@ -393,7 +393,7 @@ class ContractItemEdit extends Component<Props> {
       contract,
     } = this.props;
 
-    if(contractNumber && (prevProps.contractNumber !== contractNumber) && (contractNumber !== contract.contract_number)) {
+    if(contractNumber && (prevProps.contractNumber !== contractNumber) && contract && (contractNumber !== contract.contract_number)) {
       fetchLeasesForContractNumber({contract_number: contractNumber});
     }
   }
@@ -516,7 +516,7 @@ class ContractItemEdit extends Component<Props> {
                     <Loader isLoading={isFetchingLeasesForContractNumbers}/>
                   </LoaderWrapper>
                 }
-                {(contractNumber && !isFetchingLeasesForContractNumbers && leasesWithContractNumber && (contractNumber !== contract.contract_number)) && <WarningContainer>
+                {(contractNumber && !isFetchingLeasesForContractNumbers && leasesWithContractNumber && contract && (contractNumber !== contract.contract_number)) && <WarningContainer>
                   <WarningField
                     meta={{warning: 'Sopimusnumero käytössä!'}}
                     showWarning={true}


### PR DESCRIPTION
When inputting a contract number into a newly created contract, the page crashes because of the "is this contract in another lease already" (`leasesWithContractNumber`) check. This hotfix merely prevents crashing but also effectively disables the check for new contracts so it should be fixed properly later.