### PR TITLE
Fix basis of rent calculator issues

### DIFF
--- a/src/leases/components/leaseSections/rent/BasisOfRent.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRent.js
@@ -427,10 +427,10 @@ const BasisOfRent = ({
               isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)
             }>
               {calculatorType === CalculatorTypes.TEMPORARY && <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.BASE_YEAR_RENT)}>
-                {'Vuokra/kuukausi'}
+                {'Vuokra/kk'}
               </FormTextTitle>}
               {calculatorType !== CalculatorTypes.TEMPORARY && <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.BASE_YEAR_RENT)}>
-                {LeaseBasisOfRentsFieldTitles.RENT}
+                {'Vuokra/vuosi'}
               </FormTextTitle>}
               {calculatorType === CalculatorTypes.TEMPORARY && <FormText>{!isEmptyValue(rent) ? `${formatNumber(rent)} €` : '-'}</FormText>}
               {calculatorType === CalculatorTypes.ADDITIONAL_YARD && <FormText>{!isEmptyValue(rentExtra) ? `${formatNumber(rentExtra)} €` : '-'}</FormText>}

--- a/src/leases/components/leaseSections/rent/BasisOfRent.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRent.js
@@ -281,7 +281,6 @@ const BasisOfRent = ({
               <FormText>{getLabelOfOption(calculatorTypeOptions, calculatorType) || '-'}</FormText>
             </Authorization>
           </Column>
-
           {calculatorType === CalculatorTypes.MAST && <Column large={5} medium={9} small={12}>
             <Row>
               <Column small={6} medium={4} large={2}>
@@ -415,22 +414,6 @@ const BasisOfRent = ({
                 {LeaseBasisOfRentsFieldTitles.AREA}
               </FormTextTitle>
               <FormText>{areaText}</FormText>
-            </Authorization>
-          </Column>}
-          {(calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) && <Column small={6} medium={4} large={2}>
-            <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PLANS_INSPECTED_AT)}>
-              <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.PLANS_INSPECTED_AT)}>
-                {LeaseBasisOfRentsFieldTitles.PLANS_INSPECTED_AT}
-              </FormTextTitle>
-              <FormText>{plansInspectedText}</FormText>
-            </Authorization>
-          </Column>}
-          {(calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) && <Column small={6} medium={4} large={2}>
-            <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.LOCKED_AT)}>
-              <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.LOCKED_AT)}>
-                {LeaseBasisOfRentsFieldTitles.LOCKED_AT}
-              </FormTextTitle>
-              <FormText>{lockedText}</FormText>
             </Authorization>
           </Column>}
           {calculatorType === CalculatorTypes.ADDITIONAL_YARD && <Column small={3} medium={2} large={1} style={{marginTop: 15}}>
@@ -685,6 +668,25 @@ const BasisOfRent = ({
             </Column>
           </Fragment>}
         </Row>}
+
+        <Row>
+          {(calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) && <Column small={6} medium={4} large={2}>
+            <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PLANS_INSPECTED_AT)}>
+              <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.PLANS_INSPECTED_AT)}>
+                {LeaseBasisOfRentsFieldTitles.PLANS_INSPECTED_AT}
+              </FormTextTitle>
+              <FormText>{plansInspectedText}</FormText>
+            </Authorization>
+          </Column>}
+          <Column small={6} medium={4} large={2}>
+            <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.LOCKED_AT)}>
+              <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.LOCKED_AT)}>
+                {LeaseBasisOfRentsFieldTitles.LOCKED_AT}
+              </FormTextTitle>
+              <FormText>{lockedText}</FormText>
+            </Authorization>
+          </Column>
+        </Row>
 
         {((basisOfRent.subvention_type || (!!temporarySubventions && !!temporarySubventions.length)) && (calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022)) &&
           <WhiteBox>

--- a/src/leases/components/leaseSections/rent/BasisOfRentEdit.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRentEdit.js
@@ -913,6 +913,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
     const basicAnnualRent = calculateBasisOfRentBasicAnnualRent(basisOfRent, indexValue);
     const areaText = this.getAreaText(area);
     const lockedAtText = this.getLockedText();
+    const isLocked = !!savedBasisOfRent && !!savedBasisOfRent.locked_at;
 
     // Used by CalculatorTypes.LEASE
     const amountPerAreaText = this.getAmountPerAreaText(amountPerArea);
@@ -971,7 +972,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
             required: false,
             type: 'decimal',
           }}
