### PR TITLE
Improve plot application attachment handling

### DIFF
--- a/src/plotApplications/components/PlotApplication.js
+++ b/src/plotApplications/components/PlotApplication.js
@@ -31,19 +31,19 @@ import type {Attributes} from '$src/types';
 import type {PlotApplication as PlotApplicationType} from '$src/plotApplications/types';
 import Loader from '../../components/loader/Loader';
 import SubTitle from '../../components/content/SubTitle';
-import {getAttachmentLink, reshapeSavedApplicationObject} from '../helpers';
+import {getApplicationAttachmentDownloadLink, reshapeSavedApplicationObject} from '../helpers';
 import {
   getFormAttributes,
   getIsFetchingFormAttributes,
 } from '../../plotSearch/selectors';
 import {getFieldAttributes} from '../../util/helpers';
-import ExternalLink from '../../components/links/ExternalLink';
 import {APPLICANT_MAIN_IDENTIFIERS, APPLICANT_SECTION_IDENTIFIER, TARGET_SECTION_IDENTIFIER} from '../constants';
 import {getApplicationRelatedPlotSearch, getIsFetchingApplicationRelatedPlotSearch} from '../selectors';
 import PlotApplicationTargetInfoCheck from './infoCheck/PlotApplicationTargetInfoCheck';
 import PlotApplicationApplicantInfoCheck from './infoCheck/PlotApplicationApplicantInfoCheck';
 import type {PlotSearch, FormSection} from '../../plotSearch/types';
 import type {SavedApplicationFormSection, UploadedFileMeta} from '../types';
+import FileDownloadLink from '../../components/file/FileDownloadLink';
 
 type OwnProps = {};
 
@@ -113,7 +113,10 @@ const SingleSectionItem = ({section, answer, fieldTypes, plotSearch, topLevel, i
               // TODO: can this be cast in a cleaner way?
               const files: Array<UploadedFileMeta> = (displayValue: any);
               displayValue = files.length > 0 ? <ul>{files.map((file) => <li key={file.id}>
-                <ExternalLink href={getAttachmentLink(file.id)} text={file.name} openInNewTab />
+                <FileDownloadLink
+                  fileUrl={getApplicationAttachmentDownloadLink(file.id)}
+                  label={file.name}
+                />
               </li>)}</ul> : null;
               break;
           }
@@ -219,7 +222,7 @@ class PlotApplication extends PureComponent<Props, void> {
     });
   }
 
