### PR TITLE
Fix new plot search creation

### DIFF
--- a/src/plotSearch/components/plotSearchSections/basicInfo/BasicInfoEdit.js
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/BasicInfoEdit.js
@@ -52,21 +52,21 @@ import PlotSearchSiteEdit from './PlotSearchSiteEdit';
 import type {Attributes} from '$src/types';
 import {hasMinimumRequiredFieldsFilled} from "../../../helpers";
 import WarningField from "../../../../components/form/WarningField";
-import {getCurrentPlotSearch, getStages, isLockedForModifications} from "../../../selectors";
+import {getCurrentPlotSearch, getCurrentPlotSearchStage, getStages, isLockedForModifications} from "../../../selectors";
 import PlotSearchTargetListing from "./PlotSearchTargetListing";
 import {AUTOMATIC_PLOT_SEARCH_STAGES} from "../../../constants";
+import {PlotSearchStageTypes} from "../../../enums";
 
 type DecisionsProps = {
   attributes: Attributes,
   disabled: boolean,
   fields: any,
   formName: string,
-  isSaveClicked: Boolean,
+  isSaveClicked: boolean,
   usersPermissions: UsersPermissionsType,
+  decisionCandidates: Array<Object>,
+  hasUnidentifiedDecisions: boolean
 }
-
-// TODO
-// eslint-disable-next-line
 const renderDecisions = ({
   disabled,
   fields,
@@ -188,8 +188,10 @@ type PlotSearchSitesProps = {
   disabled: boolean,
   fields: any,
   formName: string,
-  // leaseAttrobites
   usersPermissions: UsersPermissionsType,
+  onRemove: Function,
+  change: Function,
+  form: string
 }
 
 const renderPlotSearchSites = ({
@@ -266,6 +268,10 @@ const renderPlotSearchSites = ({
   );
 };
 
+type OwnProps = {
+
+};
+
 type Props = {
   attributes: Attributes,
   collapseStateBasic: boolean,
@@ -281,7 +287,13 @@ type Props = {
   hasMinimumRequiredFieldsFilled: boolean,
   change: Function,
   currentPlotSearch: Object,
-  isLockedForModifications: boolean
+  decisionCandidates: Array<Object>,
+  selectedDecisions: Array<Object>,
+  targets: Array<Object>,
+  removeTargetDecisions: Function,
+  isLockedForModifications: boolean,
+  stages: Array<Object>,
+  currentStage: string | null
 }
 
 type State = {
@@ -290,6 +302,16 @@ type State = {
 
 class BasicInfoEdit extends PureComponent<Props, State> {
   state = {
+  }
+
+  componentDidMount() {
+    const { currentStage, change, stages } = this.props;
+    if (!currentStage) {
+      const initialStage = stages.find((stage) => stage.stage === PlotSearchStageTypes.IN_PREPARATION);
+      if (initialStage) {
+        change('stage', initialStage.id);
+      }
+    }
   }
 
   handleCollapseToggle = (key: string, val: boolean) => {
@@ -375,7 +397,7 @@ class BasicInfoEdit extends PureComponent<Props, State> {
 
     const hasUnidentifiedDecisions = selectedDecisions.some((decision) => decision?.id && !decision?.relatedPlanUnitId);
 
-    const canEditStage = !AUTOMATIC_PLOT_SEARCH_STAGES.includes(currentPlotSearch.stage.stage);
+    const canEditStage = currentPlotSearch?.stage && !AUTOMATIC_PLOT_SEARCH_STAGES.includes(currentPlotSearch.stage.stage);
     let stageAttributes = get(attributes, 'stage');
     if (stageAttributes && canEditStage) {
       stageAttributes = {
@@ -572,7 +594,7 @@ class BasicInfoEdit extends PureComponent<Props, State> {
 const formName = FormNames.PLOT_SEARCH_BASIC_INFORMATION;
 const selector = formValueSelector(formName);
 
-export default flowRight(
+export default (flowRight(
   connect(
     (state) => {
       return {
@@ -589,7 +611,8 @@ export default flowRight(
         hasMinimumRequiredFieldsFilled: hasMinimumRequiredFieldsFilled(state),
         currentPlotSearch: getCurrentPlotSearch(state),
         isLockedForModifications: isLockedForModifications(state),
-        stages: getStages(state)
+        stages: getStages(state),
+        currentStage: getCurrentPlotSearchStage(state)
       };
     },
     {
@@ -604,4 +627,4 @@ export default flowRight(
     destroyOnUnmount: false,
     change
   }),
-)(BasicInfoEdit);
+)(BasicInfoEdit) : React$AbstractComponent<OwnProps, mixed>);

--- a/src/plotSearch/selectors.js
+++ b/src/plotSearch/selectors.js
@@ -98,8 +98,10 @@ export const getTemplateForms: Selector<Object, void> = (state: RootState): Obje
 export const getForm: Selector<Object, void> = (state: RootState): Object =>
   state.plotSearch.form;
 
-export const getDecisionCandidates: Selector<Array, void> = (state: RootState): Object => {
+export const getDecisionCandidates: Selector<Array<Object>, void> = (state: RootState): Array<Object> => {
   return Object.values(state.plotSearch.decisionCandidates).reduce((acc, next) => {
+    // https://github.com/facebook/flow/issues/2133
+    // $FlowFixMe
     return ([ ...acc, ...next ]);
   }, []);
 };
@@ -112,8 +114,8 @@ export const areTargetsAllowedToHaveType: Selector<boolean, void> = (state: Root
 }
 
 export const isLockedForModifications: Selector<boolean, void> = (state: RootState): boolean => {
-  const stage = getCurrentPlotSearch(state)?.stage?.stage;
-  return stage && stage !== PlotSearchStageTypes.IN_PREPARATION;
+  const stage = getCurrentPlotSearchStage(state);
+  return stage ? stage !== PlotSearchStageTypes.IN_PREPARATION : false;
 }
 
 export const isFetchingStages: Selector<boolean, void> = (state: RootState): boolean =>
@@ -121,3 +123,6 @@ export const isFetchingStages: Selector<boolean, void> = (state: RootState): boo
 
 export const getStages: Selector<Array<Object>, void> = (state: RootState): Array<Object> =>
   state.plotSearch.stages;
+
+export const getCurrentPlotSearchStage: Selector<string | null, void> = (state: RootState): string | null =>
+  getCurrentPlotSearch(state)?.stage?.stage || null;

--- a/src/plotSearch/types.js
+++ b/src/plotSearch/types.js
@@ -25,7 +25,8 @@ export type PlotSearchState = {
   form: Object,
   templateForms: Object,
   isFetchingStages: boolean,
-  stages: Array<Object>
+  stages: Array<Object>,
+  decisionCandidates: Array<Object>
 };
 
 export type PlotSearchId = number;


### PR DESCRIPTION
- Fix crash due to an attempt to read a non-existing stage field
- Automatically set the "in preparation" stage when editing a newly created plot search

Also includes type fixes for the files involved.