-          disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+          disabled={isLocked}
           name={`${field}.current_amount_per_area`}
           unit='€'
           invisibleLabel
@@ -990,7 +991,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
             ? {...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE), required: false}
             : getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.PROFIT_MARGIN_PERCENTAGE)
           }
-          disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+          disabled={isLocked}
           name={`${field}.profit_margin_percentage`}
           unit='%'
           overrideValues={{label: LeaseBasisOfRentsFieldTitles.PROFIT_MARGIN_PERCENTAGE}}
@@ -1025,7 +1026,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
           disableTouched={isSaveClicked}
           fieldAttributes={{...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX), required: false}}
           onChange={this.onChangeIndexOptions}
-          disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+          disabled={isLocked}
           name={`${field}.index`}
           overrideValues={{
             label: LeaseBasisOfRentsFieldTitles.INDEX,
@@ -1097,7 +1098,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                   fieldAttributes={getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.TYPE)}
                   onChange={this.onChangeTypeOptions}
                   name={`${field}.type`}
-                  disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+                  disabled={isLocked}
                   overrideValues={{
                     label: 'Laskurin tyyppi',
                   }}
@@ -1114,7 +1115,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                     ? {...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.INTENDED_USE), required: false}
                     : getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.INTENDED_USE)
                   }
-                  disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+                  disabled={isLocked}
                   name={`${field}.intended_use`}
                   overrideValues={{label: LeaseBasisOfRentsFieldTitles.INTENDED_USE}}
                   enableUiDataEdit
@@ -1148,7 +1149,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                           ? {...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA), required: false}
                           : getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA)
                         }
-                        disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+                        disabled={isLocked}
                         name={`${field}.area`}
                         invisibleLabel
                         overrideValues={{label: LeaseBasisOfRentsFieldTitles.AREA}}
@@ -1163,7 +1164,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                           ? {...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA_UNIT), required: false}
                           : getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA_UNIT)
                         }
-                        disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+                        disabled={isLocked}
                         name={`${field}.area_unit`}
                         invisibleLabel
                         overrideValues={{
@@ -1193,7 +1194,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                         disableTouched={isSaveClicked}
                         fieldAttributes={getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.ZONE)}
                         name={`${field}.zone`}
-                        disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+                        disabled={isLocked}
                         overrideValues={{
                           label: LeaseBasisOfRentsFieldTitles.ZONE,
                         }}
@@ -1218,7 +1219,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                           : getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA)
                         }
                         name={`${field}.amount_per_area`}
-                        disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+                        disabled={isLocked}
                         invisibleLabel
                         unit='€'
                         overrideValues={{label: LeaseBasisOfRentsFieldTitles.PRICE}}
@@ -1257,7 +1258,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                               disableTouched={isSaveClicked}
                               fieldAttributes={getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)}
                               name={`${field}.amount_per_area`}
-                              disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+                              disabled={isLocked}
                               unit='€'
                               overrideValues={{label: 'Hinta'}}
                             />}
@@ -1275,7 +1276,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                               disableTouched={isSaveClicked}
                               fieldAttributes={getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA)}
                               name={`${field}.area`}
-                              disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+                              disabled={isLocked}
                               overrideValues={{label: 'Ala/korkeus'}}
                             />
                           </Authorization>
@@ -1305,7 +1306,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                             name={`${field}.children`}
                             formName={formName}
                             parentField={field}
-                            fieldsDisabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+                            fieldsDisabled={isLocked}
                           />
                         </Column>;
                       }}
@@ -1326,7 +1327,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                           ? {...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA), required: false}
                           : getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA)
                         }
