### PR TITLE
New basis of rent calculator type and fixes to calculations

### DIFF
--- a/src/leases/components/leaseSections/rent/BasisOfRent.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRent.js
@@ -33,7 +33,7 @@ import {
   calculateBasisOfRentSubventionAmount,
   calculateBasisOfRentSubventionAmountCumulative,
   calculateBasisOfRentSubventionPercantage,
-  calculateReLeaseDiscountPercent, 
+  calculateReLeaseDiscountPercent,
   calculateBasisOfRentSubventionPercent,
   calculateSubventionDiscountTotal,
   calculateSubventionDiscountTotalFromReLease,
@@ -268,7 +268,7 @@ const BasisOfRent = ({
 
               return <Row key={index}>
                 <Column small={6} medium={4} large={2}>
-                  <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) && isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)}>            
+                  <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) && isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)}>
                     {(index === 0) && <FormText>{`Laitekaappi`}</FormText>}
                     {(index === 1) && <FormText>{`Masto`}</FormText>}
                   </Authorization>
@@ -573,7 +573,7 @@ const BasisOfRent = ({
               </Authorization>
             </Column>
           </Fragment>}
-            
+
           {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
             <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
               <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
@@ -714,7 +714,7 @@ const BasisOfRent = ({
                       const subventionPercent = calculateBasisOfRentSubventionPercantage(subvention.subvention_amount, currentAmountPerArea);
                       /* Use initial year rent to calculate subvention total */
                       const subventionTotal = calculateBasisOfRentSubventionAmount(initialYearRent, subventionPercent);
-                      
+
                       return(
                         <Row key={subvention.id}>
                           <Column small={4} large={2}>

--- a/src/leases/components/leaseSections/rent/BasisOfRent.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRent.js
@@ -32,7 +32,7 @@ import {
   calculateBasisOfRentInitialYearRent,
   calculateBasisOfRentSubventionAmount,
   calculateBasisOfRentSubventionAmountCumulative,
-  calculateBasisOfRentSubventionPercantage,
+  calculateBasisOfRentSubventionPercentage,
   calculateReLeaseDiscountPercent,
   calculateBasisOfRentSubventionPercent,
   calculateSubventionDiscountTotal,
@@ -134,7 +134,7 @@ const BasisOfRent = ({
   const getDiscountPercentage = () => {
     if(basisOfRent.subvention_type === SubventionTypes.FORM_OF_MANAGEMENT){
       if(basisOfRent.management_subventions && !!basisOfRent.management_subventions.length && basisOfRent.management_subventions[0].subvention_amount)
-        return calculateBasisOfRentSubventionPercantage(basisOfRent.management_subventions[0].subvention_amount, currentAmountPerArea);
+        return calculateBasisOfRentSubventionPercentage(basisOfRent.management_subventions[0].subvention_amount, currentAmountPerArea);
       return 0;
     }
     if(basisOfRent.subvention_type === SubventionTypes.RE_LEASE)
@@ -739,7 +739,7 @@ const BasisOfRent = ({
 
                     {managementSubventions.map((subvention) => {
                       /* Use current amount per area to calculate percantage */
-                      const subventionPercent = calculateBasisOfRentSubventionPercantage(subvention.subvention_amount, currentAmountPerArea);
+                      const subventionPercent = calculateBasisOfRentSubventionPercentage(subvention.subvention_amount, currentAmountPerArea);
                       /* Use initial year rent to calculate subvention total */
                       const subventionTotal = calculateBasisOfRentSubventionAmount(initialYearRent, subventionPercent);
 

--- a/src/leases/components/leaseSections/rent/BasisOfRent.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRent.js
@@ -26,7 +26,7 @@ import {
   calculatorTypeOptions,
 } from '$src/leases/enums';
 import {
-  calculateBasisOfRentAmountPerArea,
+  getBasisOfRentAmountPerArea,
   calculateBasisOfRentBasicAnnualRent,
   calculateBasisOfRentDiscountedInitialYearRent,
   calculateBasisOfRentInitialYearRent,
@@ -121,7 +121,7 @@ const BasisOfRent = ({
 
   const getTotalSubventionPercent = () => {
     const indexValue = getBasisOfRentIndexValue(basisOfRent, indexOptions);
-    const currentAmountPerArea = calculateBasisOfRentAmountPerArea(basisOfRent, indexValue);
+    const currentAmountPerArea = getBasisOfRentAmountPerArea(basisOfRent, indexValue);
     return calculateBasisOfRentSubventionPercent(
       currentAmountPerArea,
       basisOfRent.subvention_type,
@@ -143,9 +143,9 @@ const BasisOfRent = ({
 
   const getSubventionDiscountedInitial = () => {
     const indexValue = getBasisOfRentIndexValue(basisOfRent, indexOptions);
-    const basicAnnualRent = calculateBasisOfRentBasicAnnualRent(basisOfRent);
+    const basicAnnualRent = calculateBasisOfRentBasicAnnualRent(basisOfRent, indexValue);
     const initialYearRent = calculateBasisOfRentInitialYearRent(basisOfRent, indexValue, basicAnnualRent);
-    const currentAmountPerArea = calculateBasisOfRentAmountPerArea(basisOfRent, indexValue);
+    const currentAmountPerArea = getBasisOfRentAmountPerArea(basisOfRent, indexValue);
     const managementSubventions = basisOfRent.management_subventions;
     if(basisOfRent.subvention_type === SubventionTypes.FORM_OF_MANAGEMENT)
       return calculateSubventionDiscountTotal(
@@ -165,9 +165,9 @@ const BasisOfRent = ({
   const amountPerAreaText = getAmountPerAreaText(basisOfRent.amount_per_area);
   const plansInspectedText = getPlansInspectedText();
   const lockedText = getLockedText();
-  const currentAmountPerArea = calculateBasisOfRentAmountPerArea(basisOfRent, indexValue);
+  const currentAmountPerArea = getBasisOfRentAmountPerArea(basisOfRent, indexValue);
   const currentAmountPerAreaText = getAmountPerAreaText(currentAmountPerArea);
-  const basicAnnualRent = calculateBasisOfRentBasicAnnualRent(basisOfRent);
+  const basicAnnualRent = calculateBasisOfRentBasicAnnualRent(basisOfRent, indexValue);
   const initialYearRent = calculateBasisOfRentInitialYearRent(basisOfRent, indexValue, basicAnnualRent);
   const discountedInitialYearRent = calculateBasisOfRentDiscountedInitialYearRent(basisOfRent, indexValue);
   const managementSubventions = basisOfRent.management_subventions;
@@ -196,6 +196,64 @@ const BasisOfRent = ({
   const mastTotal = (mastAreaRent + rackAndHeightPrice) * 0.05;
   const mastTotalIndexed = calculateBasicAnnualRentIndexed(mastTotal, indexValue);
   const zoneOptions = getFieldOptions(leaseAttributes, LeaseBasisOfRentsFieldPaths.ZONE);
+
+  // Indeksi
+  const renderIndexFormField = () => (
+    <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX)}>
+      <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.INDEX)}>
+        {LeaseBasisOfRentsFieldTitles.INDEX}
+      </FormTextTitle>
+      <FormText>{getLabelOfOption(indexOptions, basisOfRent.index) || '-'}</FormText>
+    </Authorization>
+  );
+
+  // Yksikköhinta (ind)
+  const renderUnitPriceFormField = () => (
+    <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) && isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX)}>
+      <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.UNIT_PRICE)}>
+        {LeaseBasisOfRentsFieldTitles.UNIT_PRICE}
+      </FormTextTitle>
+      <FormText>{currentAmountPerAreaText}</FormText>
+    </Authorization>
+  );
+
+  // Tuottoprosentti
+  const renderProfitMarginPercentageFormField = () => (
+    <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE)}>
+      <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE)}>
+        {LeaseBasisOfRentsFieldTitles.PROFIT_MARGIN_PERCENTAGE}
+      </FormTextTitle>
+      <FormText>{!isEmptyValue(basisOfRent.profit_margin_percentage) ? `${formatNumber(basisOfRent.profit_margin_percentage)} %` : '-'}</FormText>
+    </Authorization>
+  );
+
+  // Perusvuosivuokra (ind 100)
+  const renderBaseYearRentFormField = () => (
+    <Authorization allow={
+      isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
+      isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)
+    }>
+      <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.BASE_YEAR_RENT)}>
+        {LeaseBasisOfRentsFieldTitles.BASE_YEAR_RENT}
+      </FormTextTitle>
+      <FormText>{!isEmptyValue(basicAnnualRent) ? `${formatNumber(basicAnnualRent)} €/v` : '-'}</FormText>
+    </Authorization>
+  );
+
+  // Alkuvuosivuokra (ind)
+  const renderInitialYearRentFormField = () => (
+    <Authorization allow={
+      isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
+      isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) &&
+      isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX) &&
+      isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE)
+    }>
+      <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.INITIAL_YEAR_RENT)}>
+        {LeaseBasisOfRentsFieldTitles.INITIAL_YEAR_RENT}
+      </FormTextTitle>
+      <FormText>{!isEmptyValue(initialYearRent) ? `${formatNumber(initialYearRent)} €/v` : '-'}</FormText>
+    </Authorization>
+  );
 
   return(
     <BoxItem className='no-border-on-first-child no-border-on-last-child'>
@@ -302,7 +360,7 @@ const BasisOfRent = ({
               </Row>;
             })}
           </Column>}
-          {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
+          {(calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) && <Column small={6} medium={4} large={2}>
             <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INTENDED_USE)}>
               <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.INTENDED_USE)}>
                 {LeaseBasisOfRentsFieldTitles.INTENDED_USE}
@@ -343,7 +401,7 @@ const BasisOfRent = ({
               <FormText>{'* 1,5'}</FormText>
             </Authorization>
           </Column>}
-          {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
+          {(calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) && <Column small={6} medium={4} large={2}>
             <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA)}>
               <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.AREA)}>
                 {LeaseBasisOfRentsFieldTitles.AREA}
@@ -351,7 +409,7 @@ const BasisOfRent = ({
               <FormText>{areaText}</FormText>
             </Authorization>
           </Column>}
-          {(calculatorType !== CalculatorTypes.MAST && calculatorType !== CalculatorTypes.LEASE) && <Column small={3} medium={2} large={1}>
+          {(calculatorType !== CalculatorTypes.MAST && calculatorType !== CalculatorTypes.LEASE && calculatorType !== CalculatorTypes.LEASE2022) && <Column small={3} medium={2} large={1}>
             <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA)}>
               <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.AREA)}>
                 {LeaseBasisOfRentsFieldTitles.AREA}
@@ -359,7 +417,7 @@ const BasisOfRent = ({
               <FormText>{areaText}</FormText>
             </Authorization>
           </Column>}
-          {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
+          {(calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) && <Column small={6} medium={4} large={2}>
             <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PLANS_INSPECTED_AT)}>
               <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.PLANS_INSPECTED_AT)}>
                 {LeaseBasisOfRentsFieldTitles.PLANS_INSPECTED_AT}
@@ -367,7 +425,7 @@ const BasisOfRent = ({
               <FormText>{plansInspectedText}</FormText>
             </Authorization>
           </Column>}
-          {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
+          {(calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) && <Column small={6} medium={4} large={2}>
             <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.LOCKED_AT)}>
               <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.LOCKED_AT)}>
                 {LeaseBasisOfRentsFieldTitles.LOCKED_AT}
