### PR TITLE
Remove hardcoded values from lease statistic reports

### DIFF
--- a/src/leaseStatisticReport/components/LeaseInvoicingConfirmationReport.js
+++ b/src/leaseStatisticReport/components/LeaseInvoicingConfirmationReport.js
@@ -14,19 +14,22 @@ import FormText from '$components/form/FormText';
 import ExcelLink from '$components/excel/ExcelLink';
 import {
   getApiResponseResults,
-  formatDate,
-  formatNumber,
   hasPermissions,
   getLabelOfOption,
+  sortNumberByKeyAsc,
+  sortNumberByKeyDesc,
+  sortStringByKeyAsc,
+  sortStringByKeyDesc,
 } from '$util/helpers';
 import {
-  LeaseInvoicingReportPaths,
+  LeaseStatisticReportFormatOptions,
 } from '$src/leaseStatisticReport/enums';
 import {
+  getDisplayName,
+  getFormattedValue,
   getOutputFields,
-  getInvoiceState,
   getReportTypeOptions,
-} from '$src/leaseStatisticReport/helpers'; 
+} from '$src/leaseStatisticReport/helpers';
 import {getIsFetchingLeaseInvoicingConfirmationReport, getLeaseInvoicingConfirmationReport, getPayload} from '$src/leaseStatisticReport/selectors';
 import type {Attributes, Reports} from '$src/types';
 import type {LeaseInvoicingConfirmationReport as LeaseInvoicingConfirmationReportsType} from '$src/leaseStatisticReport/types';