-                        disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+                        disabled={isLocked}
                         name={`${field}.area`}
                         invisibleLabel
                         unit={calculatorType === CalculatorTypes.FIELD ? 'ha' : `m${String.fromCharCode(178)}`}
@@ -1377,7 +1378,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                           ? {...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX), required: false}
                           : getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX)
                         }
-                        disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+                        disabled={isLocked}
                         name={`${field}.index`}
                         overrideValues={{
                           label: LeaseBasisOfRentsFieldTitles.INDEX,
@@ -1438,7 +1439,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                           ? {...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA), required: false}
                           : getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)
                         }
-                        disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+                        disabled={isLocked}
                         name={`${field}.amount_per_area`}
                         unit='€'
                         invisibleLabel
@@ -1711,7 +1712,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                           ? {...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX), required: false}
                           : getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.INDEX)
                         }
-                        disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+                        disabled={isLocked}
                         name={`${field}.index`}
                         overrideValues={{
                           label: LeaseBasisOfRentsFieldTitles.INDEX,
@@ -1757,7 +1758,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                       ? { ...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.PLANS_INSPECTED_AT), required: false, type: 'checkbox-date-time' }
                       : { ...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.PLANS_INSPECTED_AT), type: 'checkbox-date-time' }
                     }
-                    disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+                    disabled={isLocked}
                     invisibleLabel
                     name={`${field}.plans_inspected_at`}
                     overrideValues={{ label: LeaseBasisOfRentsFieldTitles.PLANS_INSPECTED_AT }}
@@ -1838,7 +1839,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                             disableTouched={isSaveClicked}
                             fieldAttributes={{...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.SUBVENTION_TYPE), required: false}}
                             name={`${field}.subvention_type`}
-                            disabled={(!!savedBasisOfRent && !!savedBasisOfRent.locked_at)}
+                            disabled={isLocked}
                             overrideValues={{label: LeaseBasisOfRentsFieldTitles.SUBVENTION_TYPE}}
                             enableUiDataEdit
                             uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.SUBVENTION_TYPE)}
@@ -1851,7 +1852,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                         <SubTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(BasisOfRentManagementSubventionsFieldPaths.MANAGEMENT_SUBVENTIONS)}>{BasisOfRentManagementSubventionsFieldTitles.MANAGEMENT_SUBVENTIONS}</SubTitle>
                         <FieldArray
                           component={renderManagementSubventions}
-                          disabled={(!!savedBasisOfRent && !!savedBasisOfRent.locked_at)}
+                          disabled={isLocked}
                           formName={formName}
                           initialYearRent={initialYearRent}
                           currentAmountPerArea={currentAmountPerArea}
@@ -1869,7 +1870,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                               disableTouched={isSaveClicked}
                               fieldAttributes={getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.SUBVENTION_BASE_PERCENT)}
                               name={`${field}.subvention_base_percent`}
-                              disabled={(!!savedBasisOfRent && !!savedBasisOfRent.locked_at)}
+                              disabled={isLocked}
                               overrideValues={{label: LeaseBasisOfRentsFieldTitles.SUBVENTION_BASE_PERCENT}}
                               unit='%'
                               enableUiDataEdit
@@ -1883,7 +1884,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                               disableTouched={isSaveClicked}
                               fieldAttributes={getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.SUBVENTION_GRADUATED_PERCENT)}
                               name={`${field}.subvention_graduated_percent`}
-                              disabled={(!!savedBasisOfRent && !!savedBasisOfRent.locked_at)}
+                              disabled={isLocked}
                               overrideValues={{label: LeaseBasisOfRentsFieldTitles.SUBVENTION_GRADUATED_PERCENT}}
                               unit='%'
                               enableUiDataEdit
@@ -1919,7 +1920,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                       <FieldArray
                         component={renderTemporarySubventions}
                         leaseAttributes={leaseAttributes}
-                        disabled={(!!savedBasisOfRent && !!savedBasisOfRent.locked_at)}
+                        disabled={isLocked}
                         formName={formName}
                         initialYearRent={initialYearRent}
                         name={`${field}.temporary_subventions`}