@@ -380,7 +438,7 @@ const BasisOfRent = ({
               <FormText>{'*5%'}</FormText>
             </Authorization>
           </Column>}
-          {(calculatorType !== CalculatorTypes.MAST && calculatorType !== CalculatorTypes.LEASE) && <Column small={3} medium={2} large={1}>
+          {(calculatorType !== CalculatorTypes.MAST && calculatorType !== CalculatorTypes.LEASE && calculatorType !== CalculatorTypes.LEASE2022) && <Column small={3} medium={2} large={1}>
             <Authorization allow={
               isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
               isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)
@@ -396,7 +454,7 @@ const BasisOfRent = ({
               {calculatorType === CalculatorTypes.FIELD && <FormText>{!isEmptyValue(fieldsRent) ? `${formatNumber(fieldsRent)} €` : '-'}</FormText>}
             </Authorization>
           </Column>}
-          {(calculatorType !== CalculatorTypes.MAST && calculatorType !== CalculatorTypes.LEASE) && <Column small={3} medium={2} large={1}>
+          {(calculatorType !== CalculatorTypes.MAST && calculatorType !== CalculatorTypes.LEASE && calculatorType !== CalculatorTypes.LEASE2022) && <Column small={3} medium={2} large={1}>
             <Authorization allow={
               isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
               isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)
@@ -407,7 +465,7 @@ const BasisOfRent = ({
               {calculatorType === CalculatorTypes.TEMPORARY && <FormText>{!isEmptyValue(rent) ? `${formatNumber(rent * 12)} €` : '-'}</FormText>}
             </Authorization>
           </Column>}
-          {(calculatorType !== CalculatorTypes.LEASE && calculatorType !== CalculatorTypes.MAST) && <Column small={6} medium={4} large={2}>
+          {(calculatorType !== CalculatorTypes.LEASE && calculatorType !== CalculatorTypes.LEASE2022 && calculatorType !== CalculatorTypes.MAST) && <Column small={6} medium={4} large={2}>
             <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX)}>
               <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.INDEX)}>
                 {LeaseBasisOfRentsFieldTitles.INDEX}
@@ -415,7 +473,7 @@ const BasisOfRent = ({
               <FormText>{getLabelOfOption(indexOptions, basisOfRent.index) || '-'}</FormText>
             </Authorization>
           </Column>}
-          {(calculatorType !== CalculatorTypes.LEASE && calculatorType !== CalculatorTypes.MAST) && <Column small={6} medium={4} large={2}>
+          {(calculatorType !== CalculatorTypes.LEASE && calculatorType !== CalculatorTypes.LEASE2022 && calculatorType !== CalculatorTypes.MAST) && <Column small={6} medium={4} large={2}>
             <Authorization allow={
               isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
               isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)
@@ -423,7 +481,6 @@ const BasisOfRent = ({
               <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.BASE_YEAR_RENT)}>
                 {LeaseBasisOfRentsFieldTitles.BASE_YEAR_RENT}
               </FormTextTitle>
-              {calculatorType === CalculatorTypes.LEASE && <FormText>{!isEmptyValue(basicAnnualRent) ? `${formatNumber(basicAnnualRent)} €/v` : '-'}</FormText>}
               {calculatorType === CalculatorTypes.TEMPORARY && <FormText>{!isEmptyValue(temporaryRentIndexed) ? `${formatNumber(temporaryRentIndexed)} €/v` : '-'}</FormText>}
               {calculatorType === CalculatorTypes.ADDITIONAL_YARD && <FormText>{!isEmptyValue(rentExtraIndexed) ? `${formatNumber(rentExtraIndexed)} €/v` : '-'}</FormText>}
               {calculatorType === CalculatorTypes.FIELD && <FormText>{!isEmptyValue(basicAnnualFieldRentIndexed) ? `${formatNumber(basicAnnualFieldRentIndexed)} €/v` : '-'}</FormText>}
@@ -488,101 +545,70 @@ const BasisOfRent = ({
             </Column>
           </Authorization>
         </Row>}
-        <Row>
-          {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
+
+        {calculatorType === CalculatorTypes.LEASE && <Row>
+          <Column small={6} medium={4} large={2}>
             <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)}>
               <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)}>
                 {LeaseBasisOfRentsFieldTitles.AMOUNT_PER_AREA}
               </FormTextTitle>
               <FormText>{amountPerAreaText}</FormText>
             </Authorization>
-          </Column>}
-          {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
-            <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX)}>
-              <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.INDEX)}>
-                {LeaseBasisOfRentsFieldTitles.INDEX}
-              </FormTextTitle>
-              <FormText>{getLabelOfOption(indexOptions, basisOfRent.index) || '-'}</FormText>
-            </Authorization>
-          </Column>}
-          {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
-            <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) && isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX)}>
-              <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.UNIT_PRICE)}>
-                {LeaseBasisOfRentsFieldTitles.UNIT_PRICE}
-              </FormTextTitle>
-              <FormText>{currentAmountPerAreaText}</FormText>
-            </Authorization>
-          </Column>}
-          {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
-            <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE)}>
-              <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE)}>
-                {LeaseBasisOfRentsFieldTitles.PROFIT_MARGIN_PERCENTAGE}
-              </FormTextTitle>
-              <FormText>{!isEmptyValue(basisOfRent.profit_margin_percentage) ? `${formatNumber(basisOfRent.profit_margin_percentage)} %` : '-'}</FormText>
-            </Authorization>
-          </Column>}
-          {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
-            <Authorization allow={
-              isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
-              isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)
-            }>
-              <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.BASE_YEAR_RENT)}>
-                {LeaseBasisOfRentsFieldTitles.BASE_YEAR_RENT}
-              </FormTextTitle>
-              <FormText>{!isEmptyValue(basicAnnualRent) ? `${formatNumber(basicAnnualRent)} €/v` : '-'}</FormText>
-            </Authorization>
-          </Column>}
-          {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
-            <Authorization allow={
-              isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
-              isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) &&
-              isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX) &&
-              isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE)
-            }>
-              <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.INITIAL_YEAR_RENT)}>
-                {LeaseBasisOfRentsFieldTitles.INITIAL_YEAR_RENT}
-              </FormTextTitle>
-              <FormText>{!isEmptyValue(initialYearRent) ? `${formatNumber(initialYearRent)} €/v` : '-'}</FormText>
-            </Authorization>
-          </Column>}
-          {((basisOfRent.subvention_type === SubventionTypes.FORM_OF_MANAGEMENT ||
-            basisOfRent.subvention_type === SubventionTypes.RE_LEASE) && calculatorType === CalculatorTypes.LEASE) && <Fragment>
-            <Column small={6} medium={4} large={2}>
-              <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
-                <FormTextTitle>
-                  {LeaseBasisOfRentsFieldTitles.SUBVENTION_DISCOUNT_PERCENTAGE}
-                </FormTextTitle>
-                <FormText>{!isEmptyValue(discountPercentage) ? `${formatNumber(discountPercentage)} %` : '-'}</FormText>
-              </Authorization>
-            </Column>
-            <Column small={6} medium={4} large={2}>
-              <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
-                <FormTextTitle>
-                  {LeaseBasisOfRentsFieldTitles.DISCOUNTED_INITIAL}
-                </FormTextTitle>
-                <FormText>{!isEmptyValue(subventionDiscountedInitial) ? `${formatNumber(subventionDiscountedInitial)} €/v` : '-'}</FormText>
-              </Authorization>
-            </Column>
-            <Column small={0} medium={4} large={8}></Column>
-            <Column small={12} medium={12} large={12}>
-              <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
-                <FormTextTitle>
-                  {LeaseBasisOfRentsFieldTitles.TEMPORARY_DISCOUNT_PERCENTAGE}
-                </FormTextTitle>
-                <FormText>{!isEmptyValue(temporarySubventionDiscountPercentage) ? `${formatNumber(temporarySubventionDiscountPercentage)} %` : '-'}</FormText>
-              </Authorization>
-            </Column>
-          </Fragment>}
+          </Column>
+          <Column small={6} medium={4} large={2}>{renderIndexFormField()}</Column>
+          <Column small={6} medium={4} large={2}>{renderUnitPriceFormField()}</Column>
+          <Column small={6} medium={4} large={2}>{renderProfitMarginPercentageFormField()}</Column>
+          <Column small={6} medium={4} large={2}>{renderBaseYearRentFormField()}</Column>
+          <Column small={6} medium={4} large={2}>{renderInitialYearRentFormField()}</Column>
+        </Row>}
 
-          {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
+        {calculatorType === CalculatorTypes.LEASE2022 && <Row>
+          <Column small={6} medium={4} large={2}>{renderUnitPriceFormField()}</Column>
+          <Column small={6} medium={4} large={2}>{renderProfitMarginPercentageFormField()}</Column>
+          <Column small={6} medium={4} large={2}>{renderInitialYearRentFormField()}</Column>
+          <Column small={6} medium={4} large={2}>{renderIndexFormField()}</Column>
+          <Column small={6} medium={4} large={2}>{renderBaseYearRentFormField()}</Column>
+        </Row>}
+
+        {((basisOfRent.subvention_type === SubventionTypes.FORM_OF_MANAGEMENT ||
+          basisOfRent.subvention_type === SubventionTypes.RE_LEASE) && (calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022)) && <Row>
+          <Column small={6} medium={4} large={2}>
+            <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
+              <FormTextTitle>
+                {LeaseBasisOfRentsFieldTitles.SUBVENTION_DISCOUNT_PERCENTAGE}
+              </FormTextTitle>
+              <FormText>{!isEmptyValue(discountPercentage) ? `${formatNumber(discountPercentage)} %` : '-'}</FormText>
+            </Authorization>
+          </Column>
+          <Column small={6} medium={4} large={2}>
+            <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
+              <FormTextTitle>
+                {LeaseBasisOfRentsFieldTitles.DISCOUNTED_INITIAL}
+              </FormTextTitle>
+              <FormText>{!isEmptyValue(subventionDiscountedInitial) ? `${formatNumber(subventionDiscountedInitial)} €/v` : '-'}</FormText>
+            </Authorization>
+          </Column>
+          <Column small={0} medium={4} large={8}></Column>
+          <Column small={12} medium={12} large={12}>
+            <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
+              <FormTextTitle>
+                {LeaseBasisOfRentsFieldTitles.TEMPORARY_DISCOUNT_PERCENTAGE}
+              </FormTextTitle>
+              <FormText>{!isEmptyValue(temporarySubventionDiscountPercentage) ? `${formatNumber(temporarySubventionDiscountPercentage)} %` : '-'}</FormText>
+            </Authorization>
+          </Column>
+        </Row>}
+
+        {(calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) && <Row>
+          <Column small={6} medium={4} large={2} hidden>
             <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
               <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
                 {LeaseBasisOfRentsFieldTitles.DISCOUNT_PERCENTAGE}
               </FormTextTitle>
-              <FormText>{!isEmptyValue(basisOfRent.discount_percentage) ? `${formatNumber(basisOfRent.discount_percentage)} %` : '-'}</FormText>
+              <FormText>{!isEmptyValue(basisOfRent.discount_percentage) ? `${basisOfRent.discount_percentage} %` : '-'}</FormText>
             </Authorization>
-          </Column>}
-          {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={3}>
+          </Column>
+          <Column small={6} medium={4} large={3}>
             <Authorization allow={
               isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
               isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) &&
@@ -595,8 +621,8 @@ const BasisOfRent = ({
               </FormTextTitle>
               <FormText>{!isEmptyValue(discountedInitialYearRent) ? `${formatNumber(discountedInitialYearRent)} €/v` : '-'}</FormText>
             </Authorization>
-          </Column>}
-          {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={1}>
+          </Column>
+          <Column small={6} medium={4} large={1}>
             <Authorization allow={
               isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
               isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) &&
@@ -609,8 +635,8 @@ const BasisOfRent = ({
               </FormTextTitle>
               <FormText>{!isEmptyValue(rentPerMonth) ? `${formatNumber(rentPerMonth)} €` : '-'}</FormText>
             </Authorization>
-          </Column>}
-          {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={1}>
+          </Column>
+          <Column small={6} medium={4} large={1}>
             <Authorization allow={
               isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
               isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) &&
@@ -623,42 +649,41 @@ const BasisOfRent = ({
               </FormTextTitle>
               <FormText>{!isEmptyValue(rentPer2Months) ? `${formatNumber(rentPer2Months)} €` : '-'}</FormText>
             </Authorization>
-          </Column>}
-          {(showTotal && calculatorType === CalculatorTypes.LEASE) &&
-            <Fragment>
-              <Column small={6} medium={4} large={2}>
-                <Authorization allow={
-                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
-                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) &&
-                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX) &&
-                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE) &&
-                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)
-                }>
-                  <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.DISCOUNTED_INITIAL_YEAR_RENT_PER_MONTH_TOTAL)}>
-                    {LeaseBasisOfRentsFieldTitles.DISCOUNTED_INITIAL_YEAR_RENT_PER_MONTH_TOTAL}
-                  </FormTextTitle>
-                  <FormText>{!isEmptyValue(rentPerMonthTotal) ? `${formatNumber(rentPerMonthTotal)} €` : '-'}</FormText>
-                </Authorization>
-              </Column>
-              <Column small={6} medium={4} large={2}>
-                <Authorization allow={
-                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
-                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) &&
-                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX) &&
-                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE) &&
-                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)
-                }>
-                  <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.DISCOUNTED_INITIAL_YEAR_RENT_PER_2_MONTHS_TOTAL)}>
-                    {LeaseBasisOfRentsFieldTitles.DISCOUNTED_INITIAL_YEAR_RENT_PER_2_MONTHS_TOTAL}
-                  </FormTextTitle>
-                  <FormText>{!isEmptyValue(rentPer2MonthsTotal) ? `${formatNumber(rentPer2MonthsTotal)} €` : '-'}</FormText>
-                </Authorization>
-              </Column>
-            </Fragment>
-          }
-        </Row>
+          </Column>
 