@@ -81,66 +84,31 @@ class LeaseInvoicingConfirmationReport extends PureComponent<Props, State> {
 
     const columns = [];
     const outputFields = getOutputFields(reportOptions);
+
     outputFields.map(field => {
-      if(field.key === LeaseInvoicingReportPaths.SUPERVISION_DATE ||
-         field.key === LeaseInvoicingReportPaths.START_DATE ||
-         field.key === LeaseInvoicingReportPaths.END_DATE || 
-         field.key === LeaseInvoicingReportPaths.PAID_DATE || 
-         field.key === LeaseInvoicingReportPaths.DUE_DATE || 
-         field.key === LeaseInvoicingReportPaths.RETURNED_DATE || 
-         field.key === LeaseInvoicingReportPaths.SEND_DATE){
-        columns.push({
-          key: field.key,
-          text: field.label,
-          renderer: (date) => date
-            ? <FormText className='no-margin' style={{whiteSpace: 'nowrap'}}>{formatDate(date, 'dd.MM.yyyy')}</FormText> 
-            : <FormText className='no-margin' style={{whiteSpace: 'nowrap'}}>-</FormText>,
-        });
-      } else if (field.key === LeaseInvoicingReportPaths.AREA) {
-        columns.push({
-          key: field.key,
-          text: field.label,
-          sortable: false,
-          renderer: (area) => area
-            ? <FormText className='no-margin' style={{whiteSpace: 'nowrap'}}>{`${formatNumber(area)} m²`}</FormText> 
-            : <FormText className='no-margin' style={{whiteSpace: 'nowrap'}}>-</FormText>,
-        });
-      } else if(field.key === LeaseInvoicingReportPaths.LEASE_ID){
-        columns.push({
-          key: field.key,
-          text: field.label,
-          renderer: (identifier) => identifier
-            ? <FormText className='no-margin' style={{whiteSpace: 'nowrap'}}>{identifier}</FormText> 
-            : <FormText className='no-margin' style={{whiteSpace: 'nowrap'}}>-</FormText>,
-        });
-      } else if(field.key === LeaseInvoicingReportPaths.STATE){
-        columns.push({
-          key: field.key,
-          text: field.label,
-          renderer: (state) => state
-            ? <FormText className='no-margin' style={{whiteSpace: 'nowrap'}}>{getInvoiceState(state)}</FormText> 
-            : <FormText className='no-margin' style={{whiteSpace: 'nowrap'}}>-</FormText>,
-        });
-      } else if(field.key === LeaseInvoicingReportPaths.TOTAL_AMOUNT ||
-        field.key === LeaseInvoicingReportPaths.BILLED_AMOUNT ||
-        field.key === LeaseInvoicingReportPaths.OUTSTANDING_AMOUNT ||
-        field.key === LeaseInvoicingReportPaths.RENT ||
-        field.key === LeaseInvoicingReportPaths.PAID_AMOUNT) {
-        columns.push({
-          key: field.key,
-          text: field.label,
-          sortable: false,
-          renderer: (amount) => amount
-            ? <FormText className='no-margin' style={{whiteSpace: 'nowrap'}}>{`${formatNumber(amount)} €`}</FormText> 
-            : <FormText className='no-margin' style={{whiteSpace: 'nowrap'}}>-</FormText>,
-        });
-      } else {
-        columns.push({
-          key: field.key,
-          text: field.label,
-          sortable: false,
-        });
-      }
+      columns.push({
+        key: field.key,
+        text: field.label,
+        renderer: (value) => {
+          let isBold = false;
+          let outputValue = value || '-';
+
+          if (field.choices && value) {
+            outputValue = getDisplayName(field.choices, value);
+          } else if (field.format && value) {
+            outputValue = getFormattedValue(field.format, value);
+            isBold = field.format === LeaseStatisticReportFormatOptions.BOLD || field.format === LeaseStatisticReportFormatOptions.BOLD_MONEY;
+          }
+
+          return (
+            <FormText className='no-margin' style={{ whiteSpace: 'nowrap' }}>
+              {isBold ? <strong>{outputValue}</strong> : outputValue}
+            </FormText>
+          );
+        },
+        ascSortFunction: field.isNumeric ? sortNumberByKeyAsc : sortStringByKeyAsc,
+        descSortFunction: field.isNumeric ? sortNumberByKeyDesc : sortStringByKeyDesc,
+      });
     });
 
     return columns;

--- a/src/leaseStatisticReport/components/LeaseInvoicingConfirmationReport.js
+++ b/src/leaseStatisticReport/components/LeaseInvoicingConfirmationReport.js
@@ -153,11 +153,13 @@ class LeaseInvoicingConfirmationReport extends PureComponent<Props, State> {
       reportData,
       payload,
       reports,
+      reportOptions,
     } = this.props;
 
     const dev = false;
     const columns = this.getColumns();
     const reportTypeOptions = getReportTypeOptions(reports);
+    const isSortable = !reportOptions.is_already_sorted;
 
     if(isFetchingReportData) return <LoaderWrapper><Loader isLoading={true} /></LoaderWrapper>;
 
@@ -181,7 +183,7 @@ class LeaseInvoicingConfirmationReport extends PureComponent<Props, State> {
           style={{marginBottom: 10}}
           defaultSortKey='lease_id'
           defaultSortOrder={TableSortOrder.ASCENDING}
-          sortable={true}
+          sortable={isSortable}
         />
       </Fragment>
     );

--- a/src/leaseStatisticReport/enums.js
+++ b/src/leaseStatisticReport/enums.js
@@ -129,3 +129,18 @@ export const LeaseInvoicingReportTypes = {
   RENT_FORECAST: 'rent_forecast',
   LEASE_STATISTIC: 'lease_statistic',
 };
+
+/**
+ * Lease statistics report value format enumerable
+ * @readonly
+ * @enum {string}
+ */
+export const LeaseStatisticReportFormatOptions = {
+  AREA: 'area',
+  BOLD: 'bold',
+  BOLD_MONEY: 'bold_money',
+  BOOLEAN: 'boolean',
+  DATE: 'date',
+  MONEY: 'money',
+  PERCENTAGE: 'percentage',
+};

--- a/src/leaseStatisticReport/helpers.js
+++ b/src/leaseStatisticReport/helpers.js
@@ -133,6 +133,9 @@ export const getOutputFields = (options: Object): Array<Object> => {
       return {
         key: key,
         label: value.label,
+        choices: value.choices,
+        format: value.format,
+        isNumeric: value.is_numeric,
       };
     });
   else

--- a/src/leaseStatisticReport/helpers.js
+++ b/src/leaseStatisticReport/helpers.js
@@ -1,6 +1,14 @@
-import type {Reports} from '$src/types';
 import get from 'lodash/get';
 import format from 'date-fns/format';