--- a/src/leases/components/leaseSections/rent/BasisOfRentEdit.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRentEdit.js
@@ -1370,59 +1370,6 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                 </Authorization>
               </Row>
             </Column>}
-
-            {showPlansInspectedAt && (calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) &&
-              <Column small={6} medium={4} large={2}>
-                <Authorization
-                  allow={isFieldAllowedToEdit(leaseAttributes, LeaseBasisOfRentsFieldPaths.PLANS_INSPECTED_AT)}
-                  errorComponent={
-                    <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PLANS_INSPECTED_AT)}>
-                      <FormTextTitle>{LeaseBasisOfRentsFieldTitles.PLANS_INSPECTED_AT}</FormTextTitle>
-                      <FormText>{plansInspectedAtText}</FormText>
-                    </Authorization>
-                  }
-                >
-                  <FormField
-                    className='with-top-padding'
-                    disableTouched={isSaveClicked}
-                    fieldAttributes={savedBasisOfRent && !!savedBasisOfRent.locked_at
-                      ? {...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.PLANS_INSPECTED_AT), required: false, type: 'checkbox-date-time'}
-                      : {...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.PLANS_INSPECTED_AT), type: 'checkbox-date-time'}
-                    }
-                    disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
-                    invisibleLabel
-                    name={`${field}.plans_inspected_at`}
-                    overrideValues={{label: LeaseBasisOfRentsFieldTitles.PLANS_INSPECTED_AT}}
-                  />
-                </Authorization>
-              </Column>
-            }
-
-            {showLockedAt && (calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) &&
-              <Column small={6} medium={4} large={2}>
-                <Authorization
-                  allow={isFieldAllowedToEdit(leaseAttributes, LeaseBasisOfRentsFieldPaths.LOCKED_AT)}
-                  errorComponent={
-                    <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.LOCKED_AT)}>
-                      <FormTextTitle>{LeaseBasisOfRentsFieldTitles.LOCKED_AT}</FormTextTitle>
-                      <FormText>{lockedAtText}</FormText>
-                    </Authorization>
-                  }
-                >
-                  <FormField
-                    className='with-top-padding'
-                    disableTouched={isSaveClicked}
-                    fieldAttributes={{
-                      ...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.LOCKED_AT),
-                      type: 'checkbox-date-time',
-                    }}
-                    invisibleLabel
-                    name={`${field}.locked_at`}
-                    overrideValues={{label: LeaseBasisOfRentsFieldTitles.LOCKED_AT}}
-                  />
-                </Authorization>
-              </Column>
-            }
           </Row>
 
           {calculatorType === CalculatorTypes.LEASE && <Row>
@@ -1756,6 +1703,61 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
               </Column>
             </Authorization>
           </Row>}