-        {(basisOfRent.subvention_type && calculatorType === CalculatorTypes.LEASE) &&
+          {showTotal && <Fragment>
+            <Column small={6} medium={4} large={2}>
+              <Authorization allow={
+                isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
+                isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) &&
+                isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX) &&
+                isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE) &&
+                isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)
+              }>
+                <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.DISCOUNTED_INITIAL_YEAR_RENT_PER_MONTH_TOTAL)}>
+                  {LeaseBasisOfRentsFieldTitles.DISCOUNTED_INITIAL_YEAR_RENT_PER_MONTH_TOTAL}
+                </FormTextTitle>
+                <FormText>{!isEmptyValue(rentPerMonthTotal) ? `${formatNumber(rentPerMonthTotal)} €` : '-'}</FormText>
+              </Authorization>
+            </Column>
+            <Column small={6} medium={4} large={2}>
+              <Authorization allow={
+                isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
+                isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) &&
+                isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX) &&
+                isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE) &&
+                isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)
+              }>
+                <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.DISCOUNTED_INITIAL_YEAR_RENT_PER_2_MONTHS_TOTAL)}>
+                  {LeaseBasisOfRentsFieldTitles.DISCOUNTED_INITIAL_YEAR_RENT_PER_2_MONTHS_TOTAL}
+                </FormTextTitle>
+                <FormText>{!isEmptyValue(rentPer2MonthsTotal) ? `${formatNumber(rentPer2MonthsTotal)} €` : '-'}</FormText>
+              </Authorization>
+            </Column>
+          </Fragment>}
+        </Row>}
+
+        {(basisOfRent.subvention_type && (calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022)) &&
           <WhiteBox>
             <Row>
               <Column small={6} medium={4} large={2}>
@@ -734,7 +759,7 @@ const BasisOfRent = ({
                           </Column>
                           <Column small={4} large={2}>
                             <Authorization allow={isFieldAllowedToRead(leaseAttributes, BasisOfRentManagementSubventionsFieldPaths.SUBVENTION_AMOUNT)}>
-                              <FormText>{!isEmptyValue(subventionTotal) ? `${formatNumber(subventionTotal)} €` : '-'}</FormText>
+                              <FormText>{!isEmptyValue(subventionTotal) ? `${formatNumber(subventionTotal, 3)} €` : '-'}</FormText>
                             </Authorization>
                           </Column>
                         </Row>
@@ -817,7 +842,7 @@ const BasisOfRent = ({
                   </Row>
 
                   {temporarySubventions.map((subvention, index) => {
-                    const subventionAmount = calculateBasisOfRentSubventionAmountCumulative(initialYearRent, subvention.subvention_percent, managementSubventions, temporarySubventions, index, 'VIEW');
+                    const subventionAmount = calculateBasisOfRentSubventionAmountCumulative(initialYearRent, subvention.subvention_percent, managementSubventions, temporarySubventions, index, 'VIEW', currentAmountPerArea);
                     return(
                       <Row key={subvention.id}>
                         <Column small={4} large={2}>
@@ -832,7 +857,7 @@ const BasisOfRent = ({
                         </Column>
                         <Column small={4} large={2}>
                           <Authorization allow={isFieldAllowedToRead(leaseAttributes, BasisOfRentTemporarySubventionsFieldPaths.DESCRIPTION)}>
-                            <FormText>{formatNumber(subventionAmount)} €</FormText>
+                            <FormText>{formatNumber(subventionAmount, 3)} €</FormText>
                           </Authorization>
                         </Column>
                       </Row>

--- a/src/leases/components/leaseSections/rent/BasisOfRent.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRent.js
@@ -570,34 +570,37 @@ const BasisOfRent = ({
           <Column small={6} medium={4} large={2}>{renderBaseYearRentFormField()}</Column>
         </Row>}
 
-        {((basisOfRent.subvention_type === SubventionTypes.FORM_OF_MANAGEMENT ||
-          basisOfRent.subvention_type === SubventionTypes.RE_LEASE) && (calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022)) && <Row>
-          <Column small={6} medium={4} large={2}>
-            <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
-              <FormTextTitle>
-                {LeaseBasisOfRentsFieldTitles.SUBVENTION_DISCOUNT_PERCENTAGE}
-              </FormTextTitle>
-              <FormText>{!isEmptyValue(discountPercentage) ? `${formatNumber(discountPercentage)} %` : '-'}</FormText>
-            </Authorization>
-          </Column>
-          <Column small={6} medium={4} large={2}>
-            <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
-              <FormTextTitle>
-                {LeaseBasisOfRentsFieldTitles.DISCOUNTED_INITIAL}
-              </FormTextTitle>
-              <FormText>{!isEmptyValue(subventionDiscountedInitial) ? `${formatNumber(subventionDiscountedInitial)} €/v` : '-'}</FormText>
-            </Authorization>
-          </Column>
-          <Column small={0} medium={4} large={8}></Column>
-          <Column small={12} medium={12} large={12}>
-            <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
-              <FormTextTitle>
-                {LeaseBasisOfRentsFieldTitles.TEMPORARY_DISCOUNT_PERCENTAGE}
-              </FormTextTitle>
-              <FormText>{!isEmptyValue(temporarySubventionDiscountPercentage) ? `${formatNumber(temporarySubventionDiscountPercentage)} %` : '-'}</FormText>
-            </Authorization>
-          </Column>
-        </Row>}
+        {calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022 && <>
+          {(basisOfRent.subvention_type === SubventionTypes.FORM_OF_MANAGEMENT || basisOfRent.subvention_type === SubventionTypes.RE_LEASE) && <Row>
+            <Column small={6} medium={4} large={2}>
+              <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
+                <FormTextTitle>
+                  {LeaseBasisOfRentsFieldTitles.SUBVENTION_DISCOUNT_PERCENTAGE}
+                </FormTextTitle>
+                <FormText>{!isEmptyValue(discountPercentage) ? `${formatNumber(discountPercentage)} %` : '-'}</FormText>
+              </Authorization>
+            </Column>
+            <Column small={6} medium={4} large={2}>
+              <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
+                <FormTextTitle>
+                  {LeaseBasisOfRentsFieldTitles.DISCOUNTED_INITIAL}
+                </FormTextTitle>
+                <FormText>{!isEmptyValue(subventionDiscountedInitial) ? `${formatNumber(subventionDiscountedInitial)} €/v` : '-'}</FormText>
+              </Authorization>
+            </Column>
+            <Column small={0} medium={4} large={8}></Column>
+          </Row>}
+          {temporarySubventions && <Row>
+            <Column small={12} medium={12} large={12}>
+              <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
+                <FormTextTitle>
+                  {LeaseBasisOfRentsFieldTitles.TEMPORARY_DISCOUNT_PERCENTAGE}
+                </FormTextTitle>
+                <FormText>{!isEmptyValue(temporarySubventionDiscountPercentage) ? `${formatNumber(temporarySubventionDiscountPercentage)} %` : '-'}</FormText>
+              </Authorization>
+            </Column>
+          </Row>}
+        </>}
 
         {(calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) && <Row>
           <Column small={6} medium={4} large={2} hidden>
@@ -683,9 +686,9 @@ const BasisOfRent = ({
           </Fragment>}
         </Row>}
 
-        {(basisOfRent.subvention_type && (calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022)) &&
+        {((basisOfRent.subvention_type || (!!temporarySubventions && !!temporarySubventions.length)) && (calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022)) &&
           <WhiteBox>
-            <Row>
+            {basisOfRent.subvention_type && <Row>
               <Column small={6} medium={4} large={2}>
                 <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.SUBVENTION_TYPE)}>
                   <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.SUBVENTION_TYPE)}>
@@ -694,14 +697,14 @@ const BasisOfRent = ({
                   <FormText>{getLabelOfOption(subventionTypeOptions, basisOfRent.subvention_type) || '-'}</FormText>
                 </Authorization>
               </Column>
-            </Row>
+            </Row>}
             {basisOfRent.subvention_type === SubventionTypes.FORM_OF_MANAGEMENT &&
               <Authorization allow={isFieldAllowedToRead(leaseAttributes, BasisOfRentManagementSubventionsFieldPaths.MANAGEMENT_SUBVENTIONS)}>
                 <SubTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(BasisOfRentManagementSubventionsFieldPaths.MANAGEMENT_SUBVENTIONS)}>{BasisOfRentManagementSubventionsFieldTitles.MANAGEMENT_SUBVENTIONS}</SubTitle>
                 {!managementSubventions || !managementSubventions.length &&
                   <FormText>Ei hallintamuotoja</FormText>
                 }
-                {managementSubventions && managementSubventions.length &&
+                {managementSubventions && !!managementSubventions.length &&
                   <Fragment>
                     <Row>
                       <Column small={4} large={2}>

--- a/src/leases/components/leaseSections/rent/BasisOfRentEdit.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRentEdit.js
@@ -217,7 +217,7 @@ type TemporarySubventionsProps = {
 const renderTemporarySubventions = ({
   disabled,
   fields,
-  formName, 
+  formName,
   initialYearRent,
   leaseAttributes,
   usersPermissions,
@@ -440,7 +440,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
       const {subventionType, subventionBasePercent, subventionGraduatedPercent, managementSubventions, temporarySubventions} = this.props;
 
       // Don't change discount_percent automatically if basis of rent is deleted
-      if(subventionType !== undefined ||  
+      if(subventionType !== undefined ||
         subventionBasePercent !== undefined ||
         subventionGraduatedPercent !== undefined ||
         managementSubventions !== undefined ||
@@ -453,7 +453,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
   changeDiscounts(){
     const releaseDiscountPercent = this.calculateReLeaseDiscountPercent();
     const {change, field, subventionType, managementSubventions} = this.props;
-    
+
     if(subventionType === SubventionTypes.RE_LEASE){
       change(this.props.formName, `${field}.discount_percentage`, formatNumber(this.calculateTotalSubventionPercent()));
       change(this.props.formName, `${field}.subvention_discount_percentage`, releaseDiscountPercent.toFixed(2));
@@ -521,7 +521,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
   handleCopyToClipboard = () => {
     const tableContent = this.getTableContentForClipBoard(),
       el = document.createElement('table');
-    
+
     el.className = 'sortable-table__clipboard-table';
     el.innerHTML = tableContent;
     if(copyElementContentsToClipboard(el)) {
@@ -741,7 +741,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
     const currentAmountPerArea = calculateBasisOfRentAmountPerArea({amount_per_area: value}, indexValue);
     change(this.props.formName, `${field}.current_amount_per_area`, currentAmountPerArea);
   }
-  
+
   onChangeCurrentAmountPerArea = (value: any) => {
     const {basisOfRent, change, field, indexOptions} = this.props;
     const indexValue = getBasisOfRentIndexValue(basisOfRent, indexOptions);
@@ -874,7 +874,6 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
               </Authorization>
             }
           </ActionButtonWrapper>
-
           <Row>
             <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.TYPE)}>
               <Column small={6} medium={4} large={2}>
@@ -1184,7 +1183,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                 </Authorization>
               </Row>
             </Column>}
-            {showPlansInspectedAt && calculatorType === CalculatorTypes.LEASE && 
+            {showPlansInspectedAt && calculatorType === CalculatorTypes.LEASE &&
               <Column small={6} medium={4} large={2}>
                 <Authorization
                   allow={isFieldAllowedToEdit(leaseAttributes, LeaseBasisOfRentsFieldPaths.PLANS_INSPECTED_AT)}
@@ -1210,8 +1209,8 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                 </Authorization>
               </Column>
             }
-            
-            {showLockedAt && calculatorType === CalculatorTypes.LEASE && 
+
+            {showLockedAt && calculatorType === CalculatorTypes.LEASE &&
               <Column small={6} medium={4} large={2}>
                 <Authorization
                   allow={isFieldAllowedToEdit(leaseAttributes, LeaseBasisOfRentsFieldPaths.LOCKED_AT)}

--- a/src/leases/components/leaseSections/rent/BasisOfRentEdit.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRentEdit.js
@@ -1798,7 +1798,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                         <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.SUBVENTION_TYPE)}>
                           <FormField
                             disableTouched={isSaveClicked}
-                            fieldAttributes={{...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.SUBVENTION_TYPE), required: true}}
+                            fieldAttributes={{...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.SUBVENTION_TYPE), required: false}}
                             name={`${field}.subvention_type`}
                             disabled={(!!savedBasisOfRent && !!savedBasisOfRent.locked_at)}
                             overrideValues={{label: LeaseBasisOfRentsFieldTitles.SUBVENTION_TYPE}}

--- a/src/leases/components/leaseSections/rent/BasisOfRentEdit.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRentEdit.js
@@ -1,7 +1,7 @@
 // @flow
 import React, {Fragment, PureComponent, type Element} from 'react';
 import {connect} from 'react-redux';
-import {change, FieldArray, formValueSelector} from 'redux-form';
+import {change, FieldArray, formValueSelector, clearFields} from 'redux-form';
 import {Row, Column} from 'react-foundation';
 
 import {ActionTypes, AppConsumer} from '$src/app/AppContext';
@@ -37,7 +37,7 @@ import {
 } from '$src/leases/enums';
 import {UsersPermissions} from '$src/usersPermissions/enums';
 import {
-  calculateBasisOfRentAmountPerArea,
+  getBasisOfRentAmountPerArea,
   calculateAmountFromValue,
   calculateBasisOfRentBasicAnnualRent,
   calculateBasisOfRentDiscountedInitialYearRent,
@@ -373,6 +373,7 @@ type Props = {
   calculatorTypeOptions: Array<Object>,
   change: Function,
   children: ?Object,
+  clearFields: Function,
   currentLease: Lease,
   discountPercentage: ?string,
   field: string,
@@ -422,44 +423,64 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
     showSubventions: this.props.subventionType ? true : false,
   }
 
-  componentDidMount(){
-    const {basisOfRent, change, field, indexOptions} = this.props;
-    const indexValue = getBasisOfRentIndexValue(basisOfRent, indexOptions);
-    const currentAmountPerArea = calculateBasisOfRentAmountPerArea(basisOfRent, indexValue);
-    change(this.props.formName, `${field}.current_amount_per_area`, currentAmountPerArea);
+  initialFormValues = () => {
+    const {basisOfRent, change, field, indexOptions, calculatorType} = this.props;
+    if(calculatorType && (calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022)) {
+      const indexValue = getBasisOfRentIndexValue(basisOfRent, indexOptions);
+      const currentAmountPerArea = getBasisOfRentAmountPerArea(basisOfRent, indexValue);
+      change(this.props.formName, `${field}.current_amount_per_area`, currentAmountPerArea);
+    }
     this.changeDiscounts();
   }
 
-  componentDidUpdate(prevProps: Props) {
-    if(this.state.showSubventions &&
-      (this.props.subventionType !== prevProps.subventionType ||
-      this.props.subventionBasePercent !== prevProps.subventionBasePercent ||
-      this.props.subventionGraduatedPercent !== prevProps.subventionGraduatedPercent ||
-      this.props.managementSubventions !== prevProps.managementSubventions ||
-      this.props.temporarySubventions !== prevProps.temporarySubventions)) {
-      const {subventionType, subventionBasePercent, subventionGraduatedPercent, managementSubventions, temporarySubventions} = this.props;
+  componentDidMount(){
+    this.initialFormValues();
+  }
 
-      // Don't change discount_percent automatically if basis of rent is deleted
-      if(subventionType !== undefined ||
-        subventionBasePercent !== undefined ||
-        subventionGraduatedPercent !== undefined ||
-        managementSubventions !== undefined ||
-        temporarySubventions !== undefined) {
+  componentDidUpdate(prevProps: Props) {
+    const {showSubventions} = this.state;
+    const {
+      currentAmountPerArea,
+      managementSubventions,
+      subventionBasePercent,
+      subventionGraduatedPercent,
+      subventionType,
+      temporarySubventions,
+    } = this.props;
+
+    if(showSubventions) {
+      if(currentAmountPerArea !== prevProps.currentAmountPerArea && managementSubventions !== undefined) {
         this.changeDiscounts();
+      }
+
+      if(subventionType !== prevProps.subventionType ||
+        subventionBasePercent !== prevProps.subventionBasePercent ||
+        subventionGraduatedPercent !== prevProps.subventionGraduatedPercent ||
+        managementSubventions !== prevProps.managementSubventions ||
+        temporarySubventions !== prevProps.temporarySubventions) {
+
+        // Don't change discount_percent automatically if basis of rent is deleted
+        if(subventionType !== undefined ||
+          subventionBasePercent !== undefined ||
+          subventionGraduatedPercent !== undefined ||
+          managementSubventions !== undefined ||
+          temporarySubventions !== undefined) {
+          this.changeDiscounts();
+        }
       }
     }
   }
 
   changeDiscounts(){
-    const releaseDiscountPercent = this.calculateReLeaseDiscountPercent();
     const {change, field, subventionType, managementSubventions} = this.props;
 
     if(subventionType === SubventionTypes.RE_LEASE){
-      change(this.props.formName, `${field}.discount_percentage`, formatNumber(this.calculateTotalSubventionPercent()));
+      const releaseDiscountPercent = this.calculateReLeaseDiscountPercent();
+      change(this.props.formName, `${field}.discount_percentage`, this.calculateTotalSubventionPercent());
       change(this.props.formName, `${field}.subvention_discount_percentage`, releaseDiscountPercent.toFixed(2));
     }
     if(subventionType === SubventionTypes.FORM_OF_MANAGEMENT){
-      change(this.props.formName, `${field}.discount_percentage`, formatNumber(this.calculateTotalSubventionPercent()));
+      change(this.props.formName, `${field}.discount_percentage`, this.calculateTotalSubventionPercent());
       if(managementSubventions && managementSubventions[0]){
         change(this.props.formName, `${field}.subvention_discount_percentage`, managementSubventions[0].subvention_percent);
       }
@@ -554,10 +575,10 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
 
     const areaText = this.getAreaText(area);
     const indexValue = getBasisOfRentIndexValue(basisOfRent, indexOptions);
-    const currentAmountPerArea = calculateBasisOfRentAmountPerArea(basisOfRent, indexValue);
+    const currentAmountPerArea = getBasisOfRentAmountPerArea(basisOfRent, indexValue);
     const currentAmountPerAreaText = this.getAmountPerAreaText(currentAmountPerArea);
     const amountPerAreaText = this.getAmountPerAreaText(amountPerArea);
-    const basicAnnualRent = calculateBasisOfRentBasicAnnualRent(basisOfRent);
+    const basicAnnualRent = calculateBasisOfRentBasicAnnualRent(basisOfRent, indexValue);
     const initialYearRent = calculateBasisOfRentInitialYearRent(basisOfRent, indexValue, basicAnnualRent);
     const discountedInitialYearRent = calculateBasisOfRentDiscountedInitialYearRent(basisOfRent, indexValue);
     const rentPerMonth = discountedInitialYearRent != null ? discountedInitialYearRent/12 : null;
@@ -725,7 +746,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
   calculateTotalSubventionPercent = () => {
     const {basisOfRent, indexOptions, subventionType, subventionBasePercent, subventionGraduatedPercent, managementSubventions, temporarySubventions} = this.props;
     const indexValue = getBasisOfRentIndexValue(basisOfRent, indexOptions);
-    const currentAmountPerArea = calculateBasisOfRentAmountPerArea(basisOfRent, indexValue);
+    const currentAmountPerArea = getBasisOfRentAmountPerArea(basisOfRent, indexValue);
     return calculateBasisOfRentSubventionPercent(
       currentAmountPerArea,
       subventionType,
@@ -735,35 +756,85 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
       temporarySubventions);
   }
 
+  clearAllFields = () => {
+    const {clearFields, field} = this.props;
+    return clearFields(
+      this.props.formName,
+      false,
+      false,
+      `${field}.amount_per_area`, // Same field for both "price" and "amountPerArea"
+      `${field}.area`,
+      `${field}.area_unit`,
+      `${field}.base_year_rent`,
+      `${field}.current_amount_per_area`,
+      `${field}.discount_percentage`,
+      `${field}.discounted_intial_year_rent`,
+      `${field}.discounted_intial_year_rent_per_month`,
+      `${field}.discounted_intial_year_rent_per_month_total`,
+      `${field}.discounted_intial_year_rent_per_2_months`,
+      `${field}.discounted_intial_year_rent_per_2_months_total`,
+      `${field}.index`,
+      `${field}.intial_year_rent`,
+      `${field}.intended_use`,
+      `${field}.profit_margin_percentage`,
+      `${field}.subvention_base_percent`,
+      `${field}.subvention_discount_percentage`,
+      `${field}.subvention_graduated_percent`,
+      `${field}.subvention_re_lease_discount_amount`,
+      `${field}.subvention_re_lease_discount_precent`,
+      `${field}.temporary_subvention_discount_percentage`,
+      `${field}.unit_price`,
+      `${field}.zone`,
+    );
+  }
+
+  // Reset all fields when calculator type changes
+  onChangeTypeOptions = (value: any) => {
+    const {calculatorType} = this.props;
+    if(value !== calculatorType) {
+      this.clearAllFields();
+      this.handleRemoveSubventions();
+      this.initialFormValues();
+    }
+  }
+
+  // LEASE: Yksikköhinta(ind 100)
   onChangeAmountPerArea = (value: any) => {
     const {basisOfRent, change, field, indexOptions} = this.props;
     const indexValue = getBasisOfRentIndexValue(basisOfRent, indexOptions);
-    const currentAmountPerArea = calculateBasisOfRentAmountPerArea({amount_per_area: value}, indexValue);
+    const currentAmountPerArea = getBasisOfRentAmountPerArea({amount_per_area: value}, indexValue);
     change(this.props.formName, `${field}.current_amount_per_area`, currentAmountPerArea);
   }
 
+  // LEASE & LEASE2022: Yksikköhinta (ind)
   onChangeCurrentAmountPerArea = (value: any) => {
-    const {basisOfRent, change, field, indexOptions} = this.props;
-    const indexValue = getBasisOfRentIndexValue(basisOfRent, indexOptions);
-    const amountPerArea = calculateAmountFromValue(value, indexValue);
-    change(this.props.formName, `${field}.amount_per_area`, amountPerArea);
+    const {basisOfRent, change, field, indexOptions, calculatorType} = this.props;
+    if (calculatorType === CalculatorTypes.LEASE2022) {
+      change(this.props.formName, `${field}.amount_per_area`, value);
+    } else {
+      const indexValue = getBasisOfRentIndexValue(basisOfRent, indexOptions);
+      const amountPerArea = calculateAmountFromValue(value, indexValue);
+      change(this.props.formName, `${field}.amount_per_area`, amountPerArea);
+    }
   }
 
+  // LEASE & LEASE2022: Indeksi
   onChangeIndexOptions = (value: any) => {
-    const {basisOfRent, change, field, indexOptions} = this.props;
-    const indexValue = getBasisOfRentIndexValue({index: value}, indexOptions);
-    const currentAmountPerArea = calculateBasisOfRentAmountPerArea(basisOfRent, indexValue);
-    change(this.props.formName, `${field}.current_amount_per_area`, currentAmountPerArea);
+    const {basisOfRent, change, field, indexOptions, calculatorType} = this.props;
+    if (calculatorType === CalculatorTypes.LEASE) {
+      const indexValue = getBasisOfRentIndexValue({index: value}, indexOptions);
+      const currentAmountPerArea = getBasisOfRentAmountPerArea(basisOfRent, indexValue);
+      change(this.props.formName, `${field}.current_amount_per_area`, currentAmountPerArea);
+    }
   }
 
   getSubventionDiscountedInitial = () => {
     const {subventionType, managementSubventions, basisOfRent, indexOptions} = this.props;
     const indexValue = getBasisOfRentIndexValue(basisOfRent, indexOptions);
     const releaseDiscountPercent = this.calculateReLeaseDiscountPercent();
-    const basicAnnualRent = calculateBasisOfRentBasicAnnualRent(basisOfRent);
+    const basicAnnualRent = calculateBasisOfRentBasicAnnualRent(basisOfRent, indexValue);
     const initialYearRent = calculateBasisOfRentInitialYearRent(basisOfRent, indexValue, basicAnnualRent);
-    const currentAmountPerArea = calculateBasisOfRentAmountPerArea(basisOfRent, indexValue);
-
+    const currentAmountPerArea = getBasisOfRentAmountPerArea(basisOfRent, indexValue);
     if(subventionType === SubventionTypes.RE_LEASE)
       return calculateSubventionDiscountTotalFromReLease(initialYearRent, releaseDiscountPercent);
     if(subventionType === SubventionTypes.FORM_OF_MANAGEMENT)
@@ -808,35 +879,149 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
     const {showSubventions} = this.state;
 
     const savedBasisOfRent = getBasisOfRentById(currentLease, id);
+
+    // Used by all CalculatorTypes
     const indexValue = getBasisOfRentIndexValue(basisOfRent, indexOptions);
-    const currentAmountPerArea = calculateBasisOfRentAmountPerArea(basisOfRent, indexValue);
+    const basicAnnualRent = calculateBasisOfRentBasicAnnualRent(basisOfRent, indexValue);
     const areaText = this.getAreaText(area);
+
+    // Used by CalculatorTypes.LEASE
     const amountPerAreaText = this.getAmountPerAreaText(amountPerArea);
+    const currentAmountPerArea = getBasisOfRentAmountPerArea(basisOfRent, indexValue);
+
+    // Used by CalculatorTypes.LEASE and CalculatorTypes.LEASE2022
     const lockedAtText = this.getLockedText();
     const plansInspectedAtText = this.getPlansInspectedText();
-    const basicAnnualRent = calculateBasisOfRentBasicAnnualRent(basisOfRent);
     const initialYearRent = calculateBasisOfRentInitialYearRent(basisOfRent, indexValue, basicAnnualRent);
-    const discountedInitialYearRent = calculateBasisOfRentDiscountedInitialYearRent(basisOfRent, indexValue);
-    const rentPerMonth = discountedInitialYearRent != null ? discountedInitialYearRent / 12 : null;
-    const rentPer2Months = discountedInitialYearRent != null ? discountedInitialYearRent / 6 : null;
-    const rentPerMonthTotal = totalDiscountedInitialYearRent / 12;
-    const rentPer2MonthsTotal = totalDiscountedInitialYearRent / 6;
     const releaseDiscountPercent = this.calculateReLeaseDiscountPercent();
     const releaseDiscountAmount = calculateBasisOfRentSubventionAmount(initialYearRent, releaseDiscountPercent.toString());
     const totalSubventionPercent = this.calculateTotalSubventionPercent();
     const totalSubventionAmount = calculateBasisOfRentSubventionAmount(initialYearRent, totalSubventionPercent.toString());
     const subventionDiscountedInitial = this.getSubventionDiscountedInitial();
+    const discountedInitialYearRent = calculateBasisOfRentDiscountedInitialYearRent(basisOfRent, indexValue);
+    const rentPerMonth = discountedInitialYearRent != null ? discountedInitialYearRent / 12 : null;
+    const rentPer2Months = discountedInitialYearRent != null ? discountedInitialYearRent / 6 : null;
+    const rentPerMonthTotal = totalDiscountedInitialYearRent / 12;
+    const rentPer2MonthsTotal = totalDiscountedInitialYearRent / 6;
+
+    // Used by CalculatorTypes.TEMPORARY
     const zonePrice = getZonePriceFromValue(zone);
     const temporaryRent = calculateTemporaryRent(zonePrice, area);
     const temporaryRentIndexed = calculateBasicAnnualRentIndexed(temporaryRent * 12, indexValue);
+
+    // Used by CalculatorTypes.ADDITIONAL_YARD
     const rentExtra = calculateExtraRent(price, area);
     const rentExtraIndexed = calculateBasicAnnualRentIndexed(rentExtra, indexValue);
+
+    // Used by CalculatorTypes.FIELD
     const fieldsRent = calculateFieldsRent(price, area);
     const basicAnnualFieldRentIndexed = calculateBasicAnnualRentIndexed(fieldsRent, indexValue);
+
+    // Used by CalculatorTypes.MAST
     const mastAreaRent = 1.5 * calculateFieldsRent(price, area);
     const rackAndHeightPrice = calculateRackAndHeightPrice(children);
     const mastTotal = (mastAreaRent + rackAndHeightPrice) * 0.05;
     const mastTotalIndexed = calculateBasicAnnualRentIndexed(mastTotal, indexValue);
+
+    // Yksikköhinta (ind)
+    // text input
+    const renderUnitPriceFormField = (showLabel: boolean) => (
+      <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) && isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX)}>
+        {showLabel && (
+          <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.UNIT_PRICE)}>
+            {LeaseBasisOfRentsFieldTitles.UNIT_PRICE}
+          </FormTextTitle>
+        )}
+        <FormField
+          disableTouched={isSaveClicked}
+          onChange={this.onChangeCurrentAmountPerArea}
+          fieldAttributes={{
+            decimal_places: 2,
+            label: 'Yksikköhinta',
+            max_digits: 10,
+            read_only: false,
+            required: false,
+            type: 'decimal',
+          }}
+          disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+          name={`${field}.current_amount_per_area`}
+          unit='€'
+          invisibleLabel
+          overrideValues={{label: LeaseBasisOfRentsFieldTitles.AMOUNT_PER_AREA}}
+        />
+      </Authorization>
+    );
+
+    // Tuottoprosentti
+    // text input
+    const renderProfitMarginPercentageFormField = () => (
+      <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE)}>
+        <FormField
+          disableTouched={isSaveClicked}
+          fieldAttributes={savedBasisOfRent && !!savedBasisOfRent.locked_at
+            ? {...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE), required: false}
+            : getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE)
+          }
+          disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+          name={`${field}.profit_margin_percentage`}
+          unit='%'
+          overrideValues={{label: LeaseBasisOfRentsFieldTitles.PROFIT_MARGIN_PERCENTAGE}}
+          enableUiDataEdit
+          tooltipStyle={{right: 17}}
+          uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE)}
+        />
+      </Authorization>
+    );
+
+    // Alkuvuosivuokra (ind)
+    // Read only text
+    const renderInitialYearRentFormField = () => (
+      <Authorization allow={
+        isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
+        isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) &&
+        isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX) &&
+        isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE)
+      }>
+        <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.INITIAL_YEAR_RENT)}>
+          {LeaseBasisOfRentsFieldTitles.INITIAL_YEAR_RENT}
+        </FormTextTitle>
+        <FormText>{!isEmptyValue(initialYearRent) ? `${formatNumber(initialYearRent)} €/v` : '-'}</FormText>
+      </Authorization>
+    );
+
+    // Indeksi
+    // Dropdown
+    const renderIndexFormField = () => (
+      <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX)}>
+        <FormField
+          disableTouched={isSaveClicked}
+          fieldAttributes={{...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX), required: false}}
+          onChange={this.onChangeIndexOptions}
+          disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+          name={`${field}.index`}
+          overrideValues={{
+            label: LeaseBasisOfRentsFieldTitles.INDEX,
+            options: indexOptions,
+          }}
+          enableUiDataEdit
+          uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.INDEX)}
+        />
+      </Authorization>
+    );
+
+    // Perusvuosivuokra (ind 100)
+    // Read only
+    const renderBaseYearRentFormField = () => (
+      <Authorization allow={
+        isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
+        isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)
+      }>
+        <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.BASE_YEAR_RENT)}>
+          {LeaseBasisOfRentsFieldTitles.BASE_YEAR_RENT}
+        </FormTextTitle>
+        <FormText>{!isEmptyValue(basicAnnualRent) ? `${formatNumber(basicAnnualRent)} €/v` : '-'}</FormText>
+      </Authorization>
+    );
 
     if(archived && savedBasisOfRent) {
       return <BasisOfRent
@@ -880,6 +1065,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                 <FormField
                   disableTouched={isSaveClicked}
                   fieldAttributes={getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.TYPE)}
+                  onChange={this.onChangeTypeOptions}
                   name={`${field}.type`}
                   overrideValues={{
                     label: 'Laskurin tyyppi',
@@ -889,7 +1075,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                 />
               </Column>
             </Authorization>
-            {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
+            {(calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) && <Column small={6} medium={4} large={2}>
               <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INTENDED_USE)}>
                 <FormField
                   disableTouched={isSaveClicked}
@@ -905,7 +1091,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                 />
               </Authorization>
             </Column>}
-            {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
+            {(calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) && <Column small={6} medium={4} large={2}>
               <Authorization
                 allow={isFieldAllowedToEdit(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) || isFieldAllowedToEdit(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA_UNIT)}
                 errorComponent={
@@ -959,7 +1145,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                 </Row>
               </Authorization>
             </Column>}
-            {!!calculatorType && calculatorType !== CalculatorTypes.LEASE && <Column>
+            {!!calculatorType && (calculatorType !== CalculatorTypes.LEASE && calculatorType !== CalculatorTypes.LEASE2022) && <Column>
               <Row>
                 <Authorization
                   allow={isFieldAllowedToEdit(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) || isFieldAllowedToEdit(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA_UNIT)}
@@ -1174,7 +1360,6 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                       <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.BASE_YEAR_RENT)}>
                         {LeaseBasisOfRentsFieldTitles.BASE_YEAR_RENT}
                       </FormTextTitle>
-                      {calculatorType === CalculatorTypes.LEASE && <FormText>{!isEmptyValue(basicAnnualRent) ? `${formatNumber(basicAnnualRent)} €/v` : '-'}</FormText>}
                       {calculatorType === CalculatorTypes.TEMPORARY && <FormText>{!isEmptyValue(temporaryRentIndexed) ? `${formatNumber(temporaryRentIndexed)} €/v` : '-'}</FormText>}
                       {calculatorType === CalculatorTypes.ADDITIONAL_YARD && <FormText>{!isEmptyValue(rentExtraIndexed) ? `${formatNumber(rentExtraIndexed)} €/v` : '-'}</FormText>}
                       {calculatorType === CalculatorTypes.FIELD && <FormText>{!isEmptyValue(basicAnnualFieldRentIndexed) ? `${formatNumber(basicAnnualFieldRentIndexed)} €/v` : '-'}</FormText>}
@@ -1183,7 +1368,8 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                 </Authorization>
               </Row>
             </Column>}
-            {showPlansInspectedAt && calculatorType === CalculatorTypes.LEASE &&
+
+            {showPlansInspectedAt && (calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) &&
               <Column small={6} medium={4} large={2}>
                 <Authorization
                   allow={isFieldAllowedToEdit(leaseAttributes, LeaseBasisOfRentsFieldPaths.PLANS_INSPECTED_AT)}
@@ -1210,7 +1396,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
               </Column>
             }
 
-            {showLockedAt && calculatorType === CalculatorTypes.LEASE &&
+            {showLockedAt && (calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) &&
               <Column small={6} medium={4} large={2}>
                 <Authorization
                   allow={isFieldAllowedToEdit(leaseAttributes, LeaseBasisOfRentsFieldPaths.LOCKED_AT)}
@@ -1236,9 +1422,10 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
               </Column>
             }
           </Row>
-          <Row>
+
+          {calculatorType === CalculatorTypes.LEASE && <Row>
             <Column small={6} medium={4} large={2}>
-              {calculatorType === CalculatorTypes.LEASE && <Authorization
+              <Authorization
                 allow={isFieldAllowedToEdit(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)}
                 errorComponent={
                   <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)}>
@@ -1296,143 +1483,60 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                     </Authorization>
                   </Column>
                 </Row>
-              </Authorization>}
-            </Column>
-            {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
-              <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX)}>
-                <FormField
-                  disableTouched={isSaveClicked}
-                  fieldAttributes={{...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX), required: false}}
-                  onChange={this.onChangeIndexOptions}
-                  disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
-                  name={`${field}.index`}
-                  overrideValues={{
-                    label: LeaseBasisOfRentsFieldTitles.INDEX,
-                    options: indexOptions,
-                  }}
-                  enableUiDataEdit
-                  uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.INDEX)}
-                />
               </Authorization>
-            </Column>}
-            {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
-              <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) && isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX)}>
-                <FormTextTitle  enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.UNIT_PRICE)}>
+            </Column>
+            <Column small={6} medium={4} large={2}>{renderIndexFormField()}</Column>
+            <Column small={6} medium={4} large={2}>{renderUnitPriceFormField(true)}</Column>
+            <Column small={6} medium={4} large={2}>{renderProfitMarginPercentageFormField()}</Column>
+            <Column small={6} medium={4} large={2}>{renderBaseYearRentFormField()}</Column>
+            <Column small={6} medium={4} large={2}>{renderInitialYearRentFormField()}
+            </Column>
+          </Row>}
+
+          {calculatorType === CalculatorTypes.LEASE2022 && <Row>
+            <Column small={6} medium={4} large={2}>
+              <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)}>
+                <FormTextTitle
+                  required={isFieldRequired(leaseAttributes, LeaseBasisOfRentsFieldPaths.UNIT_PRICE)}
+                  enableUiDataEdit
+                  uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.UNIT_PRICE)}
+                >
                   {LeaseBasisOfRentsFieldTitles.UNIT_PRICE}
                 </FormTextTitle>
