### PR TITLE
Control the root-level target sections based on selected targets

### DIFF
--- a/src/plotApplications/actions.js
+++ b/src/plotApplications/actions.js
@@ -41,6 +41,10 @@ import type {
   ReceiveAttachmentAttributesAction,
   ReceiveAttachmentMethodsAction,
   AttachmentAttributesNotFoundAction,
+  SetCurrentEditorTargetsAction,
+  FetchApplicationRelatedPlotSearchAction,
+  ReceiveApplicationRelatedPlotSearchAction,
+  ApplicationRelatedPlotSearchNotFoundAction,
 } from './types';
 
 export const fetchPlotApplicationsList = (search: string): FetchPlotApplicationsListAction =>
@@ -127,6 +131,15 @@ export const receiveApplicationRelatedForm = (payload: Object): ReceiveApplicati
 export const applicationRelatedFormNotFound = (payload: Object): ApplicationRelatedFormNotFoundAction =>
   createAction('mvj/plotApplications/FORM_NOT_FOUND')(payload);
 
+export const fetchApplicationRelatedPlotSearch = (payload: Object): FetchApplicationRelatedPlotSearchAction =>
+  createAction('mvj/plotApplications/FETCH_PLOT_SEARCH')(payload);
+
+export const receiveApplicationRelatedPlotSearch = (payload: Object): ReceiveApplicationRelatedPlotSearchAction =>
+  createAction('mvj/plotApplications/RECEIVE_PLOT_SEARCH')(payload);
+
+export const applicationRelatedPlotSearchNotFound = (payload: Object): ApplicationRelatedPlotSearchNotFoundAction =>
+  createAction('mvj/plotApplications/PLOT_SEARCH_NOT_FOUND')(payload);
+
 export const fetchApplicationRelatedAttachments = (payload: Object): FetchApplicationRelatedAttachmentsAction =>
   createAction('mvj/plotApplications/FETCH_ATTACHMENTS')(payload);
 
@@ -168,3 +181,6 @@ export const receiveAttachmentMethods = (payload: Object): ReceiveAttachmentMeth
 
 export const attachmentAttributesNotFound = (): AttachmentAttributesNotFoundAction =>
   createAction('mvj/plotApplications/ATTACHMENT_ATTRIBUTES_NOT_FOUND')();
+
+export const setCurrentEditorTargets = (payload: Array<Object>): SetCurrentEditorTargetsAction =>
+  createAction('mvj/plotApplications/SET_CURRENT_EDITOR_TARGETS')(payload);

--- a/src/plotApplications/components/PlotApplicationSubsection.js
+++ b/src/plotApplications/components/PlotApplicationSubsection.js
@@ -13,7 +13,11 @@ import {
   getIsFetchingPendingUploads, getIsPerformingFileOperation,
   getPendingUploads
 } from '../selectors';
-import {getApplicationAttachmentDownloadLink, getSectionTemplate} from '../helpers';
+import {
+  getApplicationAttachmentDownloadLink,
+  getSectionTargetFromMeta,
+  getSectionTemplate
+} from '../helpers';
 import AddButton from "../../components/form/AddButton";
 import RemoveButton from "../../components/form/RemoveButton";
 import FormField from "../../components/form/FormField";
@@ -29,6 +33,7 @@ import {ConfirmationModalTexts} from "../../enums";
 import {ButtonColors} from "../../components/enums";
 import {ActionTypes, AppConsumer} from "../../app/AppContext";
 import FormHintText from "../../components/form/FormHintText";