+
+          <Row>
+            {showPlansInspectedAt && (calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) &&
+              <Column small={6} medium={4} large={2}>
+                <Authorization
+                  allow={isFieldAllowedToEdit(leaseAttributes, LeaseBasisOfRentsFieldPaths.PLANS_INSPECTED_AT)}
+                  errorComponent={
+                    <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.PLANS_INSPECTED_AT)}>
+                      <FormTextTitle>{LeaseBasisOfRentsFieldTitles.PLANS_INSPECTED_AT}</FormTextTitle>
+                      <FormText>{plansInspectedAtText}</FormText>
+                    </Authorization>
+                  }
+                >
+                  <FormField
+                    className='with-top-padding'
+                    disableTouched={isSaveClicked}
+                    fieldAttributes={savedBasisOfRent && !!savedBasisOfRent.locked_at
+                      ? { ...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.PLANS_INSPECTED_AT), required: false, type: 'checkbox-date-time' }
+                      : { ...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.PLANS_INSPECTED_AT), type: 'checkbox-date-time' }
+                    }
+                    disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
+                    invisibleLabel
+                    name={`${field}.plans_inspected_at`}
+                    overrideValues={{ label: LeaseBasisOfRentsFieldTitles.PLANS_INSPECTED_AT }}
+                  />
+                </Authorization>
+              </Column>
+            }
+
+            {showLockedAt &&
+              <Column small={6} medium={4} large={2}>
+                <Authorization
+                  allow={isFieldAllowedToEdit(leaseAttributes, LeaseBasisOfRentsFieldPaths.LOCKED_AT)}
+                  errorComponent={
+                    <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.LOCKED_AT)}>
+                      <FormTextTitle>{LeaseBasisOfRentsFieldTitles.LOCKED_AT}</FormTextTitle>
+                      <FormText>{lockedAtText}</FormText>
+                    </Authorization>
+                  }
+                >
+                  <FormField
+                    className='with-top-padding'
+                    disableTouched={isSaveClicked}
+                    fieldAttributes={{
+                      ...getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.LOCKED_AT),
+                      type: 'checkbox-date-time',
+                    }}
+                    invisibleLabel
+                    name={`${field}.locked_at`}
+                    overrideValues={{ label: LeaseBasisOfRentsFieldTitles.LOCKED_AT }}
+                  />
+                </Authorization>
+              </Column>
+            }
+          </Row>
 
           {(!savedBasisOfRent || !savedBasisOfRent.locked_at) && !showSubventions && (calculatorType === CalculatorTypes.LEASE || calculatorType === CalculatorTypes.LEASE2022) &&
             <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.SUBVENTION_TYPE)}>

--- a/src/leases/components/leaseSections/rent/BasisOfRentEdit.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRentEdit.js
@@ -1346,7 +1346,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                     }>
                       {calculatorType !== CalculatorTypes.TEMPORARY &&
                         <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.BASE_YEAR_RENT)}>
-                          {LeaseBasisOfRentsFieldTitles.RENT}
+                          {'Vuokra/vuosi'}
                         </FormTextTitle>}
                       {calculatorType === CalculatorTypes.TEMPORARY &&
                         <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.BASE_YEAR_RENT)}>

--- a/src/leases/components/leaseSections/rent/BasisOfRentEdit.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRentEdit.js
@@ -327,7 +327,8 @@ type renderMastChildrenProps = {
   isSaveClicked: boolean,
   formName: string,
   parentField: string,
-  fields: any
+  fields: any,
+  fieldsDisabled: boolean,
 }
 
 const renderMastChildren = ({
@@ -336,6 +337,7 @@ const renderMastChildren = ({
   formName,
   fields,
   parentField,
+  fieldsDisabled,
 }: renderMastChildrenProps): Element<*> => {
   fields = [{}, {}];
   return (
@@ -352,6 +354,7 @@ const renderMastChildren = ({
                 field={field}
                 key={index}
                 parentField={parentField}
+                fieldsDisabled={fieldsDisabled}
               />;
             })}
           </Fragment>
@@ -909,13 +912,13 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
     const indexValue = getBasisOfRentIndexValue(basisOfRent, indexOptions);
     const basicAnnualRent = calculateBasisOfRentBasicAnnualRent(basisOfRent, indexValue);
     const areaText = this.getAreaText(area);
+    const lockedAtText = this.getLockedText();
 
     // Used by CalculatorTypes.LEASE
     const amountPerAreaText = this.getAmountPerAreaText(amountPerArea);
     const currentAmountPerArea = getBasisOfRentAmountPerArea(basisOfRent, indexValue);
 
     // Used by CalculatorTypes.LEASE and CalculatorTypes.LEASE2022
-    const lockedAtText = this.getLockedText();
     const plansInspectedAtText = this.getPlansInspectedText();
     const initialYearRent = calculateBasisOfRentInitialYearRent(basisOfRent, indexValue, basicAnnualRent);
     const releaseDiscountPercent = this.calculateReLeaseDiscountPercent();
@@ -1094,6 +1097,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                   fieldAttributes={getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.TYPE)}
                   onChange={this.onChangeTypeOptions}
                   name={`${field}.type`}
+                  disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
                   overrideValues={{
                     label: 'Laskurin tyyppi',
                   }}
@@ -1189,6 +1193,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                         disableTouched={isSaveClicked}
                         fieldAttributes={getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.ZONE)}
                         name={`${field}.zone`}
+                        disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
                         overrideValues={{
                           label: LeaseBasisOfRentsFieldTitles.ZONE,
                         }}
@@ -1213,6 +1218,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                           : getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA)
                         }
                         name={`${field}.amount_per_area`}
