### PR TITLE
Small fixes to lease statistic reports

### DIFF
--- a/src/leaseStatisticReport/components/LeaseStatisticReportForm.js
+++ b/src/leaseStatisticReport/components/LeaseStatisticReportForm.js
@@ -20,7 +20,6 @@ import {
 import {
   LeaseStatisticReportPaths,
   LeaseStatisticReportTitles,
-  LeaseInvoicingReportTypes,
 } from '$src/leaseStatisticReport/enums';
 import {
   getReportTypeOptions,
@@ -122,7 +121,6 @@ class LeaseStatisticReportForm extends PureComponent<Props, State> {
       reports,
       isFetchingReports,
       isFetchingReportData,
-      reportType,
       isSendingMail,
       options,
       isFetchingOptions,
@@ -131,6 +129,7 @@ class LeaseStatisticReportForm extends PureComponent<Props, State> {
     if(isFetchingReports) return <LoaderWrapper><Loader isLoading={true} /></LoaderWrapper>;
     const reportTypeOptions = getReportTypeOptions(reports);
     const fields = getFields(options);
+    const isAsync = !!(options && options.is_async);
 
     return(
       <form>
@@ -168,7 +167,7 @@ class LeaseStatisticReportForm extends PureComponent<Props, State> {
                   </Column>
                 );
               })}
-              {((reportType !== LeaseInvoicingReportTypes.RENT_FORECAST && reportType !== LeaseInvoicingReportTypes.LEASE_STATISTIC) && fields && !isFetchingOptions) &&<Column small={3} style={{margin: '10px 0'}}>
+              {(!isAsync && fields && !isFetchingOptions) &&<Column small={3} style={{margin: '10px 0'}}>
                 <Button
                   className={ButtonColors.SUCCESS}
                   disabled={isFetchingReportData}
@@ -176,7 +175,7 @@ class LeaseStatisticReportForm extends PureComponent<Props, State> {
                   onClick={this.getReportData}
                 />
               </Column>}
-              {(reportType === LeaseInvoicingReportTypes.RENT_FORECAST || reportType ===  LeaseInvoicingReportTypes.LEASE_STATISTIC)&& <Column small={3} style={{margin: '10px 0'}}>
+              {isAsync && <Column small={3} style={{margin: '10px 0'}}>
                 <Button
                   className={ButtonColors.SUCCESS}
                   disabled={isSendingMail}

--- a/src/leaseStatisticReport/components/LeaseStatisticReportPage.js
+++ b/src/leaseStatisticReport/components/LeaseStatisticReportPage.js
@@ -17,7 +17,7 @@ import {hasPermissions, setPageTitle} from '$util/helpers';
 import {getRouteById, Routes} from '$src/root/routes';
 import {
   getReportTypeOptions,
-} from '$src/leaseStatisticReport/helpers'; 
+} from '$src/leaseStatisticReport/helpers';
 import LeaseStatisticReportForm from './LeaseStatisticReportForm';
 import LeaseInvoicingConfirmationReport from './LeaseInvoicingConfirmationReport';
 import {getIsFetching as getIsFetchingUsersPermissions, getUsersPermissions} from '$src/usersPermissions/selectors';
@@ -26,8 +26,8 @@ import type {Reports} from '$src/types';
 import GreenBox from '$components/content/GreenBox';
 import SubTitle from '$components/content/SubTitle';
 import {
-  getIsFetchingReportData, 
-  getPayload, 
+  getIsFetchingReportData,
+  getPayload,
   getReports,
 } from '$src/leaseStatisticReport/selectors';
 import {
@@ -74,9 +74,9 @@ class LeaseStatisticReportPage extends PureComponent<Props, State> {
 
   render() {
     const {
-      isFetchingUsersPermissions, 
-      usersPermissions, 
-      reportData, 
+      isFetchingUsersPermissions,
+      usersPermissions,
+      reportData,
       isFetchingReportData,
       payload,
       reports,

--- a/src/leaseStatisticReport/components/LeaseStatisticReportPage.js
+++ b/src/leaseStatisticReport/components/LeaseStatisticReportPage.js
@@ -31,9 +31,6 @@ import {
   getReports,
 } from '$src/leaseStatisticReport/selectors';
 import {
-  LeaseStatisticReportTitles,
-} from '$src/leaseStatisticReport/enums';
-import {
   getReportData,
 } from '$src/leaseStatisticReport/selectors';
 import {
@@ -94,9 +91,6 @@ class LeaseStatisticReportPage extends PureComponent<Props, State> {
           <h2>RAPORTIT</h2>
           <Divider />
           <GreenBox>
-            <SubTitle style={{textTransform: 'uppercase'}} >
-              {LeaseStatisticReportTitles.LEASE_STATISTICS_REPORT}
-            </SubTitle>
             <LeaseStatisticReportForm/>
           </GreenBox>
           {(!!reportData || isFetchingReportData) && <GreenBox className='with-top-margin'>


### PR DESCRIPTION
**1. Remove unecessary fixed title from LeaseStatisticReportForm.js**

When creating reports, the page always showed the "Vuokrausten tilastoraportti" as a title for the section, even though there
was something else selected as the report type.

Remove the title completely as we are showing the selected report title in the report output.

**2. LeaseStatisticReportForm: Render submit button based on report type**

Remove fixed value checks to determine which button (Luo raportti / Lähetä sähköpostiin) to show. Use the `is_async` from the API to render the correct form submit button for each report type.