### PR TITLE
Add info links

### DIFF
--- a/src/enums.js
+++ b/src/enums.js
@@ -176,6 +176,11 @@ export const ConfirmationModalTexts = {
     LABEL: 'Haluatko varmasti poistaa vuokrauksen täydennysrakentamiskorvauksesta?',
     TITLE: 'Poista vuokraus täydennysrakentamiskorvauksesta',
   },
+  DELETE_INFO_LINK: {
+    BUTTON: DELETE_MODAL_BUTTON_TEXT,
+    LABEL: 'Haluatko varmasti poistaa lisätietolinkin?',
+    TITLE: 'Poista lisätietolinkki',
+  },
   DELETE_INSPECTION: {
     BUTTON: DELETE_MODAL_BUTTON_TEXT,
     LABEL: 'Haluatko varmasti poistaa tarkastuksen?',

--- a/src/main.scss
+++ b/src/main.scss
@@ -68,6 +68,7 @@
 @import "leases/components/leaseSections/tenant/tenant-edit";
 @import "rentbasis/components/rent-basis-page";
 @import "plotSearch/components/plotSearchSections/application/application";
+@import "plotSearch/components/plotSearchSections/basicInfo/basic-info";
 
 @import "foundation/styles";
 

--- a/src/plotSearch/components/plotSearchSections/basicInfo/BasicInfo.js
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/BasicInfo.js
@@ -239,12 +239,12 @@ class BasicInfo extends PureComponent<Props, State> {
                   </Row>
                 )}
               </div>