+                        disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
                         invisibleLabel
                         unit='€'
                         overrideValues={{label: LeaseBasisOfRentsFieldTitles.PRICE}}
@@ -1251,6 +1257,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                               disableTouched={isSaveClicked}
                               fieldAttributes={getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)}
                               name={`${field}.amount_per_area`}
+                              disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
                               unit='€'
                               overrideValues={{label: 'Hinta'}}
                             />}
@@ -1268,6 +1275,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                               disableTouched={isSaveClicked}
                               fieldAttributes={getFieldAttributes(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA)}
                               name={`${field}.area`}
+                              disabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
                               overrideValues={{label: 'Ala/korkeus'}}
                             />
                           </Authorization>
@@ -1297,6 +1305,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                             name={`${field}.children`}
                             formName={formName}
                             parentField={field}
+                            fieldsDisabled={!!savedBasisOfRent && !!savedBasisOfRent.locked_at}
                           />
                         </Column>;
                       }}

--- a/src/leases/components/leaseSections/rent/BasisOfRentEdit.js
+++ b/src/leases/components/leaseSections/rent/BasisOfRentEdit.js
@@ -1288,7 +1288,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                         </Column>
                         <Column small={6} medium={4} large={2}>
                           <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) && isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)}>
-                            <FormTextTitle>{'Vuokra'}</FormTextTitle>
+                            <FormTextTitle>{LeaseBasisOfRentsFieldTitles.RENT}</FormTextTitle>
                             <FormText>{!isEmptyValue(mastAreaRent) ? `${formatNumber(mastAreaRent)} €` : '-'}</FormText>
                           </Authorization>
                         </Column>
@@ -1346,11 +1346,11 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                     }>
                       {calculatorType !== CalculatorTypes.TEMPORARY &&
                         <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.BASE_YEAR_RENT)}>
-                          {'Vuokra/vuosi'}
+                          {LeaseBasisOfRentsFieldTitles.RENT_PER_YEAR}
                         </FormTextTitle>}
                       {calculatorType === CalculatorTypes.TEMPORARY &&
                         <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.BASE_YEAR_RENT)}>
-                          {'Vuokra/kk'}
+                          {LeaseBasisOfRentsFieldTitles.RENT_PER_MONTH}
                         </FormTextTitle>}
                       {calculatorType === CalculatorTypes.TEMPORARY && <FormText>{!isEmptyValue(temporaryRent) ? `${formatNumber(temporaryRent)} €` : '-'}</FormText>}
                       {calculatorType === CalculatorTypes.ADDITIONAL_YARD && <FormText>{!isEmptyValue(rentExtra) ? `${formatNumber(rentExtra)} €` : '-'}</FormText>}
@@ -1364,7 +1364,7 @@ class BasisOfRentEdit extends PureComponent<Props, State> {
                     }>
                       {calculatorType === CalculatorTypes.TEMPORARY &&
                         <FormTextTitle enableUiDataEdit uiDataKey={getUiDataLeaseKey(LeaseBasisOfRentsFieldPaths.BASE_YEAR_RENT)}>
-                          {'Vuokra/vuosi'}
+                          {LeaseBasisOfRentsFieldTitles.RENT_PER_YEAR}
                         </FormTextTitle>}
                       <FormText>{!isEmptyValue(temporaryRent) ? `${formatNumber(temporaryRent * 12)} €` : '-'}</FormText>
                     </Authorization>