-                <FormField
-                  disableTouched={isSaveClicked}
-                  onChange={this.onChangeCurrentAmountPerArea}
-                  fieldAttributes={{
-                    decimal_places: 2,
-                    label: 'Yksikköhinta',
-                    max_digits: 10,
-                    read_only: false,
-                    required: false,
-                    type: 'decimal',
-                  }}
-                  disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
-                  name={`${field}.current_amount_per_area`}
-                  unit='€'
-                  invisibleLabel
-                  overrideValues={{label: LeaseBasisOfRentsFieldTitles.AMOUNT_PER_AREA}}
-                />
               </Authorization>
-            </Column>}
-            {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
-              <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE)}>
-                <FormField
-                  disableTouched={isSaveClicked}
-                  fieldAttributes={savedBasisOfRent && !!savedBasisOfRent.locked_at
-                    ? {...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE), required: false}
-                    :getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE)
-                  }
-                  disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
-                  name={`${field}.profit_margin_percentage`}
-                  unit='%'
-                  overrideValues={{label: LeaseBasisOfRentsFieldTitles.PROFIT_MARGIN_PERCENTAGE}}
-                  enableUiDataEdit
-                  tooltipStyle={{right: 17}}
-                  uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE)}
-                />
-              </Authorization>
-            </Column>}
-            {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
-              <Authorization allow={
-                isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
-                isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)
-              }>
-                <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.BASE_YEAR_RENT)}>
-                  {LeaseBasisOfRentsFieldTitles.BASE_YEAR_RENT}
-                </FormTextTitle>
-                <FormText>{!isEmptyValue(basicAnnualRent) ? `${formatNumber(basicAnnualRent)} €/v` : '-'}</FormText>
-              </Authorization>
-            </Column>}
-            {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
-              <Authorization allow={
-                isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
-                isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) &&
-                isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX) &&
-                isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE)
-              }>
-                <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.INITIAL_YEAR_RENT)}>
-                  {LeaseBasisOfRentsFieldTitles.INITIAL_YEAR_RENT}
-                </FormTextTitle>
-                <FormText>{!isEmptyValue(initialYearRent) ? `${formatNumber(initialYearRent)} €/v` : '-'}</FormText>
-              </Authorization>
-            </Column>}
-            {((subventionType === SubventionTypes.FORM_OF_MANAGEMENT || subventionType === SubventionTypes.RE_LEASE) && showSubventions && calculatorType === CalculatorTypes.LEASE) && <Fragment>
-              <Column small={6} medium={4} large={2}>
-                <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
-                  <FormField
-                    disableTouched={isSaveClicked}
-                    fieldAttributes={savedBasisOfRent && !!savedBasisOfRent.locked_at
-                      ? {...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE), required: false}
-                      : getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)
-                    }
-                    disabled={(savedBasisOfRent && !!savedBasisOfRent.locked_at) || showSubventions}
-                    name={`${field}.subvention_discount_percentage`}
-                    unit='%'
-                    overrideValues={{label: 'Subventioprosentti'}}
-                    enableUiDataEdit
-                    tooltipStyle={{right: 17}}
-                  />
-                </Authorization>
-              </Column>
-              <Column small={5} medium={4} large={3}>
-                <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
-                  <FormTextTitle>
-                    {LeaseBasisOfRentsFieldTitles.DISCOUNTED_INITIAL}
-                  </FormTextTitle>
-                  <FormText>{!isEmptyValue(subventionDiscountedInitial) ? `${formatNumber(subventionDiscountedInitial)} €/v` : '-'}</FormText>
-                </Authorization>
-              </Column>
-              <Column small={0} medium={3} large={6}></Column>
-            </Fragment>
-            }
+              <Row>
+                <Column small={6}>
+                  {renderUnitPriceFormField(false)}
+                </Column>
+                <Column small={6}>
+                  <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA_UNIT)}>
+                    <FormField
+                      className='with-slash'
+                      disableTouched={isSaveClicked}
+                      fieldAttributes={savedBasisOfRent && !!savedBasisOfRent.locked_at
+                        ? {...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA_UNIT), required: false}
+                        : getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA_UNIT)
+                      }
+                      name={`${field}.area_unit`}
+                      disabled
+                      invisibleLabel
+                      overrideValues={{
+                        label: LeaseBasisOfRentsFieldTitles.AREA_UNIT,
+                        options: areaUnitOptions,
+                      }}
+                    />
+                  </Authorization>
+                </Column>
+              </Row>
+            </Column>
+            <Column small={6} medium={4} large={2}>{renderProfitMarginPercentageFormField()}</Column>
+            <Column small={6} medium={4} large={2}>{renderInitialYearRentFormField()}</Column>
+            <Column small={6} medium={4} large={2}>{renderIndexFormField()}</Column>
+            <Column small={6} medium={4} large={2}>{renderBaseYearRentFormField()}</Column>
+          </Row>}
 
