### PR TITLE
Add special handling for applicant type

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 
 
-# MVJ UI 
+# MVJ UI
 City of Helsinki ground rental system UI
 
 Based on [React Boilerplate](https://github.com/nordsoftware/react-boilerplate).
@@ -54,20 +54,29 @@ Make sure you have [Yarn](https://yarnpkg.com/en/docs/install) installed globall
 ```bash
 yarn
 ```
+#### 3. Setup Flow typing definitions for dependencies
 
-#### 3. Add .env file
+```bash
+flow-typed install
+```
+If the tool cannot be found as is, you can invoke it from
+the node binary folder manually (i.e.
+`./node_modules/.bin/flow-typed`) instead of just
+`flow-typed`).
+
+#### 4. Add .env file
 
 ```bash
 cp .env.example .env
 ```
 
-#### 4. Start the development server
+#### 5. Start the development server
 
 ```bash
 yarn start
 ```
 
-#### 5. Compile the distribution build
+#### 6. Compile the distribution build
 
 ```bash
 yarn run compile

--- a/src/plotApplications/constants.js
+++ b/src/plotApplications/constants.js
@@ -1,11 +1,12 @@
 // @flow
 import {TableSortOrder} from '$src/enums';
+import {ApplicantTypes} from "./enums";
 
 /**
  * Default plotApplications states value for plotSearch list search
  * @const {string[]}
  */
-export const DEFAULT_PLOT_APPLICATIONS_STATES = [];
+export const DEFAULT_PLOT_APPLICATIONS_STATES: Array<string> = [];
 
 /**
  * Default sort key for plot applications list table
@@ -33,3 +34,31 @@ export const MAX_ZOOM_LEVEL_TO_FETCH_LEASES = 7;
 
 export const APPLICANT_SECTION_IDENTIFIER = 'hakijan-tiedot';
 export const TARGET_SECTION_IDENTIFIER = 'haettava-kohde';
+export const APPLICANT_TYPE_FIELD_IDENTIFIER = 'hakija';
+
+export const APPLICANT_MAIN_IDENTIFIERS: {
+  [type: string]: {
+    DATA_SECTION: string,
+    IDENTIFIER_FIELD: string,
+    NAME_FIELDS: Array<string>,
+    LABEL: string
+  }
+} = {
+  [ApplicantTypes.COMPANY]: {
+    DATA_SECTION: 'yrityksen-tiedot',
+    IDENTIFIER_FIELD: 'y-tunnus',
+    NAME_FIELDS: [
+      'yrityksen-nimi'
+    ],
+    LABEL: 'Yritys'
+  },
+  [ApplicantTypes.PERSON]: {
+    DATA_SECTION: 'henkilon-tiedot',
+    IDENTIFIER_FIELD: 'henkilotunnus',
+    NAME_FIELDS: [
+      'etunimi',
+      'Sukunimi'
+    ],
+    LABEL: 'Henkilö'
+  }
+};

--- a/src/plotApplications/enums.js
+++ b/src/plotApplications/enums.js
@@ -1,3 +1,4 @@
+//@flow
 export const ApplicationFieldPaths = {
   PLOTSEARCH: 'plotsearch',
 };
@@ -31,4 +32,15 @@ export const PlotApplicationInfoCheckFieldTitles = {
   STATE: 'Tila',
   MARK_ALL: 'Merkitse kaikkiin hakijan hakemuksiin',
   COMMENT: 'Kommentti'
+};
+
+export const ApplicantTypes = {
+  PERSON: 'Person',
+  COMPANY: 'Company',
+  BOTH: 'Both',
+  UNKNOWN: null,
+
+  // UI only states
+  UNSELECTED: 'unselected',
+  NOT_APPLICABLE: 'not applicable'
 };

--- a/src/plotApplications/types.js
+++ b/src/plotApplications/types.js
@@ -31,8 +31,28 @@ export type PlotApplicationsState = {
   lastInfoCheckUpdateSuccessful: { [id: number]: boolean }
 };
 
+export type PlotApplicationFormValue = string | Array<string> | boolean;
+
 export type PlotApplicationsList = Object;
 export type PlotApplication = Object;
+
+export type ApplicationFormField = {
+  value: PlotApplicationFormValue | null,
+  extraValue: string
+}
+
+export type ApplicationFormSection = {
+  fields: { [identifier: string]: ApplicationFormField},
+  sections: { [identifier: string]: ApplicationFormSection | Array<ApplicationFormSection> },
+  metadata?: { [key: string]: mixed },
+  sectionRestrictions: { [identifier: string]: string }
+}
+
+export type ApplicationFormState = {
+  formId: number | null,
+  targets: Array<number>,
+  formEntries: { [identifier: string]: ApplicationFormSection } | null
+}
 
 export type FetchAttributesAction = Action<'mvj/plotApplications/FETCH_ATTRIBUTES', void>;
 export type ReceiveAttributesAction = Action<'mvj/plotApplications/RECEIVE_ATTRIBUTES', Attributes>;
@@ -85,7 +105,7 @@ export type FetchPendingUploadsAction = Action<'mvj/plotApplications/FETCH_PENDI
 export type ReceivePendingUploadsAction = Action<'mvj/plotApplications/RECEIVE_PENDING_UPLOADS', Object>;
 export type PendingUploadsNotFoundAction = Action<'mvj/plotApplications/PENDING_UPLOADS_NOT_FOUND', void>;
 export type DeleteUploadAction = Action<'mvj/plotApplications/DELETE_UPLOAD', number>;
-export type UploadFileAction = Action<'mvj/plotApplications/UPLOAD_FILE', void>;
+export type UploadFileAction = Action<'mvj/plotApplications/UPLOAD_FILE', Object>;
 export type ReceiveFileOperationFinishedAction = Action<'mvj/plotApplications/RECEIVE_FILE_OPERATION_FINISHED', void>;
 
 export type FetchAttachmentAttributesAction = Action<'mvj/plotApplications/FETCH_ATTACHMENT_ATTRIBUTES', void>;

--- a/src/plotSearch/types.js
+++ b/src/plotSearch/types.js
@@ -39,7 +39,46 @@ export type Form = {
   title: string,
   id: number,
   is_template: boolean,
-  sections: Object
+  sections: Array<FormSection>
+};
+
+export type FormSection = {
+  id: number;
+  identifier: string;
+  title: string;
+  visible: boolean;
+  sort_order: number;
+  add_new_allowed: boolean;
+  add_new_text?: string;
+  subsections: Array<FormSection>;
+  fields: Array<FormField>;
+  form_id: number;
+  parent_id: number | null;
+  show_duplication_check: boolean;
+  applicant_type: string;
+};
+
+export type FormField = {
+  id: number;
+  identifier: string;
+  type: number;
+  label: string;
+  hint_text?: string;
+  enabled: boolean;
+  required: boolean;
+  validation?: string | null;
+  action?: string | null;
+  sort_order: number;
+  choices: Array<FormFieldChoice>;
+  section_id: number;
+};
+
+export type FormFieldChoice = {
+  id: number;
+  text: string;
+  value: string;
+  action?: string | null;
+  has_text_input: boolean;
 };
 
 export type FetchSinglePlotSearchAfterEditPayload = {


### PR DESCRIPTION
- Subsections within the top level applicant section will or won't be shown based on the selected applicant type
- The primary identifying detail (personal identity number or company ID) is attached into the metadata object of the section
- This identifying detail is used to label the collapse section when the application is viewed

Also includes Flow typing fixes (mostly permanent, but also some stop-gap temporary Object fallbacks) to all involved files.