--- a/src/leases/components/leaseSections/rent/MastChildrenEdit.js
+++ b/src/leases/components/leaseSections/rent/MastChildrenEdit.js
@@ -8,14 +8,14 @@ import Authorization from '$components/authorization/Authorization';
 import FormField from '$components/form/FormField';
 import FormText from '$components/form/FormText';
 import {
-  isFieldAllowedToRead, 
+  isFieldAllowedToRead,
   getFieldAttributes,
   formatNumber,
   isEmptyValue,
 } from '$util/helpers';
 import {getAttributes as getLeaseAttributes, getIsSaveClicked} from '$src/leases/selectors';
 import {
-  LeaseBasisOfRentsFieldPaths,  
+  LeaseBasisOfRentsFieldPaths,
 } from '$src/leases/enums';
 import type {Attributes} from '$src/types';
 
@@ -28,6 +28,7 @@ type Props = {
   leaseAttributes: Attributes,
   index: number,
   area: number,
+  fieldsDisabled: boolean,
 }
 
 const MastChildrenEdit = ({
@@ -36,6 +37,7 @@ const MastChildrenEdit = ({
   leaseAttributes,
   index,
   area,
+  fieldsDisabled,
 }: Props) => {
   const rent = mastCalculatorRent(index, area);
 
@@ -43,7 +45,7 @@ const MastChildrenEdit = ({
     <Fragment key={index}>
       <Row>
         <Column small={6} medium={4} large={2}>
-          <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) && isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)}>            
+          <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AREA) && isFieldAllowedToRead(leaseAttributes, LeaseBasisOfRentsFieldPaths.AMOUNT_PER_AREA)}>
             {(index === 0) && <FormText>{`Laitekaappi`}</FormText>}
             {(index === 1) && <FormText>{`Masto`}</FormText>}
           </Authorization>