-  render (){
+  render() {
     const {
       applicationCollapseState,
       attributes,

--- a/src/plotApplications/components/PlotApplicationEdit.js
+++ b/src/plotApplications/components/PlotApplicationEdit.js
@@ -94,6 +94,7 @@ type Props = {
   currentPlotApplication?: PlotApplication,
   formAttributes: Attributes,
   attachments: Array<Object>,
+  isFetchingAttachments: boolean,
   currentPlotSearch?: PlotSearch,
   isFetchingApplicationRelatedPlotSearch: boolean,
   receiveSinglePlotApplication: Function,
@@ -102,7 +103,7 @@ type Props = {
 
 type State = {
   form: Object,
-  isFormFixed: boolean
+  isFormFixed: boolean,
 }
 
 class PlotApplicationEdit extends PureComponent<Props, State> {
@@ -151,6 +152,7 @@ class PlotApplicationEdit extends PureComponent<Props, State> {
       receiveFormValidFlags,
       isNew,
       retrievingData,
+      isFetchingAttachments,
     } = this.props;
 
     if(prevProps.valid !== this.props.valid) {
@@ -159,7 +161,7 @@ class PlotApplicationEdit extends PureComponent<Props, State> {
       });
     }
 
-    if (!isNew && !retrievingData && prevProps.retrievingData) {
+    if (!isNew && !retrievingData && !isFetchingAttachments && prevProps.retrievingData && !this.state.isFormFixed) {
       this.setupEditMode();
     }
   }
@@ -445,7 +447,7 @@ export default (flowRight(
       const isFetchingForm = getIsFetchingForm(state);
       const isFetchingApplicationRelatedPlotSearch = getIsFetchingApplicationRelatedPlotSearch(state);
 
-      const isRetrievingCommonData = isFetchingFormAttributes || isFetchingAttachmentAttributes || isFetchingInfoCheckAttributes || isFetchingForm || isFetchingAttachments;
+      const isRetrievingCommonData = isFetchingFormAttributes || isFetchingAttachmentAttributes || isFetchingInfoCheckAttributes || isFetchingForm;
       const isRetrievingCreateModeData = isFetchingPlotSearchList;
       const isRetrievingEditModeData = isFetchingApplicationRelatedPlotSearch;
 

--- a/src/plotApplications/components/PlotApplicationsPage.js
+++ b/src/plotApplications/components/PlotApplicationsPage.js
@@ -298,10 +298,6 @@ class PlotApplicationsPage extends Component<Props, State> {
         if (this.isNewEditor()) {
           fetchPlotSearchList();
         }
-      } else {
-        if (plotApplicationId) {
-          fetchSinglePlotApplication(Number(plotApplicationId));
-        }
       }
     }
 

--- a/src/plotApplications/requests.js
+++ b/src/plotApplications/requests.js
@@ -69,7 +69,7 @@ export const deleteUploadRequest = (
   id: number
 ): Generator<any, any, any> => {
   return callApi(
-    new Request(createUrl('attachment/' + id), {
+    new Request(createUrl(`attachment/${id}/`), {
       method: 'DELETE',
     })
   );

--- a/src/plotApplications/saga.js
+++ b/src/plotApplications/saga.js
@@ -328,13 +328,19 @@ function* deleteUploadSaga({payload}: DeleteUploadAction): Generator<any, any, a
 
 function* uploadFileSaga({payload}: UploadFileAction): Generator<any, any, any> {
   try {
-    yield call(uploadFileRequest, payload);
+    const {path, callback, fileData} = payload;
+
+    const result = yield call(uploadFileRequest, fileData);
 
     yield put(receiveFileOperationFinished());
-    if (payload.answer) {
-      yield put(fetchApplicationRelatedAttachments(payload.answer));
+    if (fileData.answer) {
+      yield put(fetchApplicationRelatedAttachments(fileData.answer));
     } else {
       yield put(fetchPendingUploads());
+    }
+
+    if (callback) {
+      callback(path, result.bodyAsJson);
     }
   } catch (e) {
     console.log(e);

--- a/src/plotApplications/types.js
+++ b/src/plotApplications/types.js
@@ -79,6 +79,7 @@ export type UploadedFileMeta = {
   field: number;
   created_at: string;
   answer: number | null;
+  path: string | null;
 };
 
 export type FetchAttributesAction = Action<'mvj/plotApplications/FETCH_ATTRIBUTES', void>;
@@ -132,7 +133,11 @@ export type FetchPendingUploadsAction = Action<'mvj/plotApplications/FETCH_PENDI
 export type ReceivePendingUploadsAction = Action<'mvj/plotApplications/RECEIVE_PENDING_UPLOADS', Object>;
 export type PendingUploadsNotFoundAction = Action<'mvj/plotApplications/PENDING_UPLOADS_NOT_FOUND', void>;
 export type DeleteUploadAction = Action<'mvj/plotApplications/DELETE_UPLOAD', Object>;
-export type UploadFileAction = Action<'mvj/plotApplications/UPLOAD_FILE', Object>;
+export type UploadFileAction = Action<'mvj/plotApplications/UPLOAD_FILE', {
+  fileData: Object,
+  callback?: (UploadedFileMeta) => void,
+  path: string
+}>;
 export type ReceiveFileOperationFinishedAction = Action<'mvj/plotApplications/RECEIVE_FILE_OPERATION_FINISHED', void>;
 
 export type FetchAttachmentAttributesAction = Action<'mvj/plotApplications/FETCH_ATTACHMENT_ATTRIBUTES', void>;


### PR DESCRIPTION
- The path parameter is now put into use now that it's exposed and set by the backend. The path defines the exact position the file is contained in in the answer data, which allows each occurrence of a certain field object to have unique file lists (i.e. two targets can have different reference attachments).
- Many quirks when the user aborts an edit of the application have been cleaned up. Files that are removed in the editor will now actually only be deleted when the edit is submitted, and newly uploaded files will also only be linked to the field during the save. Would-be linked files from applications that were never finished and submitted will also no longer show up the next time a new application editor (possibly for an unrelated set of targets) is opened.