+import {TARGET_SECTION_IDENTIFIER} from "../constants";
 
 const ApplicationSectionKeys = {
   Subsections: 'sections',
@@ -302,7 +307,6 @@ const ApplicationFormSubsectionFieldArray = ({
   section,
   headerTag: HeaderTag,
 }) => {
-
   return (
     <div className="ApplicationFormSubsectionFieldArray">
       {fields.map((identifier, i) => (
@@ -312,9 +316,13 @@ const ApplicationFormSubsectionFieldArray = ({
         >
           <div className="ApplicationFormSubsectionFieldArray__item-content">
             <HeaderTag>
-              {section.title} ({i + 1})
+              {section.identifier === TARGET_SECTION_IDENTIFIER
+                ? <>{section.title} ({getSectionTargetFromMeta(identifier)})</>
+                : <>{section.title} ({i + 1})</>
+              }
+
             </HeaderTag>
-            {fields.length > 1 && (
+            {fields.length > 1 && section.identifier !== TARGET_SECTION_IDENTIFIER && (
               <RemoveButton
                 onClick={() => fields.remove(i)}
               />
@@ -326,10 +334,10 @@ const ApplicationFormSubsectionFieldArray = ({
           </div>
         </div>
       ))}
-      <AddButton
+      {section.identifier !== TARGET_SECTION_IDENTIFIER && <AddButton
         onClick={() => fields.push(getSectionTemplate(section.identifier))}
         label={section.add_new_text || "Lisää uusi"}
-      />
+      />}
     </div>
   );
 };

--- a/src/plotApplications/constants.js
+++ b/src/plotApplications/constants.js
@@ -30,3 +30,6 @@ export const BOUNDING_BOX_FOR_SEARCH_QUERY = ['24.681112147072024', '60.10217395
  * @const {number}
  */
 export const MAX_ZOOM_LEVEL_TO_FETCH_LEASES = 7;
+
+export const APPLICANT_SECTION_IDENTIFIER = 'hakijan-tiedot';
+export const TARGET_SECTION_IDENTIFIER = 'haettava-kohde';

--- a/src/plotApplications/reducer.js
+++ b/src/plotApplications/reducer.js
@@ -20,6 +20,7 @@ import type {
   ReceiveApplicationRelatedFormAction,
   ReceiveApplicationRelatedAttachmentsAction,
   ReceivePlotSearchSubtypesAction,
+  ReceiveApplicationRelatedPlotSearchAction,
   ReceiveAttachmentAttributesAction,
   ReceiveAttachmentMethodsAction
 } from "./types";
@@ -124,10 +125,23 @@ const formReducer: Reducer<Object> = handleActions({
   }
 }, null);
 
+const plotSearchReducer: Reducer<Object> = handleActions({
+  ['mvj/plotApplications/FETCH_PLOT_SEARCH']: () => null,
+  ['mvj/plotApplications/RECEIVE_PLOT_SEARCH']: (state: Object, { payload: plotSearch }: ReceiveApplicationRelatedPlotSearchAction) => {
+    return plotSearch;
+  }
+}, null);
+
 const isFetchingFormReducer: Reducer<boolean> = handleActions({
   ['mvj/plotApplications/FETCH_FORM']: () => true,
   ['mvj/plotApplications/RECEIVE_FORM']: () => false,
   ['mvj/plotApplications/FORM_NOT_FOUND']: () => false,
+}, false);
+
+const isFetchingPlotSearchReducer: Reducer<boolean> = handleActions({
+  ['mvj/plotApplications/FETCH_PLOT_SEARCH']: () => true,
+  ['mvj/plotApplications/RECEIVE_PLOT_SEARCH']: () => false,
+  ['mvj/plotApplications/PLOT_SEARCH_NOT_FOUND']: () => false,
 }, false);
 
 const attachmentReducer: Reducer<Object> = handleActions({
@@ -196,6 +210,10 @@ const isFetchingAttachmentAttributesReducer: Reducer<boolean> = handleActions({
   ['mvj/plotApplications/RECEIVE_ATTACHMENT_METHODS']: () => false,
 }, false);
 
+const currentEditorTargetsReducer: Reducer<Array<Object>> = handleActions({
+  ['mvj/plotApplications/SET_CURRENT_EDITOR_TARGETS']: (state, {payload: targets}) => targets
+}, []);
+
 export default combineReducers<Object, any>({
   isFetching: isFetchingReducer,
   isFetchingByBBox: isFetchingByBBoxReducer,
@@ -211,7 +229,9 @@ export default combineReducers<Object, any>({
   isFormValidById: isFormValidByIdReducer,
   subTypes: subTypesReducer,
   form: formReducer,
+  plotSearch: plotSearchReducer,
   isFetchingForm: isFetchingFormReducer,
+  isFetchingPlotSearch: isFetchingFormReducer,
   attachments: attachmentReducer,
   isFetchingAttachments: isFetchingAttachmentsReducer,
   fieldTypeMapping: fieldTypeMappingReducer,
@@ -221,5 +241,6 @@ export default combineReducers<Object, any>({
   isPerformingFileOperation: isPerformingFileOperationReducer,
   isFetchingAttachmentAttributes: isFetchingAttachmentAttributesReducer,
   attachmentAttributes: attachmentAttributesReducer,
-  attachmentMethods: attachmentMethodsReducer
+  attachmentMethods: attachmentMethodsReducer,
+  currentEditorTargets: currentEditorTargetsReducer
 });

--- a/src/plotApplications/selectors.js
+++ b/src/plotApplications/selectors.js
@@ -67,6 +67,10 @@ export const getIsFetchingApplicationRelatedForm: Selector<boolean, void> = (sta
 
 export const getApplicationRelatedForm: Selector<boolean, void> = (state: RootState): boolean => state.plotApplications.form;
 
+export const getIsFetchingApplicationRelatedPlotSearch: Selector<boolean, void> = (state: RootState): boolean => state.plotApplications.isFetchingPlotSearch;
+
+export const getApplicationRelatedPlotSearch: Selector<boolean, void> = (state: RootState): boolean => state.plotApplications.plotSearch;
+
 export const getIsFetchingApplicationRelatedAttachments: Selector<boolean, void> = (state: RootState): boolean => state.plotApplications.isFetchingAttachments;
 
 export const getApplicationRelatedAttachments: Selector<boolean, void> = (state: RootState): boolean => state.plotApplications.attachments;
@@ -94,3 +98,6 @@ export const getAttachmentMethods: Selector<Methods, void> = (state: RootState):
 
 export const getIsSaving: Selector<boolean, void> = (state: RootState): boolean =>
   state.plotApplications.isSaving;
+
+export const getCurrentEditorTargets: Selector<Array<Object>, void> = (state: RootState): Array<Object> =>
+  state.plotApplications.currentEditorTargets;

--- a/src/plotApplications/spec.js
+++ b/src/plotApplications/spec.js
@@ -28,6 +28,7 @@ const baseState: PlotApplicationsState = {
   attachmentMethods: null,
   attachments: null,
   attributes: null,
+  currentEditorTargets: [],
   fieldTypeMapping: {},
   form: null,
   isFetching: false,
@@ -35,6 +36,7 @@ const baseState: PlotApplicationsState = {
   isFetchingAttachments: false,
   isFetchingAttributes: false,
   isFetchingByBBox: false,
+  isFetchingPlotSearch: false,
   listByBBox: null,
   isFetchingForm: false,
   isFetchingPendingUploads: false,
@@ -51,7 +53,8 @@ const baseState: PlotApplicationsState = {
     'plot-application': true,
   },
   subTypes: null,
-  pendingUploads: []
+  pendingUploads: [],
+  plotSearch: null
 };
 
 // $FlowFixMe

--- a/src/plotApplications/types.js
+++ b/src/plotApplications/types.js
@@ -24,6 +24,7 @@ export type PlotApplicationsState = {
   attachmentMethods: Methods,
   isFetchingAttachmentAttributes: boolean,
   attachments: ?Array<Object>,
+  currentEditorTargets: Array<Object>
 };
 
 export type PlotApplicationsList = Object;
@@ -66,6 +67,10 @@ export type FetchApplicationRelatedFormAction = Action<'mvj/plotApplications/FET
 export type ReceiveApplicationRelatedFormAction = Action<'mvj/plotApplications/RECEIVE_FORM', Object>;
 export type ApplicationRelatedFormNotFoundAction = Action<'mvj/plotApplications/FORM_NOT_FOUND', void>;
 
+export type FetchApplicationRelatedPlotSearchAction = Action<'mvj/plotApplications/FETCH_PLOT_SEARCH', void>;
+export type ReceiveApplicationRelatedPlotSearchAction = Action<'mvj/plotApplications/RECEIVE_PLOT_SEARCH', Object>;
+export type ApplicationRelatedPlotSearchNotFoundAction = Action<'mvj/plotApplications/PLOT_SEARCH_NOT_FOUND', void>;
+
 export type FetchApplicationRelatedAttachmentsAction = Action<'mvj/plotApplications/FETCH_ATTACHMENTS', void>;
 export type ReceiveApplicationRelatedAttachmentsAction = Action<'mvj/plotApplications/RECEIVE_ATTACHMENTS', Object>;
 export type ApplicationRelatedAttachmentsNotFoundAction = Action<'mvj/plotApplications/ATTACHMENTS_NOT_FOUND', void>;
@@ -82,4 +87,6 @@ export type ReceiveFileOperationFinishedAction = Action<'mvj/plotApplications/FI
 export type FetchAttachmentAttributesAction = Action<'mvj/plotApplications/FETCH_ATTACHMENT_ATTRIBUTES', void>;
 export type ReceiveAttachmentAttributesAction = Action<'mvj/plotApplications/RECEIVE_ATTACHMENT_ATTRIBUTES', Attributes>;
 export type ReceiveAttachmentMethodsAction = Action<'mvj/plotApplications/RECEIVE_ATTACHMENT_METHODS', Methods>;
-export type AttachmentAttributesNotFoundAction = Action<'mvj/plotApplications/ATTACHMENT_METHODS_NOT_FOUND', void>;
+export type AttachmentAttributesNotFoundAction = Action<'mvj/plotApplications/ATTACHMENT_ATTRIBUTES_NOT_FOUND', void>;
+
+export type SetCurrentEditorTargetsAction = Action<'mvj/plotApplications/SET_CURRENT_EDITOR_TARGETS', Array<Object>>;


### PR DESCRIPTION
- Target data sections can't be added or removed manually, they're generated automatically based on selected targets
- Metadata is attached to these sections, signifying the target they're related to
- This metadata is also used in the application inspection view to show the address and identifier of each related target