@@ -66,6 +68,7 @@ const MastChildrenEdit = ({
               name={`${parentField}.children[${index}].area`}
               invisibleLabel={true}
               overrideValues={{label: 'Ala/korkeus'}}
+              disabled={fieldsDisabled}
             />
           </Authorization>
         </Column>

--- a/src/leases/enums.js
+++ b/src/leases/enums.js
@@ -1221,6 +1221,8 @@ export const LeaseBasisOfRentsFieldTitles = {
   PRICE: 'Hinta',
   PROFIT_MARGIN_PERCENTAGE: 'Tuottoprosentti',
   RENT: 'Vuokra',
+  RENT_PER_YEAR: 'Vuokra/vuosi',
+  RENT_PER_MONTH: 'Vuokra/kk',
   SUBVENTION_BASE_PERCENT: 'Markkinavuokran subventio',
   SUBVENTION_GRADUATED_PERCENT: 'Siirtymäajan subventio',
   SUBVENTION_RE_LEASE_DISCOUNT_AMOUNT: 'Subventio euroa/vuosi',

--- a/src/leases/enums.js
+++ b/src/leases/enums.js
@@ -1216,7 +1216,7 @@ export const LeaseBasisOfRentsFieldTitles = {
   INITIAL_YEAR_RENT: 'Alkuvuosivuokra (ind)',
   INITIAL_YEAR_RENT_TOTAL: 'Alkuvuosivuokra (ind) yhteensä',
   INTENDED_USE: 'Käyttötarkoitus',
-  LOCKED_AT: 'Laskelma lukittu',
+  LOCKED_AT: 'Laskuri lukittu',
   PLANS_INSPECTED_AT: 'Piirustukset tarkastettu',
   PRICE: 'Hinta',
   PROFIT_MARGIN_PERCENTAGE: 'Tuottoprosentti',

--- a/src/leases/enums.js
+++ b/src/leases/enums.js
@@ -552,7 +552,7 @@ export const LeaseAreaAddressesFieldTitles = {
 
 /**
  * Lease area custom detailed plan field paths enumerable
- * 
+ *
  * @type {{}}
  */
 export const LeaseAreaCustomDetailedPlanFieldPaths = {
@@ -574,7 +574,7 @@ export const LeaseAreaCustomDetailedPlanFieldPaths = {
 
 /**
  * Lease area custom detailed plan usage distribution field paths enumerable
- * 
+ *
  * @type {{}}
  */
 export const LeaseAreaCustomDetailedPlanUsageDistributionFieldPaths = {
@@ -585,7 +585,7 @@ export const LeaseAreaCustomDetailedPlanUsageDistributionFieldPaths = {
 
 /**
  * Lease area custom detailed plan usage distribution field titles enumerable
- * 
+ *
  * @type {{}}
  */
 export const LeaseAreaCustomDetailedPlanUsageDistributionFieldTitles = {
@@ -596,7 +596,7 @@ export const LeaseAreaCustomDetailedPlanUsageDistributionFieldTitles = {
 
 /**
  * Lease area custom detailed plan usage distribution field paths enumerable
- * 
+ *
  * @type {{}}
  */
 export const LeaseAreaCustomDetailedPlanInfoLinksFieldPaths = {
@@ -607,7 +607,7 @@ export const LeaseAreaCustomDetailedPlanInfoLinksFieldPaths = {
 
 /**
  * Lease area custom detailed plan usage distribution field titles enumerable
- * 
+ *
  * @type {{}}
  */
 export const LeaseAreaCustomDetailedPlanInfoLinksFieldTitles = {

--- a/src/leases/helpers.js
+++ b/src/leases/helpers.js
@@ -2767,7 +2767,7 @@ export const getPayloadRentDueDates = (rent: Object): Array<Object> => {
  * @returns {string}
  */
 export const areaUnit = (item: Object): string => {
-  if(item.type === CalculatorTypes.LEASE)
+  if(item.type === CalculatorTypes.LEASE || item.type === CalculatorTypes.LEASE2022)
     return item.area_unit;
   return 'm2';
 };
@@ -2778,7 +2778,7 @@ export const areaUnit = (item: Object): string => {
  * @returns {number}
  */
 export const intendedUse = (item: Object): number => {
-  if(item.type === CalculatorTypes.LEASE)
+  if(item.type === CalculatorTypes.LEASE || item.type === CalculatorTypes.LEASE2022)
     return item.intended_use;
   return 7;
 };

--- a/src/leases/helpers.js
+++ b/src/leases/helpers.js
@@ -1818,6 +1818,17 @@ export const getRentWarnings = (rents: Array<Object>): Array<string> => {
  */
 export const getContentBasisOfRents = (lease: Object): Array<Object> => {
   const allChildren = get(lease, 'basis_of_rents', []).flatMap(item => item.children);
+
+  // Get children sorted ascending by id
+  const getSortedChildren = (lease: Object, item: Object): Array<Object> => {
+    const children = get(lease, 'basis_of_rents', [])
+      .filter(filterItem => get(item, 'children', []).includes(filterItem.id));
+
+    if (!children.length) return [];
+
+    return [...children].sort((a, b) => a.id - b.id);
+  }
+
   return get(lease, 'basis_of_rents', []).filter(item => !allChildren.includes(item.id)).map((item) => {
     return {
       id: item.id || undefined,
@@ -1827,7 +1838,7 @@ export const getContentBasisOfRents = (lease: Object): Array<Object> => {
       amount_per_area: item.amount_per_area,
       index: get(item, 'index.id') || get(item, 'index'),
       profit_margin_percentage: item.profit_margin_percentage,
-      children: get(lease, 'basis_of_rents', []).filter(filterItem => get(item, 'children', []).includes(filterItem.id)),
+      children: getSortedChildren(lease, item),
       type: item.type,
       discount_percentage: item.discount_percentage,
       plans_inspected_at: item.plans_inspected_at,


### PR DESCRIPTION
* Remove whitespace from `src/leases/enums.js`
* Fix issues in area unit and intended use
  * Add missing `LEASE2022` check
*  Move checkbox fields to their own row
  * Remove if clause from `locked_at` to always show `locked_at` field
* Fix copy to clipboard fields
  * Use it only for the `LEASE` and `LEASE2022` types
  * Update what fields are copied
* Add missing disabled attribute to fields with `locked_at`
* Fix rent titles
* Update `locked_at` text
* Sort basis of rent children by their id when fetching data