-            {showSubventions && calculatorType === CalculatorTypes.LEASE  && <Fragment>
-              <Column small={6} medium={4} large={2}>
-                <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
-                  <FormField
-                    disableTouched={isSaveClicked}
-                    fieldAttributes={savedBasisOfRent && !!savedBasisOfRent.locked_at
-                      ? {...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE), required: false}
-                      : getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)
-                    }
-                    disabled={(savedBasisOfRent && !!savedBasisOfRent.locked_at) || showSubventions}
-                    name={`${field}.temporary_subvention_discount_percentage`}
-                    unit='%'
-                    overrideValues={{label: 'Tilapäisalennuksen prosentti'}}
-                    enableUiDataEdit
-                    tooltipStyle={{right: 17}}
-                  />
-                </Authorization>
-              </Column>
-              <Column small={6} medium={8} large={10}></Column>
-            </Fragment>
-            }
-            {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
+          {((subventionType === SubventionTypes.FORM_OF_MANAGEMENT || subventionType === SubventionTypes.RE_LEASE) && showSubventions && (calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022)) && <Row>
+            <Column small={6} medium={4} large={2}>
               <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
                 <FormField
                   disableTouched={isSaveClicked}
@@ -1441,16 +1545,67 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                     : getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)
                   }
                   disabled={(savedBasisOfRent && !!savedBasisOfRent.locked_at) || showSubventions}
-                  name={`${field}.discount_percentage`}
+                  name={`${field}.subvention_discount_percentage`}
                   unit='%'
+                  overrideValues={{label: 'Subventioprosentti'}}
+                  enableUiDataEdit
+                  tooltipStyle={{right: 17}}
+                />
+              </Authorization>
+            </Column>
+            <Column small={5} medium={4} large={3}>
+              <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
+                <FormTextTitle>
+                  {LeaseBasisOfRentsFieldTitles.DISCOUNTED_INITIAL}
+                </FormTextTitle>
+                <FormText>{!isEmptyValue(subventionDiscountedInitial) ? `${formatNumber(subventionDiscountedInitial)} €/v` : '-'}</FormText>
+              </Authorization>
+            </Column>
+            <Column small={0} medium={3} large={6}></Column>
+          </Row>}
+
+          {showSubventions && (calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) && <Row>
+            <Column small={6} medium={4} large={2}>
+              <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
+                <FormField
+                  disableTouched={isSaveClicked}
+                  fieldAttributes={savedBasisOfRent && !!savedBasisOfRent.locked_at
+                    ? {...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE), required: false}
+                    : getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)
+                  }
+                  disabled={(savedBasisOfRent && !!savedBasisOfRent.locked_at) || showSubventions}
+                  name={`${field}.temporary_subvention_discount_percentage`}
+                  unit='%'
+                  overrideValues={{label: 'Tilapäisalennuksen prosentti'}}
+                  enableUiDataEdit
+                  tooltipStyle={{right: 17}}
+                />
+              </Authorization>
+            </Column>
+            <Column small={6} medium={8} large={10}></Column>
+          </Row>}
+
+          {(calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) && <Row>
+            <Column small={6} medium={4} large={2} hidden>
+              <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}>
+                <FormField
+                  disableTouched={isSaveClicked}
+                  fieldAttributes={{
+                    label: 'Lopullinen alennusprosentti',
+                    read_only: true,
+                    required: false,
+                    type: 'string',
+                  }}
+                  disabled={(savedBasisOfRent && !!savedBasisOfRent.locked_at) || showSubventions}
+                  name={`${field}.discount_percentage`}
                   overrideValues={{label: LeaseBasisOfRentsFieldTitles.DISCOUNT_PERCENTAGE}}
                   enableUiDataEdit
                   tooltipStyle={{right: 17}}
                   uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)}
                 />
               </Authorization>
-            </Column>}
-            {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={3}>
+            </Column>
+            <Column small={6} medium={4} large={3}>
               <Authorization allow={
                 isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
                 isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) &&
@@ -1463,8 +1618,8 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                 </FormTextTitle>
                 <FormText>{!isEmptyValue(discountedInitialYearRent) ? `${formatNumber(discountedInitialYearRent)} €/v` : '-'}</FormText>
               </Authorization>
-            </Column>}
-            {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
+            </Column>
+            <Column small={6} medium={4} large={2}>
               <Authorization allow={
                 isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
                 isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) &&
@@ -1477,8 +1632,8 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                 </FormTextTitle>
                 <FormText>{!isEmptyValue(rentPerMonth) ? `${formatNumber(rentPerMonth)} €` : '-'}</FormText>
               </Authorization>
-            </Column>}
-            {calculatorType === CalculatorTypes.LEASE && <Column small={6} medium={4} large={2}>
+            </Column>
+            <Column small={6} medium={4} large={2}>
               <Authorization allow={
                 isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
                 isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) &&
@@ -1491,40 +1646,39 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                 </FormTextTitle>
                 <FormText>{!isEmptyValue(rentPer2Months) ? `${formatNumber(rentPer2Months)} €` : '-'}</FormText>
               </Authorization>
-            </Column>}
-            {showTotal && calculatorType === CalculatorTypes.LEASE &&
-              <Fragment>
-                <Column small={6} medium={4} large={2}>
-                  <Authorization allow={
-                    isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
-                    isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) &&
-                    isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX) &&
-                    isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE) &&
-                    isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)
-                  }>
-                    <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.DISCOUNTED_INITIAL_YEAR_RENT_PER_MONTH_TOTAL)}>
-                      {LeaseBasisOfRentsFieldTitles.DISCOUNTED_INITIAL_YEAR_RENT_PER_MONTH_TOTAL}
-                    </FormTextTitle>
-                    <FormText>{!isEmptyValue(rentPerMonthTotal) ? `${formatNumber(rentPerMonthTotal)} €` : '-'}</FormText>
-                  </Authorization>
-                </Column>
-                <Column small={6} medium={4} large={2}>
-                  <Authorization allow={
-                    isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
-                    isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) &&
-                    isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX) &&
-                    isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE) &&
-                    isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)
-                  }>
-                    <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.DISCOUNTED_INITIAL_YEAR_RENT_PER_2_MONTHS_TOTAL)}>
-                      {LeaseBasisOfRentsFieldTitles.DISCOUNTED_INITIAL_YEAR_RENT_PER_2_MONTHS_TOTAL}
-                    </FormTextTitle>
-                    <FormText>{!isEmptyValue(rentPer2MonthsTotal) ? `${formatNumber(rentPer2MonthsTotal)} €` : '-'}</FormText>
-                  </Authorization>
-                </Column>
-              </Fragment>
-            }
-          </Row>
+            </Column>
+            {showTotal && <Fragment>
+              <Column small={6} medium={4} large={2}>
+                <Authorization allow={
+                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
+                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) &&
+                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX) &&
+                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE) &&
+                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)
+                }>
+                  <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.DISCOUNTED_INITIAL_YEAR_RENT_PER_MONTH_TOTAL)}>
+                    {LeaseBasisOfRentsFieldTitles.DISCOUNTED_INITIAL_YEAR_RENT_PER_MONTH_TOTAL}
+                  </FormTextTitle>
+                  <FormText>{!isEmptyValue(rentPerMonthTotal) ? `${formatNumber(rentPerMonthTotal)} €` : '-'}</FormText>
+                </Authorization>
+              </Column>
+              <Column small={6} medium={4} large={2}>
+                <Authorization allow={
+                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
+                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA) &&
+                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX) &&
+                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE) &&
+                  isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.DISCOUNT_PERCENTAGE)
+                }>
+                  <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.DISCOUNTED_INITIAL_YEAR_RENT_PER_2_MONTHS_TOTAL)}>
+                    {LeaseBasisOfRentsFieldTitles.DISCOUNTED_INITIAL_YEAR_RENT_PER_2_MONTHS_TOTAL}
+                  </FormTextTitle>
+                  <FormText>{!isEmptyValue(rentPer2MonthsTotal) ? `${formatNumber(rentPer2MonthsTotal)} €` : '-'}</FormText>
+                </Authorization>
+              </Column>
+            </Fragment>}
+          </Row>}
+
           {calculatorType === CalculatorTypes.MAST && <Row>
             <Authorization allow={
               isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
@@ -1541,6 +1695,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
               </Column>
             </Authorization>
           </Row>}
+
           {calculatorType === CalculatorTypes.MAST && <Row>
             <Authorization allow={
               isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) &&
@@ -1600,7 +1755,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
             </Authorization>
           </Row>}
 
-          {(!savedBasisOfRent || !savedBasisOfRent.locked_at) && !showSubventions && calculatorType === CalculatorTypes.LEASE  &&
+          {(!savedBasisOfRent || !savedBasisOfRent.locked_at) && !showSubventions && (calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) &&
             <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.SUBVENTION_TYPE)}>
               <Row>
                 <Column>
@@ -1612,7 +1767,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
               </Row>
             </Authorization>
           }