-              {(!!plotSearch.targets && plotSearch.targets.
+              {(!!plotSearch.plot_search_targets && plotSearch.plot_search_targets.
                 filter(plotSearchSite => plotSearchSite.target_type === 'searchable').length > 0) && <WhiteBox>
                 <SubTitle>
                   {'HAETTAVAT KOHTEET'}
                 </SubTitle>
-                {!!plotSearch.targets && plotSearch.targets.
+                {!!plotSearch.plot_search_targets && plotSearch.plot_search_targets.
                   filter(plotSearchSite => plotSearchSite.target_type === 'searchable').
                   map((plotSearchSite, index) => {
                     return(
@@ -257,12 +257,12 @@ class BasicInfo extends PureComponent<Props, State> {
                     );
                   })}
               </WhiteBox>}
-              {(!!plotSearch.targets && plotSearch.targets.
+              {(!!plotSearch.plot_search_targets && plotSearch.plot_search_targets.
                 filter(plotSearchSite => plotSearchSite.target_type === 'procedural_reservation').length > 0) && <WhiteBox>
                 <SubTitle>
                   {'MENETTELYVARAUS'}
                 </SubTitle>
-                {!!plotSearch.targets && plotSearch.targets.
+                {!!plotSearch.plot_search_targets && plotSearch.plot_search_targets.
                   filter(plotSearchSite => plotSearchSite.target_type === 'procedural_reservation').
                   map((plotSearchSite, index) => {
                     return(
@@ -275,12 +275,12 @@ class BasicInfo extends PureComponent<Props, State> {
                     );
                   })}
               </WhiteBox>}
-              {(!!plotSearch.targets && plotSearch.targets.
+              {(!!plotSearch.plot_search_targets && plotSearch.plot_search_targets.
                 filter(plotSearchSite => plotSearchSite.target_type === 'direct_reservation').length > 0) && <WhiteBox>
                 <SubTitle>
                   {'SUORAVARAUS'}
                 </SubTitle>
-                {!!plotSearch.targets && plotSearch.targets.
+                {!!plotSearch.plot_search_targets && plotSearch.plot_search_targets.
                   filter(plotSearchSite => plotSearchSite.target_type === 'direct_reservation').
                   map((plotSearchSite, index) => {
                     return(

--- a/src/plotSearch/components/plotSearchSections/basicInfo/BasicInfo.js
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/BasicInfo.js
@@ -92,7 +92,7 @@ class BasicInfo extends PureComponent<Props, State> {
           {PlotSearchFieldTitles.BASIC_INFO}
         </Title>
         <Divider />
-        <Row className='summary__content-wrapper'>
+        <Row className='summary__content-wrapper plot_search__basic-info'>
           <Column small={12}>
             <Collapse
               defaultOpen={basicInformationCollapseState !== undefined ? basicInformationCollapseState : true}

--- a/src/plotSearch/components/plotSearchSections/basicInfo/BasicInfoEdit.js
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/BasicInfoEdit.js
@@ -192,6 +192,8 @@ const renderPlotSearchSites = ({
   disabled,
   fields,
   formName,
+  form,
+  change,
   onRemove
   // usersPermissions,
 }: PlotSearchSitesProps): Element<*> => {
@@ -234,7 +236,9 @@ const renderPlotSearchSites = ({
                 index={index}
                 disabled={disabled}
                 field={field}
+                form={form}
                 formName={formName}
+                change={change}
                 onRemove={handleRemove}
                 onReplace={handleChange}
               />;

--- a/src/plotSearch/components/plotSearchSections/basicInfo/BasicInfoEdit.js
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/BasicInfoEdit.js
@@ -505,7 +505,7 @@ class BasicInfoEdit extends PureComponent<Props, State> {
                   isClicked={isSaveClicked}
                   disabled={!hasMinimumRequiredFieldsFilled}
                   formName={FormNames.PLOT_SEARCH_BASIC_INFORMATION}
-                  name={'targets'}
+                  name={'plot_search_targets'}
                   usersPermissions={usersPermissions}
                   onRemove={this.onTargetRemoved}
                 />
@@ -535,7 +535,7 @@ export default flowRight(
         plotSearchSubTypes: getPlotSearchSubTypes(state),
         decisionCandidates: getDecisionCandidates(state),
         selectedDecisions: selector(state, 'decisions'),
-        targets: selector(state, 'targets'),
+        targets: selector(state, 'plot_search_targets'),
         hasMinimumRequiredFieldsFilled: hasMinimumRequiredFieldsFilled(state)
       };
     },

--- a/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSite.js
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSite.js
@@ -33,6 +33,9 @@ import {
   fetchPlanUnit,
   fetchPlanUnitAttributes,
 } from '$src/plotSearch/actions';
+import {
+  PlotSearchFieldTitles
+} from '$src/plotSearch/enums';
 
 type Props = {
   attributes: Attributes,
@@ -113,6 +116,7 @@ class PlotSearchSite extends PureComponent<Props, State> {
   render(){
 
     const {
+      attributes,
       collapseState,
       plotSearchSite,
       isFetchingPlanUnitAttributes,
@@ -134,6 +138,12 @@ class PlotSearchSite extends PureComponent<Props, State> {
     const address = get(leaseAddress, 'address');
     const leaseIdentifier = get(plotSearchSite, 'lease_identifier');
     const leaseHitas = get(plotSearchSite, 'lease_hitas');
+    const infoLinks = get(plotSearchSite, 'info_links');
+
+    const getInfoLinkLanguageDisplayText = (key) => {
+      const languages = get(attributes, 'plot_search_targets.child.children.info_links.child.children.language.choices');
+      return languages?.find((language) => language.value === key)?.display_name || key;
+    }
 
     return (
       <Column large={12}>
@@ -289,6 +299,42 @@ class PlotSearchSite extends PureComponent<Props, State> {
                   {leaseHitas || '-'}
                 </FormText>
               </Column>}
+              {infoLinks.length > 0 && (<Column small={12} medium={12} large={12} className="plot_search_target__info-links">
+                <Row>
+                  <Column small={12} medium={4} large={4}>
+                    <FormTextTitle>
+                      {PlotSearchFieldTitles.INFO_LINK_DESCRIPTION}
+                    </FormTextTitle>
+                  </Column>
+                  <Column small={8} medium={6} large={6}>
+                    <FormTextTitle>
+                      {PlotSearchFieldTitles.INFO_LINK_URL}
+                    </FormTextTitle>
+                  </Column>
+                  <Column small={4} medium={2} large={2}>
+                    <FormTextTitle>
+                      {PlotSearchFieldTitles.INFO_LINK_LANGUAGE}
+                    </FormTextTitle>
+                  </Column>
+                </Row>
+                {infoLinks.map((infoLink) => <Row key={infoLink.id}>
+                  <Column small={12} medium={4} large={4}>
+                    <FormText>
+                      {infoLink.description}
+                    </FormText>
+                  </Column>
+                  <Column small={8} medium={6} large={6}>
+                    <FormText>
+                      <ExternalLink href={infoLink.url} text={infoLink.url} />
+                    </FormText>
+                  </Column>
+                  <Column small={4} medium={2} large={2}>
+                    <FormText>
+                      {getInfoLinkLanguageDisplayText(infoLink.language)}
+                    </FormText>
+                  </Column>
+                </Row>)}
+              </Column>)}
             </Fragment>}
           </Row>
         </Collapse>

--- a/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSiteEdit.js
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSiteEdit.js
@@ -310,7 +310,7 @@ class PlotSearchSiteEdit extends Component<Props, State> {
       change,
     } = this.props;
 
-    const currentTarget = currentPlotSearch.targets[index];
+    const currentTarget = currentPlotSearch.plot_search_targets[index];
     const masterPlanUnitId = get(currentTarget, 'master_plan_unit_id');
     const planUnit = planUnitMap[masterPlanUnitId];
     const payload = {
@@ -359,7 +359,7 @@ class PlotSearchSiteEdit extends Component<Props, State> {
     const planUnitTypeOptions = getFieldOptions(planUnitAttributesByValue, 'plan_unit_type');
     const plotDivisionStateOptions = getFieldOptions(planUnitAttributesByValue, 'plot_division_state');
 
-    const currentTarget = currentPlotSearch.targets[index];
+    const currentTarget = currentPlotSearch.plot_search_targets[index];
     const isDeleted = get(currentTarget, 'is_master_plan_unit_deleted');
     const isNewer = get(currentTarget, 'is_master_plan_unit_newer');
     const label = get(currentTarget, 'message_label');
@@ -406,7 +406,7 @@ class PlotSearchSiteEdit extends Component<Props, State> {
             <div style={{display: 'none'}}>
               <FormField
                 disableTouched={isSaveClicked}
-                fieldAttributes={get(attributes, 'targets.child.children.plan_unit_id')}
+                fieldAttributes={get(attributes, 'plot_search_targets.child.children.plan_unit_id')}
                 name={`${field}.plan_unit_id`}
               />
             </div>
@@ -416,7 +416,7 @@ class PlotSearchSiteEdit extends Component<Props, State> {
             <FormField
               disableTouched={isSaveClicked}
               invisibleLabel={true}
-              fieldAttributes={get(attributes, 'targets.child.children.target_type')}
+              fieldAttributes={get(attributes, 'plot_search_targets.child.children.target_type')}
               name={`${field}.target_type`}
               disabled={disabled}
             />

--- a/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSiteEdit.js
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSiteEdit.js
@@ -540,7 +540,6 @@ class PlotSearchSiteEdit extends Component<Props, State> {
   }
 }
 
-const formName = FormNames.PLOT_SEARCH_BASIC_INFORMATION;
 
 export default flowRight(
   connect(
@@ -582,9 +581,4 @@ export default flowRight(
       fetchPlanUnitAttributes,
     }
   ),
-  reduxForm({
-    form: formName,
-    destroyOnUnmount: false,
-    change,
-  }),
 )(PlotSearchSiteEdit);

--- a/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSiteEdit.js
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSiteEdit.js
@@ -31,6 +31,9 @@ import {
   fetchPlanUnitAttributes,
 } from '$src/plotSearch/actions';
 import {
+  PlotSearchFieldTitles
+} from '$src/plotSearch/enums';
+import {
   formatDate,
   getFieldOptions,
   getLabelOfOption,
@@ -52,6 +55,7 @@ import {
 import type {Attributes} from '$src/types';
 import type {UsersPermissions as UsersPermissionsType} from '$src/usersPermissions/types';
 import SuggestedEdit from './SuggestedEdit';
+import RemoveButton from "../../../../components/form/RemoveButton";
 
 type SuggestedProps = {
   attributes: Attributes,
@@ -132,6 +136,121 @@ const renderSuggested = ({
       }}
     </AppConsumer>
   );
+};
+
+const renderInfoLinks = ({
+   disabled,
+   fields,
+   formName,
+   attributes,
+   isSaveClicked,
+ }): Element<*> => {
+  const handleAdd = () => {
+    fields.push({});
+  };
+
+  return (
+    <AppConsumer>
+      {({ dispatch }) => {
+        return <div>
+          <FormTextTitle>
+            Lisätietolinkit
+          </FormTextTitle>
+          <div role="table">
+            <Row>
+              <Column large={4} role="columnheader">
+                <FormTextTitle>
+                  {PlotSearchFieldTitles.INFO_LINK_DESCRIPTION}
+                </FormTextTitle>
+              </Column>
+              <Column large={5} role="columnheader">
+                <FormTextTitle>
+                  {PlotSearchFieldTitles.INFO_LINK_URL}
+                </FormTextTitle>
+              </Column>
+              <Column large={2} role="columnheader">
+                <FormTextTitle>
+                  {PlotSearchFieldTitles.INFO_LINK_LANGUAGE}
+                </FormTextTitle>
+              </Column>
+              <Column large={1} />
+            </Row>
+            {!!fields.length && fields.map((field, index) => {
+              const handleRemove = () => {
+                dispatch({
+                  type: ActionTypes.SHOW_CONFIRMATION_MODAL,
+                  confirmationFunction: () => {
+                    fields.remove(index);
+                  },
+                  confirmationModalButtonClassName: ButtonColors.ALERT,
+                  confirmationModalButtonText: ConfirmationModalTexts.DELETE_INFO_LINK.BUTTON,
+                  confirmationModalLabel: ConfirmationModalTexts.DELETE_INFO_LINK.LABEL,
+                  confirmationModalTitle: ConfirmationModalTexts.DELETE_INFO_LINK.TITLE,
+                });
+              };
+
+              return <Row role="row" key={index}>
+                <Column role="cell" large={4}>
+                  <FormField
+                    fieldAttributes={get(attributes, 'plot_search_targets.child.children.info_links.child.children.description')}
+                    name={`${field}.description`}
+                    invisibleLabel
+                    overrideValues={{
+                      label: PlotSearchFieldTitles.INFO_LINK_DESCRIPTION
+                    }}
+                    disabled={disabled}
+                    disableTouched={isSaveClicked}
+                  />
+                </Column>
+                <Column role="cell" large={5}>
+                  <FormField
+                    fieldAttributes={get(attributes, 'plot_search_targets.child.children.info_links.child.children.url')}
+                    name={`${field}.url`}
+                    invisibleLabel
+                    overrideValues={{
+                      label: PlotSearchFieldTitles.INFO_LINK_URL
+                    }}
+                    disabled={disabled}
+                    disableTouched={isSaveClicked}
+                  />
+                </Column>
+                <Column role="cell" large={2}>
+                  <FormField
+                    fieldAttributes={get(attributes, 'plot_search_targets.child.children.info_links.child.children.language')}
+                    name={`${field}.language`}
+                    invisibleLabel
+                    overrideValues={{
+                      label: PlotSearchFieldTitles.INFO_LINK_LANGUAGE
+                    }}
+                    disabled={disabled}
+                    disableTouched={isSaveClicked}
+                  />
+                </Column>
+                <Column role="cell" large={1}>
+                  <RemoveButton
+                    className='third-level'
+                    onClick={(...rest) => handleRemove(index, ...rest)}
+                    style={{height: 'unset'}}
+                    title='Poista lisätietolinkki'
+                    disabled={disabled}
+                  />
+                </Column>
+              </Row>;
+            })}
+            {!disabled &&
+            <Row>
+              <Column>
+                <AddButtonThird
+                  label='Lisää lisätietolinkki'
+                  onClick={handleAdd}
+                />
+              </Column>
+            </Row>
+            }
+          </div>
+        </div>;
+      }}
+    </AppConsumer>);
 };
 
 type Props = {
@@ -525,10 +644,20 @@ class PlotSearchSiteEdit extends Component<Props, State> {
                 {`${get(planUnitByValue, 'section_area')} m²` || '-'}
               </FormText>
             </Column>
+            <Column small={12} medium={12} large={12}>
+              <FieldArray
+                component={renderInfoLinks}
+                attributes={attributes}
+                isSaveClicked={isSaveClicked}
+                disabled={disabled}
+                formName={FormNames.PLOT_SEARCH_BASIC_INFORMATION}
+                name={`${field}.info_links`}
+              />
+            </Column>
             <FieldArray
               component={renderSuggested}
               attributes={attributes}
-              isClicked={isSaveClicked}
+              isSaveClicked={isSaveClicked}
               disabled={true}
               formName={FormNames.PLOT_SEARCH_BASIC_INFORMATION}
               name={`${field}.suggested`}

--- a/src/plotSearch/components/plotSearchSections/basicInfo/_basic-info.scss
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/_basic-info.scss
@@ -1,0 +1,7 @@
+.plot_search__basic-info {
+  .plot_search_target__info-links {
+    .form__text, .links__external-link {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/src/plotSearch/enums.js
+++ b/src/plotSearch/enums.js
@@ -40,6 +40,9 @@ export const PlotSearchFieldTitles = {
   DECISION: 'Päätös',
   DECISION_TO_LIST: 'Päätös hakutuloslistaan',
   STAGE: 'Haun vaihe',
+  INFO_LINK_DESCRIPTION: 'Lisätietolinkin kuvaus',
+  INFO_LINK_URL: 'Lisätietolinkki',
+  INFO_LINK_LANGUAGE: 'Kieli'
 };
 
 /**

--- a/src/plotSearch/helpers.js
+++ b/src/plotSearch/helpers.js
@@ -30,7 +30,7 @@ export const getContentBasicInformation = (plotSearch: PlotSearch): Object => {
     stage: get(plotSearch.stage, 'id'),
     subtype: get(plotSearch.subtype, 'id'),
     type: get(plotSearch.type, 'id'),
-    targets: plotSearch.targets?.map((target) => ({
+    plot_search_targets: plotSearch.plot_search_targets?.map((target) => ({
       ...target,
       plan_unit_id: target.plan_unit?.id
     })),
@@ -41,8 +41,9 @@ export const getContentBasicInformation = (plotSearch: PlotSearch): Object => {
     last_update: plotSearch.last_update,
     plotSearch_sites: getContentSearchProperties(plotSearch.plotSearch_sites), */
     decisions: plotSearch.decisions?.map((decision) => {
-      // Targets are simple IDs if called for listing search items, so the decision array might not necessarily exist.
-      const matchingTarget = plotSearch.targets.find((target) => target.decisions?.find((targetDecision) => targetDecision.id === decision.id));
+      // Detailed target objects are not available in a search result, only when fetching a single plot search,
+      // so the decisions might not always be available.
+      const matchingTarget = plotSearch.plot_search_targets?.find((target) => target.decisions?.find((targetDecision) => targetDecision.id === decision.id));
       return annotatePlanUnitDecision(decision, matchingTarget?.plan_unit);
     })
   };
@@ -130,11 +131,11 @@ export const getPlanUnitFromObjectKeys = (planUnit: Object, index: any): ?Object
  * @returns {Object}
  */
 export const cleanTargets = (payload: Object): Object => {
-  const targets = payload.targets.map(target => ({
+  const plot_search_targets = payload.plot_search_targets.map(target => ({
     plan_unit_id: target.plan_unit_id,
     target_type: target.target_type,
   }));
-  return payload = {...payload, targets: targets};
+  return payload = {...payload, plot_search_targets};
 };
 
 /**

--- a/src/plotSearch/helpers.js
+++ b/src/plotSearch/helpers.js
@@ -132,8 +132,10 @@ export const getPlanUnitFromObjectKeys = (planUnit: Object, index: any): ?Object
  */
 export const cleanTargets = (payload: Object): Object => {
   const plot_search_targets = payload.plot_search_targets.map(target => ({
+    id: target.id,
     plan_unit_id: target.plan_unit_id,
     target_type: target.target_type,
+    info_links: target.info_links
   }));
   return payload = {...payload, plot_search_targets};
 };

--- a/src/plotSearch/mock-data.json
+++ b/src/plotSearch/mock-data.json
@@ -66,7 +66,8 @@
         ]
       }
     ],
-    "targets": [
+    "targets": [1],
+    "plot_search_targets": [
       {
         "id": 1,
         "plan_unit": {

--- a/src/plotSearch/saga.js
+++ b/src/plotSearch/saga.js
@@ -114,7 +114,7 @@ function* fetchSinglePlotSearchSaga({payload: id}): Generator<any, any, any> {
           yield put(receiveForm(null));
         }
         yield put(resetPlanUnitDecisions());
-        for (const target of bodyAsJson.targets) {
+        for (const target of bodyAsJson.plot_search_targets) {
           yield put(addPlanUnitDecisions(target.plan_unit));
         }
         break;

--- a/src/plotSearch/spec.js
+++ b/src/plotSearch/spec.js
@@ -429,7 +429,7 @@ describe('PlotSearch', () => {
       });
 
       it('should add and annotate decision candidates from plan units', () => {
-        const state = mockData[0].targets.reduce(
+        const state = mockData[0].plot_search_targets.reduce(
           (state, nextTarget) => plotSearchReducer(state, addPlanUnitDecisions(nextTarget.plan_unit)),
           {});
 
@@ -441,7 +441,7 @@ describe('PlotSearch', () => {
       });
 
       it('should remove decision candidates when plan units are no longer present in any targets', () => {
-        let state = mockData[0].targets.reduce(
+        let state = mockData[0].plot_search_targets.reduce(
           (state, nextTarget) => plotSearchReducer(state, addPlanUnitDecisions(nextTarget.plan_unit)),
           {});
 
@@ -454,7 +454,7 @@ describe('PlotSearch', () => {
       });
 
       it('should not remove unrelated decision candidates', () => {
-        let state = mockData[0].targets.reduce(
+        let state = mockData[0].plot_search_targets.reduce(
           (state, nextTarget) => plotSearchReducer(state, addPlanUnitDecisions(nextTarget.plan_unit)),
           {});
 
@@ -467,7 +467,7 @@ describe('PlotSearch', () => {
       });
 
       it('should reset decision candidates', () => {
-        let state = mockData[0].targets.reduce(
+        let state = mockData[0].plot_search_targets.reduce(
           (state, nextTarget) => plotSearchReducer(state, addPlanUnitDecisions(nextTarget.plan_unit)),
           {});
 


### PR DESCRIPTION
Also includes the matching change for the `targets` -> `plot_search_targets` breaking change in the backend.