+
+import {
+  formatDate,
+  formatNumber,
+} from '$util/helpers';
+import {
+  LeaseStatisticReportFormatOptions,
+} from '$src/leaseStatisticReport/enums';
+import type {Reports} from '$src/types';
 
 /**
  * Get report type options
@@ -53,23 +61,43 @@ export const getPayload = (query: string, url: string, reportType: string): Obje
 };
 
 /**
- * Get invoice state
- * @param {string} state
+ * Get display name from choices
+ * @param {Object[]} choices
+ * @param {string} value
+ * @return {string}
  */
-export const getInvoiceState = (state: string): string => {
-  switch(state) {
-    case 'open':
-      return 'Avoin';
-    case 'paid':
-      return 'Maksettu';
-    case 'refunded':
-      return 'Hyvitetty';
+export const getDisplayName = (choices: Array<Object>, value: string): string => {
+  let displayName = value;
+  const matchingName = choices.find((choice) => choice.value === value)?.display_name;
+  if (matchingName) {
+    displayName = matchingName;
+  }
+  return displayName;
+}
+
+/**
+ * Get formatted value
+ * @param {string} formatType
+ * @param {string} value
+ * @return {string}
+ */
+export const getFormattedValue = (formatType: string, value: string): string => {
+  switch (formatType) {
+    case LeaseStatisticReportFormatOptions.DATE:
+      return formatDate(value, 'dd.MM.yyyy');
+    case LeaseStatisticReportFormatOptions.MONEY:
+    case LeaseStatisticReportFormatOptions.BOLD_MONEY:
+      return `${formatNumber(value)} €`;
+    case LeaseStatisticReportFormatOptions.PERCENTAGE:
+      return `${formatNumber(value)} %`;
+    case LeaseStatisticReportFormatOptions.AREA:
+      return `${formatNumber(value)} m²`;
     default:
-      return state;
+      return value;
   }
 };
 
-/* 
+/*
 * Get fields
 * @param {object} options
 */
@@ -77,7 +105,7 @@ export const getFields = (options: Object): Array => {
   return get(options, 'actions.GET');
 };
 
-/* 
+/*
 * Get Query parameters
 * @param {object} formValues
 */
@@ -88,7 +116,7 @@ export const getQueryParams = (formValues: Object): Array => {
       if(key.includes('date')){
         query += `${key}=${format(value, 'yyyy-MM-dd')}&`;
       }
-      else 
+      else
         query += `${key}=${value}&`;
     });
   return query.slice(0, -1);

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -395,10 +395,14 @@ export const sortStringAsc = (a: ?string, b: ?string): number => {
  * @returns {number}
  */
 export const sortStringByKeyAsc = (a: Object, b: Object, key: string): number => {
-  const valA = (get(a, key) || '').toLowerCase();
-  const valB = (get(b, key) || '').toLowerCase();
+  const valA = (get(a, key) || '');
+  const valB = (get(b, key) || '');
 
-  return sortStringAsc(valA, valB);
+  // Check if the value is actually a string before trying to convert it to lowercase
+  const finalValA = String(valA) === valA ? valA.toLowerCase() : '';
+  const finalValB = String(valB) === valB ? valB.toLowerCase() : '';
+
+  return sortStringAsc(finalValA, finalValB);
 };
 
 /**
@@ -419,10 +423,14 @@ export const sortStringDesc = (a: ?string, b: ?string): number => {
  * @returns {number}
  */
 export const sortStringByKeyDesc = (a: Object, b: Object, key: string): number => {
-  const valA = (get(a, key) || '').toLowerCase();
-  const valB = (get(b, key) || '').toLowerCase();
+  const valA = (get(a, key) || '');
+  const valB = (get(b, key) || '');
 
-  return sortStringDesc(valA, valB);
+  // Check if the value is actually a string before trying to convert it to lowercase
+  const finalValA = String(valA) === valA ? valA.toLowerCase() : '';
+  const finalValB = String(valB) === valB ? valB.toLowerCase() : '';
+
+  return sortStringDesc(finalValA, finalValB);
 };
 
 /**


### PR DESCRIPTION
* Remove all hardcoded checks for different types of fields based on their name
* Use value formatting provided by the backend
* Use the correct table sort function based on the is_numeric boolean

Depends on https://github.com/City-of-Helsinki/mvj/pull/463 