-          {showSubventions && calculatorType === CalculatorTypes.LEASE  &&
+          {showSubventions && (calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022)  &&
             <AppConsumer>
               {({dispatch}) => {
                 const handleRemoveSubventions = () => {
@@ -1653,7 +1808,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                         </Authorization>
                       </Column>
                     </Row>
-                    {subventionType === SubventionTypes.FORM_OF_MANAGEMENT && calculatorType === CalculatorTypes.LEASE &&
+                    {subventionType === SubventionTypes.FORM_OF_MANAGEMENT && (calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) &&
                       <Authorization allow={isFieldAllowedToRead(leaseAttributes, BasisOfRentManagementSubventionsFieldPaths.MANAGEMENT_SUBVENTIONS)}>
                         <SubTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(BasisOfRentManagementSubventionsFieldPaths.MANAGEMENT_SUBVENTIONS)}>{BasisOfRentManagementSubventionsFieldTitles.MANAGEMENT_SUBVENTIONS}</SubTitle>
                         <FieldArray
@@ -1668,7 +1823,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                         />
                       </Authorization>
                     }
-                    {subventionType === SubventionTypes.RE_LEASE && calculatorType === CalculatorTypes.LEASE &&
+                    {subventionType === SubventionTypes.RE_LEASE && (calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) &&
                       <Row>
                         <Column small={4} large={2}>
                           <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.SUBVENTION_BASE_PERCENT)}>
@@ -1800,5 +1955,6 @@ export default connect(
   },
   {
     change,
+    clearFields,
   },
 )(BasisOfRentEdit);

--- a/src/leases/components/leaseSections/rent/BasisOfRentEdit.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRentEdit.js
@@ -420,7 +420,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
   }
 
   state = {
-    showSubventions: this.props.subventionType ? true : false,
+    showSubventions: (this.props.subventionType || (this.props.temporarySubventions && !!this.props.temporarySubventions.length)) ? true : false,
   }
 
   initialFormValues = () => {
@@ -448,7 +448,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
       temporarySubventions,
     } = this.props;
 
-    if(showSubventions) {
+    if(showSubventions || (temporarySubventions && !!temporarySubventions.length)) {
       if(currentAmountPerArea !== prevProps.currentAmountPerArea && managementSubventions !== undefined) {
         this.changeDiscounts();
       }
@@ -474,13 +474,12 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
   changeDiscounts(){
     const {change, field, subventionType, managementSubventions} = this.props;
 
+    change(this.props.formName, `${field}.discount_percentage`, this.calculateTotalSubventionPercent());
     if(subventionType === SubventionTypes.RE_LEASE){
       const releaseDiscountPercent = this.calculateReLeaseDiscountPercent();
-      change(this.props.formName, `${field}.discount_percentage`, this.calculateTotalSubventionPercent());
       change(this.props.formName, `${field}.subvention_discount_percentage`, releaseDiscountPercent.toFixed(2));
     }
     if(subventionType === SubventionTypes.FORM_OF_MANAGEMENT){
-      change(this.props.formName, `${field}.discount_percentage`, this.calculateTotalSubventionPercent());
       if(managementSubventions && managementSubventions[0]){
         change(this.props.formName, `${field}.subvention_discount_percentage`, managementSubventions[0].subvention_percent);
       }
@@ -731,10 +730,13 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
   }
 
   handleRemoveSubventions = () => {
-    const {change, field, formName} = this.props;
+    const {change, field, formName, temporarySubventions} = this.props;
 
     change(formName, `${field}.subvention_type`, null);
-    this.setState({showSubventions: false});
+
+    if(!temporarySubventions?.length) {
+      this.setState({showSubventions: false});
+    }
   }
 
   calculateReLeaseDiscountPercent = () => {

--- a/src/leases/components/leaseSections/rent/BasisOfRentManagementSubventionEdit.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRentManagementSubventionEdit.js
@@ -40,27 +40,27 @@ class BasisOfRentManagementSubventionEdit extends PureComponent<Props, State> {
 
   componentDidMount() {
     const {change, currentAmountPerArea, formName, field, subventionAmount} = this.props;
-    const subventionPercent = calculateBasisOfRentSubventionPercantage(subventionAmount, currentAmountPerArea).toFixed(2);
+    const subventionPercent = calculateBasisOfRentSubventionPercantage(subventionAmount, currentAmountPerArea);
     change(formName, `${field}.subvention_percent`, subventionPercent);
   }
 
   componentDidUpdate(prevProps: Props) {
     const {change, currentAmountPerArea, formName, field, subventionAmount} = this.props;
     if(currentAmountPerArea !== prevProps.currentAmountPerArea) {
-      const subventionPercent = calculateBasisOfRentSubventionPercantage(subventionAmount, currentAmountPerArea).toFixed(2);
+      const subventionPercent = calculateBasisOfRentSubventionPercantage(subventionAmount, currentAmountPerArea);
       change(formName, `${field}.subvention_percent`, subventionPercent);
     }
   }
 
   onChangeCurrentSubventionAmount = (value: any) => {
     const {change, currentAmountPerArea, formName, field} = this.props;
-    const subventionAmount = calculateSubventionAmountFromPercantage(value, currentAmountPerArea).toFixed(2);
+    const subventionAmount = calculateSubventionAmountFromPercantage(value, currentAmountPerArea);
     change(formName, `${field}.subvention_amount`, subventionAmount);
   };
 
   onChangeCurrentSubventionPercent = (value: any) => {
     const {change, currentAmountPerArea, formName, field} = this.props;
-    const subventionPercent = calculateBasisOfRentSubventionPercantage(value, currentAmountPerArea).toFixed(2);
+    const subventionPercent = calculateBasisOfRentSubventionPercantage(value, currentAmountPerArea);
     change(formName, `${field}.subvention_percent`, subventionPercent);
   };
 

--- a/src/leases/components/leaseSections/rent/BasisOfRentManagementSubventionEdit.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRentManagementSubventionEdit.js
@@ -136,7 +136,7 @@ class BasisOfRentManagementSubventionEdit extends PureComponent<Props, State> {
           <FieldAndRemoveButtonWrapper
             field={
               <Authorization allow={isFieldAllowedToRead(leaseAttributes, BasisOfRentManagementSubventionsFieldPaths.SUBVENTION_AMOUNT)}>
-                <FormText className='full-width'>{formatNumber(subventionTotal)} €</FormText>
+                <FormText className='full-width'>{formatNumber(subventionTotal, 3)} €</FormText>
               </Authorization>
             }
             removeButton={

--- a/src/leases/components/leaseSections/rent/BasisOfRentManagementSubventionEdit.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRentManagementSubventionEdit.js
@@ -44,6 +44,14 @@ class BasisOfRentManagementSubventionEdit extends PureComponent<Props, State> {
     change(formName, `${field}.subvention_percent`, subventionPercent);
   }
 
+  componentDidUpdate(prevProps: Props) {
+    const {change, currentAmountPerArea, formName, field, subventionAmount} = this.props;
+    if(currentAmountPerArea !== prevProps.currentAmountPerArea) {
+      const subventionPercent = calculateBasisOfRentSubventionPercantage(subventionAmount, currentAmountPerArea).toFixed(2);
+      change(formName, `${field}.subvention_percent`, subventionPercent);
+    }
+  }
+
   onChangeCurrentSubventionAmount = (value: any) => {
     const {change, currentAmountPerArea, formName, field} = this.props;
     const subventionAmount = calculateSubventionAmountFromPercantage(value, currentAmountPerArea).toFixed(2);

--- a/src/leases/components/leaseSections/rent/BasisOfRentManagementSubventionEdit.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRentManagementSubventionEdit.js
@@ -11,7 +11,7 @@ import FormText from '$components/form/FormText';
 import RemoveButton from '$components/form/RemoveButton';
 import {BasisOfRentManagementSubventionsFieldPaths, BasisOfRentManagementSubventionsFieldTitles} from '$src/leases/enums';
 import {UsersPermissions} from '$src/usersPermissions/enums';
-import {calculateBasisOfRentSubventionAmount, calculateBasisOfRentSubventionPercantage, calculateSubventionAmountFromPercantage} from '$src/leases/helpers';
+import {calculateBasisOfRentSubventionAmount, calculateBasisOfRentSubventionPercentage, calculateSubventionAmountFromPercantage} from '$src/leases/helpers';
 import {formatNumber, hasPermissions, isFieldAllowedToRead, getFieldAttributes} from '$util/helpers';
 import {getAttributes as getLeaseAttributes, getIsSaveClicked} from '$src/leases/selectors';
 import {getUsersPermissions} from '$src/usersPermissions/selectors';
@@ -40,14 +40,14 @@ class BasisOfRentManagementSubventionEdit extends PureComponent<Props, State> {
 
   componentDidMount() {
     const {change, currentAmountPerArea, formName, field, subventionAmount} = this.props;
-    const subventionPercent = calculateBasisOfRentSubventionPercantage(subventionAmount, currentAmountPerArea);
+    const subventionPercent = calculateBasisOfRentSubventionPercentage(subventionAmount, currentAmountPerArea);
     change(formName, `${field}.subvention_percent`, subventionPercent);
   }
 
   componentDidUpdate(prevProps: Props) {
     const {change, currentAmountPerArea, formName, field, subventionAmount} = this.props;
     if(currentAmountPerArea !== prevProps.currentAmountPerArea) {
-      const subventionPercent = calculateBasisOfRentSubventionPercantage(subventionAmount, currentAmountPerArea);
+      const subventionPercent = calculateBasisOfRentSubventionPercentage(subventionAmount, currentAmountPerArea);
       change(formName, `${field}.subvention_percent`, subventionPercent);
     }
   }
@@ -60,7 +60,7 @@ class BasisOfRentManagementSubventionEdit extends PureComponent<Props, State> {
 
   onChangeCurrentSubventionPercent = (value: any) => {
     const {change, currentAmountPerArea, formName, field} = this.props;
-    const subventionPercent = calculateBasisOfRentSubventionPercantage(value, currentAmountPerArea);
+    const subventionPercent = calculateBasisOfRentSubventionPercentage(value, currentAmountPerArea);
     change(formName, `${field}.subvention_percent`, subventionPercent);
   };
 
@@ -78,7 +78,7 @@ class BasisOfRentManagementSubventionEdit extends PureComponent<Props, State> {
     } = this.props;
 
     /* Use current amount per area to calculate percantage */
-    const subventionPercent = calculateBasisOfRentSubventionPercantage(subventionAmount, currentAmountPerArea);
+    const subventionPercent = calculateBasisOfRentSubventionPercentage(subventionAmount, currentAmountPerArea);
 
     /* Use initial year rent to calculate subvention total */
     const subventionTotal = calculateBasisOfRentSubventionAmount(initialYearRent, subventionPercent);

--- a/src/leases/components/leaseSections/rent/BasisOfRentTemporarySubventionEdit.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRentTemporarySubventionEdit.js
@@ -83,7 +83,7 @@ const BasisOfRentTemporarySubventionEdit = ({
         <FieldAndRemoveButtonWrapper
           field={
             <Authorization allow={isFieldAllowedToRead(leaseAttributes, BasisOfRentTemporarySubventionsFieldPaths.SUBVENTION_PERCENT)}>
-              <FormText className='full-width'>{formatNumber(subventionAmount)} €</FormText>
+              <FormText className='full-width'>{formatNumber(subventionAmount, 3)} €</FormText>
             </Authorization>
           }
           removeButton={

--- a/src/leases/components/leaseSections/rent/BasisOfRentsEdit.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRentsEdit.js
@@ -90,12 +90,8 @@ class BasisOfRentsEdit extends PureComponent<Props, State> {
   }
 
   handleAdd = () => {
-    const {basisOfRents, fields} = this.props;
-    const lastBasisOfRent = basisOfRents.slice(-1).pop();
-
-    fields.push({
-      profit_margin_percentage: lastBasisOfRent ? lastBasisOfRent.profit_margin_percentage : null,
-    });
+    const {fields} = this.props;
+    fields.push({});
   }
 
   removeBasisOfRent = (index: number) => {

--- a/src/leases/components/leaseSections/rent/BasisOfRentsEdit.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRentsEdit.js
@@ -120,8 +120,8 @@ class BasisOfRentsEdit extends PureComponent<Props, State> {
       usersPermissions,
     } = this.props;
     const {
-      areaUnitOptions, 
-      indexOptions, 
+      areaUnitOptions,
+      indexOptions,
       intendedUseOptions,
       managementTypeOptions,
       subventionTypeOptions,
@@ -139,7 +139,7 @@ class BasisOfRentsEdit extends PureComponent<Props, State> {
             <Column>
               <AddButtonSecondary
                 className={classNames(
-                  addButtonClass, 
+                  addButtonClass,
                   {'no-top-margin': (!fields || !fields.length)})
                 }
                 label='Lisää vuokralaskuri'
@@ -286,7 +286,7 @@ class BasisOfRentsEdit extends PureComponent<Props, State> {
                   </Row>
                 </Authorization>
 
-                {basisOfRents.length > 1 && <CalculateRentTotal 
+                {basisOfRents.length > 1 && <CalculateRentTotal
                   basisOfRents={basisOfRents}
                   indexOptions={indexOptions}
                 />}

--- a/src/leases/enums.js
+++ b/src/leases/enums.js
@@ -17,6 +17,7 @@ export const AreaLocation = {
  * @type {{}}
  */
 export const CalculatorTypes = {
+  LEASE2022: 'lease2022',
   LEASE: 'lease',
   TEMPORARY: 'temporary',
   ADDITIONAL_YARD: 'additional_yard',
@@ -1551,7 +1552,8 @@ export const LeaseInvoiceNotesFieldTitles = {
  * @type {{}}
  */
 export const calculatorTypeOptions = [
-  {value: 'lease', label: 'Vuokra'},
+  {value: 'lease2022', label: 'Vuokra'},
+  {value: 'lease', label: 'Vuokra (Vanha)'},
   {value: 'temporary', label: 'Tilapäiset'},
   {value: 'additional_yard', label: 'Lisäpihat'},
   {value: 'field', label: 'Pelto'},

--- a/src/leases/helpers.js
+++ b/src/leases/helpers.js
@@ -165,7 +165,7 @@ export const getContentLeaseIdentifier = (lease: Object): ?string =>
  * @param {Object} lease
  * @returns {Object[]}
  */
-export const getContentLeaseListTenants = (lease: Object, query: Object = {}): Array<Object> => 
+export const getContentLeaseListTenants = (lease: Object, query: Object = {}): Array<Object> =>
   get(lease, 'tenants', [])
     .map((item) => get(item, 'tenantcontact_set', []).find((x) => x.type === TenantContactType.TENANT))
     .filter((tenant) => query.only_past_tenants === 'true' ? isArchived(tenant) : !isArchived(tenant))
@@ -178,7 +178,7 @@ export const getContentLeaseListTenants = (lease: Object, query: Object = {}): A
  * @param {Object} lease
  * @returns {Object[]}
  */
-export const getContentLeaseListAreaIdentifiers = (lease: Object): Array<Object> => 
+export const getContentLeaseListAreaIdentifiers = (lease: Object): Array<Object> =>
   get(lease, 'lease_areas', [])
     .filter((area) => !area.archived_at)
     .map((area) => area.identifier)
@@ -204,7 +204,7 @@ export const getContentLeaseListLeaseAddresses = (lease: Object): Array<Object> 
   const sortedAddresses = addresses
     .filter((address, index, self) =>  self.indexOf(address) == index)
     .sort(sortStringAsc);
-  
+
   return sortedAddresses;
 };
 
@@ -463,7 +463,7 @@ export const getContentLeaseAreaAddresses = (area: Object): Array<Object> => {
  * @param {Object} area
  * @returns {Object[]}
  */
-export const getContentPlots = (area: Object): Array<Object> => 
+export const getContentPlots = (area: Object): Array<Object> =>
   get(area, 'plots', []).map((plot) => {
     return {
       id: plot.id,
@@ -483,7 +483,7 @@ export const getContentPlots = (area: Object): Array<Object> =>
  * @param {Object} area
  * @returns {Object[]}
  */
-export const getContentPlanUnits = (area: Object): Array<Object> => 
+export const getContentPlanUnits = (area: Object): Array<Object> =>
   get(area, 'plan_units', []).map((planunit) => {
     return {
       id: planunit.id,
@@ -513,7 +513,7 @@ export const getContentPlanUnits = (area: Object): Array<Object> =>
  */
 export const getContentCustomDetailedPlan = (area: Object): Object => {
   let customDetailedPlan = get(area, 'custom_detailed_plan');
-  
+
   if (!customDetailedPlan) {
     return null;
   }
@@ -573,8 +573,8 @@ export const getContentLeaseAreas = (lease: Object): Array<Object> =>
  * @returns {Object}
  */
 export const getLeaseAreaById = (lease: Lease, id: ?number): ?Object =>
-  id 
-    ? getContentLeaseAreas(lease).find((area) => area.id === id) 
+  id
+    ? getContentLeaseAreas(lease).find((area) => area.id === id)
     : null;
 
 /**
@@ -868,7 +868,7 @@ export const getContentInvoiceNote = (invoiceNote: Object): Object => ({
  * @param {Object} lease
  * @returns {Object[]}
  */
-export const getContentInvoiceNotes = (lease: Lease): Array<Object> => 
+export const getContentInvoiceNotes = (lease: Lease): Array<Object> =>
   get(lease, 'invoice_notes', []).map((note) => getContentInvoiceNote(note));
 
 /**
@@ -1004,7 +1004,7 @@ export const getTenantRentShareWarnings = (tenants: Array<Object>, leaseAttribut
     const tenants = dateRange.items;
     const rentShares = [];
     const sharesByIntendedUse = {};
-    
+
     tenants.forEach((tenant) => {
       if(tenant.rent_shares && tenant.rent_shares.length) {
         rentShares.push(...tenant.rent_shares);
@@ -1111,7 +1111,7 @@ export const getBasisOfRentIndexValue = (basisOfRent: Object, indexOptions: Arra
  */
 export const calculateBasisOfRentBasicAnnualRent = (basisOfRent: Object): number => {
   if(!isDecimalNumberStr(basisOfRent.amount_per_area) || !isDecimalNumberStr(basisOfRent.area)) return 0;
-  
+
   return Number(convertStrToDecimalNumber(basisOfRent.amount_per_area))
     * Number(convertStrToDecimalNumber(basisOfRent.area))
     * Number(isDecimalNumberStr(basisOfRent.profit_margin_percentage) ? Number(convertStrToDecimalNumber(basisOfRent.profit_margin_percentage))/100 : 0);
@@ -1162,7 +1162,7 @@ export const calculateBasisOfRentInitialYearRent = (basisOfRent: Object, indexVa
  */
 export const calculateBasisOfRentDiscountedInitialYearRentsTotal = (basisOfRents: Object[], indexOptions: Object[]): number => {
   if(basisOfRents)
-    return Number(basisOfRents.map(basisOfRent => 
+    return Number(basisOfRents.map(basisOfRent =>
       calculateBasisOfRentDiscountedInitialYearRent(basisOfRent, getBasisOfRentIndexValue(basisOfRent, indexOptions))).reduce((sum, cur) => sum + cur));
   else
     return 0;
@@ -1175,7 +1175,7 @@ export const calculateBasisOfRentDiscountedInitialYearRentsTotal = (basisOfRents
  */
 export const calculateInitialYearRentsTotal = (basisOfRents: Object[], indexOptions: Object[]): number => {
   if(basisOfRents)
-    return Number(basisOfRents.map(basisOfRent => 
+    return Number(basisOfRents.map(basisOfRent =>
       calculateBasisOfRentInitialYearRent(basisOfRent, getBasisOfRentIndexValue(basisOfRent, indexOptions))).reduce((sum, cur) => sum + cur));
   else
     return 0;
@@ -1206,7 +1206,7 @@ export const calculateBasisOfRentDiscountedInitialYearRent = (basisOfRent: Objec
 export const calculateBasisOfRentTotalDiscountedInitialYearRent = (basisOfRents: Array<Object>, indexOptions: Array<Object>): ?number => {
   return basisOfRents.reduce((total, basisOfRent) => {
     const indexValue = getBasisOfRentIndexValue(basisOfRent, indexOptions);
-    
+
     return  calculateBasisOfRentDiscountedInitialYearRent(basisOfRent, indexValue) + total;
   }, 0);
 };
@@ -1224,7 +1224,7 @@ export const calculateBasisOfRentSubventionAmount = (initialYearRent: number, su
     * initialYearRent;
 };
 
-/** 
+/**
  * Calculate basis of rent temporary rent cumulative
  * @param {number} initialYearRent
  * @param {any} subventionPercent
@@ -1362,7 +1362,7 @@ export const calculateBasisOfRentSubventionPercent = (
   if(subventionType === SubventionTypes.RE_LEASE) {
     discount = discount * ((100 - calculateReLeaseDiscountPercent(subventionBasePercent, subventionGraduatedPercent)) / 100);
   }
-  
+
   if(subventionType === SubventionTypes.FORM_OF_MANAGEMENT) {
     if(managementSubventions) {
       managementSubventions.forEach((subvention) => {
@@ -1370,13 +1370,13 @@ export const calculateBasisOfRentSubventionPercent = (
       });
     }
   }
-  
+
   if(temporarySubventions) {
     temporarySubventions.forEach((subvention) => {
       discount = discount * (Number((100 - Number(convertStrToDecimalNumber(subvention.subvention_percent))) / 100) || 1);
     });
   }
-  
+
   return (1 - discount) * 100;
 };
 
@@ -1402,7 +1402,7 @@ export const calculateRentAdjustmentSubventionPercentCumulative = (
   if(subventionType === SubventionTypes.RE_LEASE) {
     discount = discount * ((100 - calculateReLeaseDiscountPercent(subventionBasePercent, subventionGraduatedPercent)) / 100);
   }
-  
+
   if(subventionType === SubventionTypes.FORM_OF_MANAGEMENT) {
     if(managementSubventions) {
       managementSubventions.forEach((subvention) => {
@@ -1410,13 +1410,13 @@ export const calculateRentAdjustmentSubventionPercentCumulative = (
       });
     }
   }
-  
+
   if(temporarySubventions) {
     temporarySubventions.forEach((subvention) => {
       discount = discount * (Number((100 - Number(convertStrToDecimalNumber(subvention.subvention_percent))) / 100) || 1);
     });
   }
-  
+
   return (1 - discount) * 100;
 };
 
@@ -1724,7 +1724,7 @@ export const getRentWarnings = (rents: Array<Object>): Array<string> => {
       if(rent.intended_use) {
         const filteredFixedInitialYearRents = fixedInitialYearRents.filter((item) => item.intended_use === rent.intended_use);
         const filteredContractRents = contractRents.filter((item) => item.intended_use === rent.intended_use);
-        
+
         if(filteredFixedInitialYearRents.length !== filteredContractRents.length) {
           showWarning = true;
           return false;
@@ -2737,7 +2737,7 @@ export const addRentsFormValuesToPayload = (payload: Object, formValues: Object,
   payload.is_rent_info_complete = formValues.is_rent_info_complete ? true : false;
 
   const basisOfRents = [
-    ...get(formValues, 'basis_of_rents', []), 
+    ...get(formValues, 'basis_of_rents', []),
     ...get(formValues, 'basis_of_rents_archived', []),
   ];
 
@@ -2752,7 +2752,7 @@ export const addRentsFormValuesToPayload = (payload: Object, formValues: Object,
     } else {
       return {
         id: item.id,
-        intended_use: intendedUse(item), 
+        intended_use: intendedUse(item),
         area: convertStrToDecimalNumber(item.area),
         area_unit: areaUnit(item),
         type: item.type,
@@ -2775,7 +2775,7 @@ export const addRentsFormValuesToPayload = (payload: Object, formValues: Object,
   });
 
   const rents = [
-    ...get(formValues, 'rents', []), 
+    ...get(formValues, 'rents', []),
     ...get(formValues, 'rentsArchived', []),
   ];
 
@@ -2883,7 +2883,7 @@ export const getZonePriceFromValue = (zone: ?string): number => {
 };
 
 /**
- * Map lease page search filters for API 
+ * Map lease page search filters for API
  * @param {Object} query
  * @returns {Object}
  */

--- a/src/leases/helpers.js
+++ b/src/leases/helpers.js
@@ -1292,7 +1292,7 @@ export const calculateBasisOfRentSubventionAmountCumulative = (initialYearRent: 
     if(view === 'EDIT') {
       discounted = discounted * ((100 - Number(convertStrToDecimalNumber(managementSubvention.subvention_percent))) / 100);
     }else{
-      const subventionPercentage = calculateBasisOfRentSubventionPercantage(managementSubvention.subvention_amount, currentAmountPerArea);
+      const subventionPercentage = calculateBasisOfRentSubventionPercentage(managementSubvention.subvention_amount, currentAmountPerArea);
       discounted = discounted * ((100 - Number(convertStrToDecimalNumber(subventionPercentage))) / 100);
     }
   });
@@ -1330,7 +1330,7 @@ export const calculateTemporarySubventionDiscountPercentage = (temporarySubventi
  * @param {number} currentAmountPerArea
  * @return {number}
  */
-export const calculateBasisOfRentSubventionPercantage = (subventionAmount: string | number, currentAmountPerArea: number | number): number => {
+export const calculateBasisOfRentSubventionPercentage = (subventionAmount: string | number, currentAmountPerArea: number | number): number => {
   if(!isDecimalNumberStr(subventionAmount)) return 0;
   if(!currentAmountPerArea) return 0;
 
@@ -1425,7 +1425,7 @@ export const calculateBasisOfRentSubventionPercent = (
   if(subventionType === SubventionTypes.FORM_OF_MANAGEMENT) {
     if(managementSubventions) {
       managementSubventions.forEach((subvention) => {
-        const calculatedSubventionPercentage = Number(convertStrToDecimalNumber(calculateBasisOfRentSubventionPercantage(subvention.subvention_amount, currentAmountPerArea)));
+        const calculatedSubventionPercentage = Number(convertStrToDecimalNumber(calculateBasisOfRentSubventionPercentage(subvention.subvention_amount, currentAmountPerArea)));
         const subventionMultiplier = (100 - calculatedSubventionPercentage) / 100 || 1;
         const subventionMultiplierRounded = Number(convertStrToDecimalNumber(subventionMultiplier.toFixed(4)));
         discount = Number(convertStrToDecimalNumber(discount.toFixed(4))) * subventionMultiplierRounded;
@@ -1496,7 +1496,7 @@ export const calculateRentAdjustmentSubventionPercentCumulative = (
 export const calculateSubventionDiscountTotal = (initialYearRent: number, managementSubventions: ?Array<Object>, currentAmountPerArea: number): number => {
   if(managementSubventions && managementSubventions[0] && managementSubventions[0].subvention_amount !== null){
     const roundedInitialYear = initialYearRent.toFixed(2);
-    const roundedDiscountPercentage = Number(convertStrToDecimalNumber(calculateBasisOfRentSubventionPercantage(managementSubventions[0].subvention_amount, currentAmountPerArea))).toFixed(2);
+    const roundedDiscountPercentage = Number(convertStrToDecimalNumber(calculateBasisOfRentSubventionPercentage(managementSubventions[0].subvention_amount, currentAmountPerArea))).toFixed(2);
     const discountMultiplier = Number(((100 - roundedDiscountPercentage) / 100) || 1);
 
     return Number(roundedInitialYear * discountMultiplier);

--- a/src/leases/helpers.js
+++ b/src/leases/helpers.js
@@ -1328,7 +1328,9 @@ export const calculateBasisOfRentSubventionPercantage = (subventionAmount: strin
   if(!isDecimalNumberStr(subventionAmount)) return 0;
   if(!currentAmountPerArea) return 0;
 
-  return  (1 - (Number(convertStrToDecimalNumber(subventionAmount)) / currentAmountPerArea)) * 100;
+  const subventionPercentage = (1 - (Number(convertStrToDecimalNumber(subventionAmount)) / currentAmountPerArea)) * 100;
+
+  return Number(subventionPercentage.toFixed(2));
 };
 
 /**
@@ -1340,7 +1342,8 @@ export const calculateBasisOfRentSubventionPercantage = (subventionAmount: strin
 export const calculateSubventionAmountFromPercantage = (subventionPercantage: string | number, currentAmountPerArea: number | number): number => {
   if(!isDecimalNumberStr(subventionPercantage)) return 0;
   if(!currentAmountPerArea) return 0;
-  return  (1 - (Number(convertStrToDecimalNumber(subventionPercantage)) / 100)) * currentAmountPerArea;
+  const subventionAmount = (1 - (Number(convertStrToDecimalNumber(subventionPercantage)) / 100)) * currentAmountPerArea;
+  return Number(subventionAmount.toFixed(2));
 };
 
 /**

--- a/src/leases/helpers.js
+++ b/src/leases/helpers.js
@@ -1107,14 +1107,39 @@ export const getBasisOfRentIndexValue = (basisOfRent: Object, indexOptions: Arra
 /**
  * Calculate basis of rent basis annual rent
  * @param {Object} basisOfRent
+ * @param {string} indexValue
  * @return {number}
  */
-export const calculateBasisOfRentBasicAnnualRent = (basisOfRent: Object): number => {
-  if(!isDecimalNumberStr(basisOfRent.amount_per_area) || !isDecimalNumberStr(basisOfRent.area)) return 0;
+export const calculateBasisOfRentBasicAnnualRent = (basisOfRent: Object, indexValue: ?string): number => {
+  if(basisOfRent.type === CalculatorTypes.LEASE2022) {
+    const initialYearRent = calculateBasisOfRentInitialYearRent(basisOfRent, indexValue);
+    if(!initialYearRent || !isDecimalNumberStr(indexValue)) {
+      return 0;
+    }
+    return Number(initialYearRent / (convertStrToDecimalNumber(indexValue) / 100));
+  }
+
+  if(!isDecimalNumberStr(basisOfRent.amount_per_area) || !isDecimalNumberStr(basisOfRent.area)) {
+    return 0;
+  }
 
   return Number(convertStrToDecimalNumber(basisOfRent.amount_per_area))
     * Number(convertStrToDecimalNumber(basisOfRent.area))
     * Number(isDecimalNumberStr(basisOfRent.profit_margin_percentage) ? Number(convertStrToDecimalNumber(basisOfRent.profit_margin_percentage))/100 : 0);
+};
+
+/**
+ * Get current basis of rent amount per area based on calculator type
+ * @param {Object} basisOfRent
+ * @param {string} indexValue
+ * @return {number}
+ */
+export const getBasisOfRentAmountPerArea = (basisOfRent: Object, indexValue: ?string): number => {
+  if(basisOfRent.type === CalculatorTypes.LEASE2022) {
+    return Number(convertStrToDecimalNumber(basisOfRent.amount_per_area));
+  }
+
+  return calculateBasisOfRentAmountPerArea(basisOfRent, indexValue);
 };
 
 /**
@@ -1151,6 +1176,18 @@ export const calculateAmountFromValue = (value: string, indexValue: ?string): nu
  * @return {number}
  */
 export const calculateBasisOfRentInitialYearRent = (basisOfRent: Object, indexValue: ?string, basicAnnualRent: ?number): number => {
+  if(basisOfRent.type === CalculatorTypes.LEASE2022) {
+    const area = convertStrToDecimalNumber(basisOfRent.area);
+    const amountPerArea = convertStrToDecimalNumber(basisOfRent.amount_per_area);
+    const profitMarginPercentage = convertStrToDecimalNumber(basisOfRent.profit_margin_percentage);
+
+    if(!isDecimalNumberStr(area) || !isDecimalNumberStr(amountPerArea) || !isDecimalNumberStr(profitMarginPercentage)) {
+      return 0;
+    }
+
+    return Number(area * amountPerArea * Number(profitMarginPercentage / 100));
+  }
+
   return Number(roundToFixed(Number(basicAnnualRent), 2)) * Number(convertStrToDecimalNumber(indexValue)) / 100;
 };
 
@@ -1174,11 +1211,16 @@ export const calculateBasisOfRentDiscountedInitialYearRentsTotal = (basisOfRents
  * @return {number}
  */
 export const calculateInitialYearRentsTotal = (basisOfRents: Object[], indexOptions: Object[]): number => {
-  if(basisOfRents)
-    return Number(basisOfRents.map(basisOfRent =>
-      calculateBasisOfRentInitialYearRent(basisOfRent, getBasisOfRentIndexValue(basisOfRent, indexOptions))).reduce((sum, cur) => sum + cur));
-  else
+  if(basisOfRents) {
+    const initialYearRents = basisOfRents.map(basisOfRent => {
+      const basicAnnualRent = calculateBasisOfRentBasicAnnualRent(basisOfRent);
+      const indexValue = getBasisOfRentIndexValue(basisOfRent, indexOptions);
+      return calculateBasisOfRentInitialYearRent(basisOfRent, indexValue, basicAnnualRent);
+    });
+    return Number(initialYearRents.reduce((sum, cur) => sum + cur));
+  } else {
     return 0;
+  }
 };
 
 /**
@@ -1193,8 +1235,11 @@ export const calculateBasisOfRentDiscountedInitialYearRent = (basisOfRent: Objec
 
   if(!isDecimalNumberStr(initialYearRent)) return 0;
 
-  return Number(convertStrToDecimalNumber(initialYearRent))
-    * Number(isDecimalNumberStr(basisOfRent.discount_percentage) ? (100 - Number(convertStrToDecimalNumber(basisOfRent.discount_percentage)))/100 : 1);
+  const decimalNumberInitialYearRent = Number(convertStrToDecimalNumber(initialYearRent));
+  const decimalNumberDiscountPercentage = Number(convertStrToDecimalNumber(basisOfRent.discount_percentage));
+  const discountMultiplier = Number(isDecimalNumberStr(basisOfRent.discount_percentage) ? (100 - decimalNumberDiscountPercentage) / 100 : 1);
+
+  return decimalNumberInitialYearRent * discountMultiplier;
 };
 
 /**
@@ -1429,8 +1474,13 @@ export const calculateRentAdjustmentSubventionPercentCumulative = (
  */
 export const calculateSubventionDiscountTotal = (initialYearRent: number, managementSubventions: ?Array<Object>, currentAmountPerArea: number): number => {
   if(managementSubventions && managementSubventions[0] && managementSubventions[0].subvention_amount !== null){
-    return Number(initialYearRent * (1 - ((currentAmountPerArea - Number(convertStrToDecimalNumber(managementSubventions[0].subvention_amount))) / currentAmountPerArea)));
+    const roundedInitialYear = initialYearRent.toFixed(2);
+    const roundedDiscountPercentage = Number(convertStrToDecimalNumber(calculateBasisOfRentSubventionPercantage(managementSubventions[0].subvention_amount, currentAmountPerArea))).toFixed(2);
+    const discountMultiplier = Number(((100 - roundedDiscountPercentage) / 100) || 1);
+
+    return Number(roundedInitialYear * discountMultiplier);
   }
+
   return Number(initialYearRent);
 };
 

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -239,16 +239,16 @@ export const formatNumberWithThousandSeparator = (x: any, separator?: string = '
 
   return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, separator);
 };
-  
+
 
 /**
  * Format decimal number
  * @param {number} x
  * @returns {string}
  */
-export const formatDecimalNumber = (x: ?number): ?string => 
-  !isEmptyValue(x) 
-    ? parseFloat(x).toFixed(2).toString().replace('.', ',') 
+export const formatDecimalNumber = (x: ?number, decimals: ?number = 2): ?string =>
+  !isEmptyValue(x)
+    ? parseFloat(x).toFixed(decimals).toString().replace('.', ',')
     : null;
 
 /**
@@ -256,9 +256,9 @@ export const formatDecimalNumber = (x: ?number): ?string =>
  * @param {*} x
  * @returns {string}
  */
-export const formatNumber = (x: any): string => 
-  !isEmptyValue(x) 
-    ? formatNumberWithThousandSeparator(formatDecimalNumber(x)) 
+export const formatNumber = (x: any, decimals: ?number = 2): string =>
+  !isEmptyValue(x)
+    ? formatNumberWithThousandSeparator(formatDecimalNumber(x, decimals))
     : '';
 
 /**

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -24,8 +24,8 @@ import type {UsersPermissions} from '$src/usersPermissions/types';
  * @returns {string}
  */
 export const composePageTitle = (title: string = '', prepend?: boolean = true): string => {
-  return prepend 
-    ? `${title ? `${title} | ` : ''}Maanvuokrausjärjestelmä | Helsingin Kaupunki` 
+  return prepend
+    ? `${title ? `${title} | ` : ''}Maanvuokrausjärjestelmä | Helsingin Kaupunki`
     : title;
 };
 
@@ -231,7 +231,7 @@ export const formatNumberWithThousandSeparator = (x: any, separator?: string = '
   if(isDecimalNumber) {
     const decimalSeparator = x.toString().includes('.') ? '.' : ',';
     const parts = x.toString().split(decimalSeparator);
-    
+
     return parts[0].toString().replace(/\B(?=(\d{3})+(?!\d))/g, separator) +
       decimalSeparator +
       parts[1];
@@ -266,7 +266,7 @@ export const formatNumber = (x: any): string =>
  * @param {*} value
  * @returns {boolean}
  */
-export const isDecimalNumberStr = (value: any): boolean => 
+export const isDecimalNumberStr = (value: any): boolean =>
   (!isEmptyValue(value) && !isNaN(value.toString().replace(',', '.').replace(/\s+/g, '')));
 
 /**
@@ -274,8 +274,8 @@ export const isDecimalNumberStr = (value: any): boolean =>
  * @param {*} x
  * @returns {number}
  */
-export const convertStrToDecimalNumber = (x: any): ?number => 
-  isDecimalNumberStr(x) 
+export const convertStrToDecimalNumber = (x: any): ?number =>
+  isDecimalNumberStr(x)
     ? Number(x.toString().replace(',', '.').replace(/\s+/g, ''))
     : null;
 
@@ -335,7 +335,7 @@ export const getReferenceNumberLink = (referenceNumber: ?string): ?string => {
  * @param {number} id
  * @returns {Object}
  */
-export const findItemById = (collection: Array<Object>, id: number): ?Object => 
+export const findItemById = (collection: Array<Object>, id: number): ?Object =>
   collection.find((item) => item.id == id);
 
 /**
@@ -344,7 +344,7 @@ export const findItemById = (collection: Array<Object>, id: number): ?Object =>
  * @param {*} value
  * @returns {string}
  */
-export const getLabelOfOption = (options: Array<Object>, value: any): ?string => 
+export const getLabelOfOption = (options: Array<Object>, value: any): ?string =>
   (options && value != null)
     ? get(options.find(x => x.value == value), 'label', null)
     : null;
@@ -479,7 +479,7 @@ const getFilenameFromContentDisposition = (contentDisposition: any): ?string => 
  * @returns {string | null}
  */
 /* istanbul ignore next */
-export const getFileNameFromResponse = (response: any) => 
+export const getFileNameFromResponse = (response: any) =>
   getFilenameFromContentDisposition(response.headers.get('content-disposition'));
 
 /**
@@ -535,7 +535,7 @@ export const copyElementContentsToClipboard = (el: any) => {
  * @param {Object[]} options
  * @returns {Object[]}
  */
-export const addEmptyOption = (options: Array<Object>): Array<Object> => 
+export const addEmptyOption = (options: Array<Object>): Array<Object> =>
   [{value: '', label: ''}, ...options];
 
 /**
@@ -626,7 +626,7 @@ export const getFieldOptions = (attributes: Attributes, path: string, addEmpty: 
  * @returns {Object}
  */
 
-export const getFieldAttributes = (attributes: Attributes, path: string): ?Object => 
+export const getFieldAttributes = (attributes: Attributes, path: string): ?Object =>
   get(attributes, path);
 
 /**
@@ -648,7 +648,7 @@ export const humanReadableByteCount = (bytes: number): string => {
  * @param {string} text
  * @returns {boolean}
  */
-export const hasNumber = (text: string): boolean => 
+export const hasNumber = (text: string): boolean =>
   /\d/.test(text);
 
 /**
@@ -672,7 +672,7 @@ export const findFromOcdString = (ocd: string, key: string) => {
  * @param {string} url
  * @returns {string}
  */
-export const createPaikkatietovipunenUrl = (url: string): string => 
+export const createPaikkatietovipunenUrl = (url: string): string =>
   `${PAIKKATIETOVIPUNEN_URL}/${url}`;
 
 
@@ -681,7 +681,7 @@ export const createPaikkatietovipunenUrl = (url: string): string =>
  * @param {Object} response
  * @returns {number}
  */
-export const getApiResponseCount = (response: ApiResponse): number => 
+export const getApiResponseCount = (response: ApiResponse): number =>
   get(response, 'count', 0);
 
 /**
@@ -701,7 +701,7 @@ export const getApiResponseMaxPage = (response: ApiResponse, size: number): numb
  * @param {Object} response
  * @returns {Object[]}
  */
-export const  getApiResponseResults = (response: ApiResponse) => 
+export const  getApiResponseResults = (response: ApiResponse) =>
   get(response, 'results', []);
 
 /**


### PR DESCRIPTION
* Fix whitespace on some of the components
* formatNumber: Add optional visible decimals
* Add a new basis of rent calculator type
* BasisOfRentsEdit: Ignore the last profit margin percentage
  * We don't want to copy the last profit margin percentage to a new calculator anymore. So use an empty object as the new calculator base.
* Update BasisOfRent calculation helper functions
* Update BasisOfRent components to include a new calculator type
  * Include new calculator type "lease2022"
  * When changing the calculator type, reset/clear all fields and remove subventions
  * Update both the form component and the component that renders saved values
  * Update discount values when currentAmountPerArea changes
  * Add code comments and group constants to have a better understanding of the code
* Update subvention percentage when currentAmountPerArea is updated
* Subventions: Return values with two decimals for percentage and amount
* Fix rounding issues in basis of rent subvention calculations
* Show 3 decimals for each amount in subvention rows
* Make subvention type selection optional