### PR TITLE
Clean up code in plot searches and applications

### DIFF
--- a/src/components/search/SearchContainer.js
+++ b/src/components/search/SearchContainer.js
@@ -6,7 +6,10 @@ type Props = {
   onSubmit: Function,
 }
 
-const SearchContainer = ({children, onSubmit}: Props) => 
+const SearchContainer = ({children, onSubmit}: Props): React$Node =>
+  // TODO: determine which components actually have an use for onSubmit and consider
+  //  making it optional. Several search components seem to provide a function that
+  //  they themselves take as props, but then that prop is never defined itself.
   <form onSubmit={onSubmit} className='search__container'>{children}</form>;
 
 export default SearchContainer;

--- a/src/landUseContract/types.js
+++ b/src/landUseContract/types.js
@@ -15,7 +15,7 @@ export type LandUseContractState = {
 
 export type FetchSingleLandUseContractAfterEditPayload = {
   id: any,
-  callbackFuntions?: Array<Object | Function>,
+  callbackFunctions?: Array<Object | Function>,
 }
 
 export type InvoiceListMap = Object;

--- a/src/leases/components/leaseSections/leaseArea/CustomDetailedPlan.js
+++ b/src/leases/components/leaseSections/leaseArea/CustomDetailedPlan.js
@@ -45,7 +45,7 @@ const CustomDetailedPlan = ({
   attributes,
   customDetailedPlan,
 }: Props) => {
-  
+
   const stateOptions = getFieldOptions(attributes, LeaseAreaCustomDetailedPlanFieldPaths.STATE);
   const typeOptions = getFieldOptions(attributes, LeaseAreaCustomDetailedPlanFieldPaths.TYPE);
   const intendedUseOptions = getFieldOptions(attributes, LeaseAreaCustomDetailedPlanFieldPaths.INTENDED_USE);
@@ -196,7 +196,7 @@ const CustomDetailedPlan = ({
       </Fragment>
       }
       {/* Info Links (Lisätietolinkit) */}
-      {customDetailedPlan.info_links.length > 0 && 
+      {customDetailedPlan.info_links.length > 0 &&
       <Fragment>
         <SubTitle>
           {LeaseAreaCustomDetailedPlanFieldTitles.INFO_LINKS}
@@ -252,4 +252,4 @@ export default (flowRight(
       };
     }
   ),
-)(CustomDetailedPlan): React$AbstractComponent<OwnProps, mixed>);
+)(CustomDetailedPlan): React$ComponentType<OwnProps>);

--- a/src/leases/components/leaseSections/leaseArea/CustomDetailedPlanEdit.js
+++ b/src/leases/components/leaseSections/leaseArea/CustomDetailedPlanEdit.js
@@ -354,7 +354,7 @@ class CustomDetailedPlanEdit extends PureComponent<Props> {
               />
             </Authorization>
           </ActionButtonWrapper>
-          <Row> 
+          <Row>
             {/* Kohteen tunnus */}
             <Column small={12} medium={4} large={4}>
               <Authorization allow={isFieldAllowedToRead(attributes, LeaseAreaCustomDetailedPlanFieldPaths.IDENTIFIER)}>
@@ -589,4 +589,4 @@ export default (flowRight(
     destroyOnUnmount: false,
     change,
   }),
-)(CustomDetailedPlanEdit): React$AbstractComponent<OwnProps, mixed>);
+)(CustomDetailedPlanEdit): React$ComponentType<OwnProps>);

--- a/src/leases/components/leaseSections/leaseArea/LeaseArea.js
+++ b/src/leases/components/leaseSections/leaseArea/LeaseArea.js
@@ -353,7 +353,7 @@ const LeaseArea = ({
           </Column>
         </Row>
       </Authorization>
-      
+
       {/* Custom detailed plan (Oma muu alue) */}
       <Authorization allow={isFieldAllowedToRead(attributes, LeaseAreaCustomDetailedPlanFieldPaths.CUSTOM_DETAILED_PLAN)}>
         <Row>
@@ -407,4 +407,4 @@ export default (flowRight(
       receiveCollapseStates,
     }
   ),
-)(LeaseArea): React$AbstractComponent<Props, mixed>);
+)(LeaseArea): React$ComponentType<Props>);

--- a/src/leases/components/leaseSections/leaseArea/LeaseAreaEdit.js
+++ b/src/leases/components/leaseSections/leaseArea/LeaseAreaEdit.js
@@ -560,7 +560,7 @@ class LeaseAreaEdit extends PureComponent<Props> {
       usersPermissions,
       custom_detailed_plan,
     } = this.props;
-    
+
     const mapLinkUrl = this.getMapLinkUrl();
 
     return (
@@ -798,4 +798,4 @@ export default (flowRight(
       receiveCollapseStates,
     }
   ),
-)(LeaseAreaEdit): React$AbstractComponent<OwnProps, mixed>);
+)(LeaseAreaEdit): React$ComponentType<OwnProps>);

--- a/src/leases/types.js
+++ b/src/leases/types.js
@@ -34,7 +34,7 @@ export type CreateChargePayload = {
 
 export type FetchSingleLeaseAfterEditPayload = {
   leaseId: LeaseId,
-  callbackFuntions?: Array<Object | Function>,
+  callbackFunctions?: Array<Object | Function>,
 }
 
 export type SendEmailPayload = {

--- a/src/plotApplications/components/PlotApplicationSubsection.js
+++ b/src/plotApplications/components/PlotApplicationSubsection.js
@@ -377,7 +377,7 @@ const ApplicationFormSubsectionFieldArray = ({
 }: {
   fields: Fields,
   section: Object,
-  headerTag: string | React$AbstractComponent<{ children?: React$Node }, null>
+  headerTag: string | React$ComponentType<{ children?: React$Node }>
 }): React$Node => {
   return (
     <div className="ApplicationFormSubsectionFieldArray">
@@ -422,7 +422,7 @@ const PlotApplicationSubsection = ({
 }: {
   path: Array<string>,
   section: Object,
-  headerTag?: string | React$AbstractComponent<{ children?: React$Node }, null>,
+  headerTag?: string | React$ComponentType<{ children?: React$Node }>,
   parentApplicantType?: string | null
 }): React$Node => {
   if (!section.visible) {

--- a/src/plotApplications/components/PlotApplicationsListPage.js
+++ b/src/plotApplications/components/PlotApplicationsListPage.js
@@ -9,7 +9,7 @@ import type {ContextRouter} from 'react-router';
 import {Row, Column} from 'react-foundation';
 import {initialize} from 'redux-form';
 
-import Search from './search/Search';
+import Search from '$src/plotApplications/components/search/Search';
 import {receiveTopNavigationSettings} from '$components/topNavigation/actions';
 import {
   fetchPlotApplicationsList,

--- a/src/plotApplications/components/map/ApplicationListMap.js
+++ b/src/plotApplications/components/map/ApplicationListMap.js
@@ -6,7 +6,7 @@ import flowRight from 'lodash/flowRight';
 import isEmpty from 'lodash/isEmpty';
 
 import AreaNotesEditMap from '$src/areaNote/components/AreaNotesEditMap';
-import TargetListLayer from './TargetListLayer';
+import TargetListLayer from '$src/plotApplications/components/map/TargetListLayer';
 import {DEFAULT_ZOOM, MAP_COLORS} from '$src/constants';
 import {MAX_ZOOM_LEVEL_TO_FETCH_LEASES} from '$src/leases/constants';
 import {getApplicationTargetGeoJson} from '$src/plotApplications/helpers';

--- a/src/plotApplications/components/search/Search.js
+++ b/src/plotApplications/components/search/Search.js
@@ -464,4 +464,4 @@ export default (flowRight(
   reduxForm({
     form: formName,
   }),
-)(Search): React$AbstractComponent<OwnProps, mixed>);
+)(Search): React$ComponentType<OwnProps>);

--- a/src/plotApplications/constants.js
+++ b/src/plotApplications/constants.js
@@ -1,6 +1,6 @@
 // @flow
 import {TableSortOrder} from '$src/enums';
-import {ApplicantTypes} from './enums';
+import {ApplicantTypes} from '$src/plotApplications/enums';
 
 /**
  * Default plotApplications states value for plotSearch list search

--- a/src/plotSearch/actions.js
+++ b/src/plotSearch/actions.js
@@ -60,7 +60,7 @@ import type {
   FetchPlotSearchStagesAction,
   ReceivePlotSearchStagesAction,
   PlotSearchStagesNotFoundAction,
-} from './types';
+} from '$src/plotSearch/types';
 
 export const fetchAttributes = (): FetchAttributesAction =>
   createAction('mvj/plotSearch/FETCH_ATTRIBUTES')();

--- a/src/plotSearch/components/CreatePlotSearchForm.js
+++ b/src/plotSearch/components/CreatePlotSearchForm.js
@@ -16,11 +16,15 @@ import {PlotSearchFieldTitles} from '$src/plotSearch/enums';
 
 import type {Attributes} from '$src/types';
 
-type Props = {
-  attributes: Attributes,
-  change: Function,
+type OwnProps = {
   onClose: Function,
   onSubmit: Function,
+};
+
+type Props = {
+  ...OwnProps,
+  attributes: Attributes,
+  change: Function,
   valid: boolean,
   name: string,
 }
@@ -65,7 +69,7 @@ class CreatePlotSearchForm extends Component<Props> {
               fieldAttributes={get(attributes, 'name')}
               name='name'
               overrideValues={{
-                label: PlotSearchFieldTitles.NAME
+                label: PlotSearchFieldTitles.NAME,
               }}
             />
           </Column>
@@ -91,7 +95,7 @@ class CreatePlotSearchForm extends Component<Props> {
 const formName = FormNames.PLOT_SEARCH_CREATE;
 const selector = formValueSelector(formName);
 
-export default flowRight(
+export default (flowRight(
   connect(
     (state) => {
       return {
@@ -108,4 +112,4 @@ export default flowRight(
   reduxForm({
     form: formName,
   }),
-)(CreatePlotSearchForm);
+)(CreatePlotSearchForm): React$ComponentType<OwnProps>);

--- a/src/plotSearch/components/CreatePlotSearchModal.js
+++ b/src/plotSearch/components/CreatePlotSearchModal.js
@@ -1,7 +1,7 @@
 // @flow
 import React, {Component} from 'react';
 
-import CreatePlotSearchForm from './CreatePlotSearchForm';
+import CreatePlotSearchForm from '$src/plotSearch/components/CreatePlotSearchForm';
 import Modal from '$components/modal/Modal';
 
 
@@ -20,11 +20,11 @@ class CreatePlotSearchModal extends Component<Props> {
     }
   }
 
-  setRefForForm = (element: any) => {
+  setRefForForm: Function = (element: any): void => {
     this.form = element;
   }
 
-  render () {
+  render(): React$Node {
     const {
       isOpen,
       onClose,

--- a/src/plotSearch/components/PlotSearchListPage.js
+++ b/src/plotSearch/components/PlotSearchListPage.js
@@ -19,7 +19,7 @@ import MapIcon from '$components/icons/MapIcon';
 import PageContainer from '$components/content/PageContainer';
 import Pagination from '$components/table/Pagination';
 import {receiveTopNavigationSettings} from '$components/topNavigation/actions';
-import Search from './search/Search';
+import Search from '$src/plotSearch/components/search/Search';
 import {LIST_TABLE_PAGE_SIZE} from '$src/constants';
 import SortableTable from '$components/table/SortableTable';
 import TableFilters from '$components/table/TableFilters';
@@ -29,7 +29,7 @@ import TableIcon from '$components/icons/TableIcon';
 import type {UsersPermissions as UsersPermissionsType} from '$src/usersPermissions/types';
 import VisualisationTypeWrapper from '$components/table/VisualisationTypeWrapper';
 import {
-  createPlotSearch, 
+  createPlotSearch,
   fetchPlotSearchList,
 } from '$src/plotSearch/actions';
 import {
@@ -57,7 +57,7 @@ import {
   getContentPlotSearchListResults,
 } from '$src/plotSearch/helpers';
 import type {PlotSearch, PlotSearchList} from '$src/plotSearch/types';
-import CreatePlotSearchModal from './CreatePlotSearchModal';
+import CreatePlotSearchModal from '$src/plotSearch/components/CreatePlotSearchModal';
 import AddButtonSecondary from '$components/form/AddButtonSecondary';
 import {withPlotSearchAttributes} from '$components/attributes/PlotSearchAttributes';
 
@@ -73,7 +73,12 @@ const visualizationTypeOptions = [
   {value: VisualizationTypes.MAP, label: 'Kartta', icon: <MapIcon className='icon-medium' />},
 ];
 
+type OwnProps = {
+
+};
+
 type Props = {
+  ...OwnProps,
   history: Object,
   location: Object,
   createPlotSearch: Function,
@@ -158,7 +163,7 @@ class PlotSearchListPage extends PureComponent<Props, State> {
   }
 
   getColumns = () => {
-    const {plotSearchAttributes} = this.props;    
+    const {plotSearchAttributes} = this.props;
     const columns = [];
     const typeOptions = getFieldOptions(plotSearchAttributes, 'type');
     const subtypeOptions = getFieldOptions(plotSearchAttributes, 'subtype');
@@ -176,7 +181,7 @@ class PlotSearchListPage extends PureComponent<Props, State> {
       sortable: false,
       renderer: (val) => getLabelOfOption(typeOptions, val),
     });
-  
+
     columns.push({
       key: 'subtype',
       text: 'Haun alatyyppi',
@@ -192,33 +197,33 @@ class PlotSearchListPage extends PureComponent<Props, State> {
     });
 
     columns.push({
-      key: 'begin_at', 
-      text: 'Alkupvm', 
+      key: 'begin_at',
+      text: 'Alkupvm',
       sortable: false,
       renderer: (val) => formatDate(val),
     });
 
     columns.push({
-      key: 'end_at', 
-      text: 'Loppupvm', 
+      key: 'end_at',
+      text: 'Loppupvm',
       sortable: false,
       renderer: (val) => formatDate(val),
     });
-    
+
     columns.push({
-      key: 'latest_decicion', 
-      text: 'Viimeisin päätös', 
+      key: 'latest_decicion',
+      text: 'Viimeisin päätös',
       sortable: false,
-      renderer: (id) => id 
+      renderer: (id) => id
         ? <ExternalLink href={'/'} text={id}/> // getReferenceNumberLink(id)
         : null,
     });
-    
+
     columns.push({
-      key: 'id', 
-      text: 'Kohteen tunnus', 
+      key: 'id',
+      text: 'Kohteen tunnus',
       sortable: false,
-      renderer: (id) => id 
+      renderer: (id) => id
         ? <ExternalLink href={'/'} text={id}/> // getReferenceNumberLink(id)
         : null,
     });
@@ -234,7 +239,7 @@ class PlotSearchListPage extends PureComponent<Props, State> {
     if(page > 1) {
       searchQuery.offset = (page - 1) * LIST_TABLE_PAGE_SIZE;
     }
-    
+
     searchQuery.limit = LIST_TABLE_PAGE_SIZE;
     delete searchQuery.page;
 
@@ -301,7 +306,7 @@ class PlotSearchListPage extends PureComponent<Props, State> {
 
   handleSearchChange = (query: Object, resetActivePage?: boolean = true) => {
     const {history} = this.props;
-    
+
     if(resetActivePage) {
       this.setState({activePage: 1});
       delete query.page;
@@ -426,6 +431,7 @@ class PlotSearchListPage extends PureComponent<Props, State> {
               isSearchInitialized={isSearchInitialized}
               onSearch={this.handleSearchChange}
               states={selectedStates}
+              handleSubmit={() => {}}
             />
           </Column>
         </Row>
@@ -438,7 +444,7 @@ class PlotSearchListPage extends PureComponent<Props, State> {
               filterValue={plotSearchStates}
               onFilterChange={this.handlePlotSearchStatesChange}
             />
-            
+
           }
           visualizationComponent={
             <VisualisationTypeWrapper>
@@ -485,7 +491,7 @@ class PlotSearchListPage extends PureComponent<Props, State> {
   }
 }
 
-export default flowRight(
+export default (flowRight(
   withRouter,
   withPlotSearchAttributes,
   connect(
@@ -503,4 +509,4 @@ export default flowRight(
       fetchPlotSearchList,
     },
   ),
-)(PlotSearchListPage);
+)(PlotSearchListPage): React$ComponentType<OwnProps>);

--- a/src/plotSearch/components/PlotSearchPage.js
+++ b/src/plotSearch/components/PlotSearchPage.js
@@ -36,7 +36,7 @@ import {
   getIsFetchingAnyPlanUnits,
   getIsFetchingPlanUnitAttributes,
   areTargetsAllowedToHaveType, isLockedForModifications, isFetchingStages, getIsFetchingSubtypes,
-} from '../selectors';
+} from '$src/plotSearch/selectors';
 import {
   editPlotSearch,
   hideEditMode,
@@ -67,16 +67,21 @@ import {
   cleanDecisions,
 } from '$src/plotSearch/helpers';
 
-import PlotSearchInfo from './plotSearchSections/plotSearchInfo/PlotSearchInfo';
-import BasicInfo from './plotSearchSections/basicInfo/BasicInfo';
-import BasicInfoEdit from './plotSearchSections/basicInfo/BasicInfoEdit';
-import Application from './plotSearchSections/application/Application';
-import ApplicationEdit from './plotSearchSections/application/ApplicationEdit';
-import ApplicationMap from './plotSearchSections/map/ApplicationMap';
+import PlotSearchInfo from '$src/plotSearch/components/plotSearchSections/plotSearchInfo/PlotSearchInfo';
+import BasicInfo from '$src/plotSearch/components/plotSearchSections/basicInfo/BasicInfo';
+import BasicInfoEdit from '$src/plotSearch/components/plotSearchSections/basicInfo/BasicInfoEdit';
+import Application from '$src/plotSearch/components/plotSearchSections/application/Application';
+import ApplicationEdit from '$src/plotSearch/components/plotSearchSections/application/ApplicationEdit';
+import ApplicationMap from '$src/plotSearch/components/plotSearchSections/map/ApplicationMap';
 import {withPlotSearchAttributes} from '$components/attributes/PlotSearchAttributes';
-import {FIELDS_LOCKED_FOR_EDITING} from '../constants';
+import {FIELDS_LOCKED_FOR_EDITING} from '$src/plotSearch/constants';
+
+type OwnProps = {
+
+};
 
 type Props = {
+  ...OwnProps,
   applicationFormValues: Object,
   basicInformationFormValues: Object,
   currentPlotSearch: PlotSearch,
@@ -696,4 +701,4 @@ export default (flowRight(
       deletePlotSearch,
     }
   ),
-)(PlotSearchPage): React$AbstractComponent<Props, mixed>);
+)(PlotSearchPage): React$ComponentType<OwnProps>);

--- a/src/plotSearch/components/plotSearchSections/application/Application.js
+++ b/src/plotSearch/components/plotSearchSections/application/Application.js
@@ -9,33 +9,29 @@ import Divider from '$components/content/Divider';
 import Title from '$components/content/Title';
 import type {UsersPermissions as UsersPermissionsType} from '$src/usersPermissions/types';
 import {
-  getAttributes,
   getCollapseStateByKey,
-  getCurrentPlotSearch,
   getIsFetchingFormAttributes,
   getIsFetchingForm,
-  getFormAttributes,
   getForm,
-  getIsFetchingTemplateForms
+  getIsFetchingTemplateForms,
 } from '$src/plotSearch/selectors';
 import {receiveCollapseStates} from '$src/plotSearch/actions';
-import {getContentApplication} from '$src/plotSearch/helpers';
 import {ApplicationFieldTitles} from '$src/plotSearch/enums';
-import {
-  getFieldOptions,
-} from '$util/helpers';
+import ApplicationPreviewSection from '$src/plotSearch/components/plotSearchSections/application/ApplicationPreviewSection';
+import FormText from '$components/form/FormText';
 
-import type {Attributes} from '$src/types';
-import type {PlotSearch} from '$src/plotSearch/types';
-import ApplicationPreviewSection from "./ApplicationPreviewSection";
-import FormText from "../../../../components/form/FormText";
+type OwnProps = {
+
+};
 
 type Props = {
+  ...OwnProps,
   usersPermissions: UsersPermissionsType,
-  applicationCollapseState: Boolean,
+  applicationCollapseState: boolean,
   receiveCollapseStates: Function,
-  isFetchingFormAttributes: Boolean,
-  ifFetchingForm: Boolean,
+  isFetchingFormAttributes: boolean,
+  isFetchingForm: boolean,
+  isFetchingTemplateForms: boolean,
   form: Object,
 }
 
@@ -77,12 +73,12 @@ class Application extends PureComponent<Props, State> {
         </Title>
         <Divider />
         {form && form.sections.filter((section) => section.visible).map((section, index) =>
-            <ApplicationPreviewSection
-              section={section}
-              key={index}
-              handleToggle={() => this.handleBasicInfoCollapseToggle(index)}
-              defaultOpen={applicationCollapseState}
-            />
+          <ApplicationPreviewSection
+            section={section}
+            key={index}
+            handleToggle={() => this.handleBasicInfoCollapseToggle(index)}
+            defaultOpen={applicationCollapseState}
+          />
         )}
         {!form && <FormText>Hakemuslomaketta ei ole vielä määritetty.</FormText>}
       </Fragment>
@@ -90,7 +86,7 @@ class Application extends PureComponent<Props, State> {
   }
 }
 
-export default connect(
+export default (connect(
   (state) => {
     return {
       usersPermissions: getUsersPermissions(state),
@@ -104,4 +100,4 @@ export default connect(
   {
     receiveCollapseStates,
   }
-)(Application);
+)(Application): React$ComponentType<OwnProps>);

--- a/src/plotSearch/components/plotSearchSections/application/ApplicationEdit.js
+++ b/src/plotSearch/components/plotSearchSections/application/ApplicationEdit.js
@@ -20,7 +20,7 @@ import {FormNames, ViewModes} from '$src/enums';
 import FormField from '$components/form/FormField';
 import {
   receiveCollapseStates,
-  fetchFormAttributes
+  fetchFormAttributes,
 } from '$src/plotSearch/actions';
 import {
   getAttributes,
@@ -33,16 +33,22 @@ import {
   getCurrentPlotSearch,
   getForm,
   getIsFetchingFormAttributes,
-  isLockedForModifications
-} from '../../../selectors';
-import EditPlotApplicationSectionModal from './EditPlotApplicationSectionModal';
+  isLockedForModifications,
+} from '$src/plotSearch/selectors';
+import EditPlotApplicationSectionModal from '$src/plotSearch/components/plotSearchSections/application/EditPlotApplicationSectionModal';
 import type {Attributes} from '$src/types';
-import Loader from "../../../../components/loader/Loader";
-import ApplicationPreviewSection from "./ApplicationPreviewSection";
-import {hasMinimumRequiredFieldsFilled} from "../../../helpers";
-import WarningField from "../../../../components/form/WarningField";
+import Loader from '$components/loader/Loader';
+import ApplicationPreviewSection from '$src/plotSearch/components/plotSearchSections/application/ApplicationPreviewSection';
+import {hasMinimumRequiredFieldsFilled} from '$src/plotSearch/helpers';
+import WarningField from '$components/form/WarningField';
+import type {Form, PlotSearch} from '$src/plotSearch/types';
+
+type OwnProps = {
+
+};
 
 type Props = {
+  ...OwnProps,
   collapseStateBasic: boolean,
   receiveCollapseStates: Function,
   fetchFormAttributes: Function,
@@ -53,20 +59,30 @@ type Props = {
   attributes: Attributes,
   hasMinimumRequiredFieldsFilled: boolean,
   isFetchingFormAttributes: boolean,
-  isLockedForModifications: boolean
+  isLockedForModifications: boolean,
+  formAttributes: Attributes,
+  change: Function,
+  useExistingForm: '0' | '1',
+  templateForms: Object,
+  isFetchingTemplateForms: boolean,
+  currentPlotSearch: PlotSearch,
+  currentPlotSearchForm: Form,
+  formData: Object,
 }
 
 type State = {
   isModalOpen: boolean,
+  modalSectionIndex: number,
 }
 
 class ApplicationEdit extends PureComponent<Props, State> {
   state = {
     isModalOpen: false,
+    modalSectionIndex: 0,
   }
 
   componentDidMount() {
-    const { formAttributes, formData, fetchFormAttributes } = this.props;
+    const {formAttributes, formData, fetchFormAttributes} = this.props;
     if (!formAttributes && formData?.id) {
       fetchFormAttributes(formData?.id);
     }
@@ -89,22 +105,22 @@ class ApplicationEdit extends PureComponent<Props, State> {
   }
 
   loadTemplate = (newTemplateId) => {
-    const { templateForms, fetchFormAttributes, change } = this.props;
+    const {templateForms, fetchFormAttributes, change} = this.props;
 
     const template = templateForms.find((templateForm) => templateForm.id === newTemplateId);
     change('form', {
       ...template,
-      is_template: undefined
+      is_template: undefined,
     });
     fetchFormAttributes(template.id);
   };
 
   replaceTemplate = (useExisting) => {
-    const { currentPlotSearchForm, change } = this.props;
+    const {currentPlotSearchForm, change} = this.props;
 
     if (useExisting) {
       change('template', null);
-      change('form', { ...currentPlotSearchForm });
+      change('form', {...currentPlotSearchForm});
     } else {
       change('form', null);
     }
@@ -117,7 +133,7 @@ class ApplicationEdit extends PureComponent<Props, State> {
   openEditPlotApplicationSectionModal = (sectionIndex) => {
     this.setState({
       isModalOpen: true,
-      modalSectionIndex: sectionIndex
+      modalSectionIndex: sectionIndex,
     });
   }
 
@@ -134,7 +150,7 @@ class ApplicationEdit extends PureComponent<Props, State> {
       useExistingForm,
       hasMinimumRequiredFieldsFilled,
       isLockedForModifications,
-      change
+      change,
     } = this.props;
 
     const {
@@ -146,20 +162,20 @@ class ApplicationEdit extends PureComponent<Props, State> {
 
     const formOptions = templateForms?.map((templateForm) => ({
       value: templateForm.id,
-      label: templateForm.title
+      label: templateForm.title,
     })) || [];
 
     const formTemplateSelect = <FormField
       disableTouched={isSaveClicked}
       fieldAttributes={{
-        "type": "field",
-        "required": false,
-        "read_only": false,
-        "label": currentPlotSearch.form !== null ? "Korvaava lomakepohja" : "Lomakepohja"
+        'type': 'field',
+        'required': false,
+        'read_only': false,
+        'label': currentPlotSearch.form !== null ? 'Korvaava lomakepohja' : 'Lomakepohja',
       }}
       name={`template`}
       overrideValues={{
-        options: formOptions
+        options: formOptions,
       }}
       onChange={(_, newValue) => this.loadTemplate(newValue)}
       disabled={!hasMinimumRequiredFieldsFilled}
@@ -196,35 +212,35 @@ class ApplicationEdit extends PureComponent<Props, State> {
                         fieldAttributes={{
                           required: false,
                           read_only: false,
-                          label: "Lomakepohja",
-                          type: "radio-with-field",
-                          choices: []
+                          label: 'Lomakepohja',
+                          type: 'radio-with-field',
+                          choices: [],
                         }}
                         name={`useExistingForm`}
                         overrideValues={{
                           options: [
                             {
-                              label: "Käytä aiemmin tallennettua lomaketta",
-                              value: "1"
+                              label: 'Käytä aiemmin tallennettua lomaketta',
+                              value: '1',
                             },
                             {
-                              label: "Korvaa uudella lomakepohjalla",
-                              value: "0"
-                            }
-                          ]
+                              label: 'Korvaa uudella lomakepohjalla',
+                              value: '0',
+                            },
+                          ],
                         }}
                         onChange={(_, value) => this.replaceTemplate(value === '1')}
                         disabled={!hasMinimumRequiredFieldsFilled}
                       />
-                      {useExistingForm === "0" && formTemplateSelect}
+                      {useExistingForm === '0' && formTemplateSelect}
                     </> : <>
                       {formTemplateSelect}
                     </>}
                     <WarningField showWarning={formIdChanged} meta={{
-                      warning: "Lomakkeen kenttiä voi muokata vasta, kun lomakepohjan vaihto on vahvistettu tonttihaku tallentamalla."
+                      warning: 'Lomakkeen kenttiä voi muokata vasta, kun lomakepohjan vaihto on vahvistettu tonttihaku tallentamalla.',
                     }} />
                     <WarningField showWarning={!hasMinimumRequiredFieldsFilled} meta={{
-                      warning: "Ole hyvä ja täytä ensin pakolliset perustiedot."
+                      warning: 'Ole hyvä ja täytä ensin pakolliset perustiedot.',
                     }} />
                   </>}
                 </Column>
@@ -233,27 +249,27 @@ class ApplicationEdit extends PureComponent<Props, State> {
             {formData !== null && (!formAttributes
               ? <Loader isLoading={true} />
               : <>
-              <Collapse
-                defaultOpen={collapseStateBasic !== undefined ? collapseStateBasic : true}
-                hasErrors={isSaveClicked && !isEmpty(errors)}
-                headerTitle={ApplicationFieldTitles.APPLICATION}
-                onToggle={this.handleBasicInfoCollapseToggle}
-              >
-                <WhiteBox className='application__white-stripes'>
-                  <TitleH3>
-                    <FormField
-                      disableTouched={isSaveClicked}
-                      fieldAttributes={get(formAttributes, ApplicationFieldPaths.NAME)}
-                      name='form.title'
-                      overrideValues={{
-                        label: ApplicationFieldTitles.APPLICATION_NAME,
-                        allowEdit: !isLockedForModifications
-                      }}
-                      enableUiDataEdit
-                      uiDataKey={getUiDataLeaseKey(ApplicationFieldPaths.NAME)}
-                    />
-                  </TitleH3>
-                  {/* <FieldArray
+                <Collapse
+                  defaultOpen={collapseStateBasic !== undefined ? collapseStateBasic : true}
+                  hasErrors={isSaveClicked && !isEmpty(errors)}
+                  headerTitle={ApplicationFieldTitles.APPLICATION}
+                  onToggle={this.handleBasicInfoCollapseToggle}
+                >
+                  <WhiteBox className='application__white-stripes'>
+                    <TitleH3>
+                      <FormField
+                        disableTouched={isSaveClicked}
+                        fieldAttributes={get(formAttributes, ApplicationFieldPaths.NAME)}
+                        name='form.title'
+                        overrideValues={{
+                          label: ApplicationFieldTitles.APPLICATION_NAME,
+                          allowEdit: !isLockedForModifications,
+                        }}
+                        enableUiDataEdit
+                        uiDataKey={getUiDataLeaseKey(ApplicationFieldPaths.NAME)}
+                      />
+                    </TitleH3>
+                    {/* <FieldArray
                       component={renderApplicant}
                       disabled={false}
                       formName={FormNames.PLOT_SEARCH_APPLICATION}
@@ -268,13 +284,13 @@ class ApplicationEdit extends PureComponent<Props, State> {
                   </WhiteBox>
                 </Collapse>
                 {formData.sections.map((section, index) =>
-                    <ApplicationPreviewSection
-                      section={section}
-                      key={index}
-                      handleToggle={() => this.handleBasicInfoCollapseToggle(index)}
-                      openEditPlotApplicationSectionModal={() => this.openEditPlotApplicationSectionModal(index)}
-                      disabled={isReadOnly}
-                    />
+                  <ApplicationPreviewSection
+                    section={section}
+                    key={index}
+                    handleToggle={() => this.handleBasicInfoCollapseToggle(index)}
+                    openEditPlotApplicationSectionModal={() => this.openEditPlotApplicationSectionModal(index)}
+                    disabled={isReadOnly}
+                  />
                 )}
               </>)
             }
@@ -287,7 +303,7 @@ class ApplicationEdit extends PureComponent<Props, State> {
 
 const formName = FormNames.PLOT_SEARCH_APPLICATION;
 
-export default flowRight(
+export default (flowRight(
   connect(
     (state) => {
       return {
@@ -303,12 +319,12 @@ export default flowRight(
         currentPlotSearch: getCurrentPlotSearch(state),
         currentPlotSearchForm: getForm(state),
         hasMinimumRequiredFieldsFilled: hasMinimumRequiredFieldsFilled(state),
-        isLockedForModifications: isLockedForModifications(state)
+        isLockedForModifications: isLockedForModifications(state),
       };
     },
     {
       receiveCollapseStates,
-      fetchFormAttributes
+      fetchFormAttributes,
     }
   ),
   reduxForm({
@@ -317,6 +333,6 @@ export default flowRight(
   }),
   formValues({
     formData: 'form',
-    useExistingForm: 'useExistingForm'
+    useExistingForm: 'useExistingForm',
   })
-)(ApplicationEdit);
+)(ApplicationEdit): React$ComponentType<OwnProps>);

--- a/src/plotSearch/components/plotSearchSections/application/ApplicationPreviewSection.js
+++ b/src/plotSearch/components/plotSearchSections/application/ApplicationPreviewSection.js
@@ -1,35 +1,41 @@
 // @flow
 import React, {Fragment, PureComponent} from 'react';
 import {Row, Column} from 'react-foundation';
-import {reduxForm} from "redux-form";
-import flowRight from "lodash/flowRight";
-import get from "lodash/get";
+import {reduxForm} from 'redux-form';
+import flowRight from 'lodash/flowRight';
+import get from 'lodash/get';
 import classNames from 'classnames';
-import {connect} from "react-redux";
+import {connect} from 'react-redux';
 
-import {FormNames} from "$src/enums";
+import {FormNames} from '$src/enums';
 import SubTitle from '$components/content/SubTitle';
 import FormText from '$components/form/FormText';
 import FormTextTitle from '$components/form/FormTextTitle';
-import FormField from "$components/form/FormField";
-import FormHintText from "$components/form/FormHintText";
-import AddButtonThird from "$components/form/AddButtonThird";
-import Collapse from "$components/collapse/Collapse";
-import {getFormAttributes} from "../../../selectors";
-import Button from "../../../../components/button/Button";
-import {ButtonColors} from "../../../../components/enums";
+import FormField from '$components/form/FormField';
+import FormHintText from '$components/form/FormHintText';
+import AddButtonThird from '$components/form/AddButtonThird';
+import Collapse from '$components/collapse/Collapse';
+import {getFormAttributes} from '$src/plotSearch/selectors';
+import Button from '$components/button/Button';
+import {ButtonColors} from '$components/enums';
+import type {Attributes} from '$src/types';
+
+type OwnProps = {
+  section: Object,
+  handleToggle: Function,
+  defaultOpen?: boolean,
+  openEditPlotApplicationSectionModal?: Function,
+  disabled?: boolean,
+}
 
 type Props = {
-  section: Object,
-  handleToggle: function,
-  defaultOpen?: boolean,
-  openEditPlotApplicationSectionModal?: function,
-  disabled?: boolean
+  ...OwnProps,
+  attributes: Attributes,
 };
 
 class ApplicationPreviewSection extends PureComponent<Props> {
   static defaultProps = {
-    defaultOpen: true
+    defaultOpen: true,
   }
 
   renderSection = (section: Object, isFirstLevel: boolean) => {
@@ -64,13 +70,13 @@ class ApplicationPreviewSection extends PureComponent<Props> {
   }
 
   renderField = (field: Object) => {
-    const { attributes } = this.props;
+    const {attributes} = this.props;
     const fakeFieldId = `fakeField${field.id}`;
     let fieldSpecificComponents = [];
     let columnWidths = {
       small: 12,
       medium: 12,
-      large: 12
+      large: 12,
     };
 
     const typeMapping = get(attributes, 'sections.child.children.fields.child.children.type.choices');
@@ -79,32 +85,32 @@ class ApplicationPreviewSection extends PureComponent<Props> {
     switch (matchingType) {
       case 'checkbox':
         fieldSpecificComponents = <FormField name={fakeFieldId} fieldAttributes={{
-          type: "checkbox",
+          type: 'checkbox',
           required: false,
           read_only: false,
-          label: get(field, 'label')
+          label: get(field, 'label'),
         }} overrideValues={{
           options: get(field, 'choices')?.map((choice) => ({
             label: choice.has_text_input ? <>
               {choice.text}
-              { " " }
+              { ' ' }
               <FormField name={`${fakeFieldId}_input`} fieldAttributes={{
-                type: "string",
+                type: 'string',
                 required: false,
                 read_only: false,
-                label: ''
+                label: '',
               }} invisibleLabel disabled />
             </> : choice.text,
-            value: choice.value
-          }))
+            value: choice.value,
+          })),
         }} disabled />;
         break;
       case 'textarea':
         fieldSpecificComponents = <FormField name={fakeFieldId} fieldAttributes={{
-          type: "textarea",
+          type: 'textarea',
           required: false,
           read_only: false,
-          label: get(field, 'label')
+          label: get(field, 'label'),
         }} disabled />;
         break;
       case 'radiobutton':
@@ -113,10 +119,10 @@ class ApplicationPreviewSection extends PureComponent<Props> {
           <FormField
             name={fakeFieldId}
             fieldAttributes={{
-            type: "radio-with-field",
-            required: false,
-            read_only: false,
-            label: get(field, 'label')
+              type: 'radio-with-field',
+              required: false,
+              read_only: false,
+              label: get(field, 'label'),
             }}
             overrideValues={{
               options: get(field, 'choices')?.map((choice) => ({
@@ -124,13 +130,13 @@ class ApplicationPreviewSection extends PureComponent<Props> {
                 value: choice.value,
                 field: choice.has_text_input
                   ? <FormField name={`${fakeFieldId}_input`} fieldAttributes={{
-                      type: "string",
-                      required: false,
-                      read_only: false,
-                      label: ''
-                    }} invisibleLabel disabled />
-                  : null
-              }))
+                    type: 'string',
+                    required: false,
+                    read_only: false,
+                    label: '',
+                  }} invisibleLabel disabled />
+                  : null,
+              })),
             }}
             disabled
             className={field.type === 'radiobuttoninline' ? 'form-field__radio-button-inline' : ''}
@@ -139,30 +145,30 @@ class ApplicationPreviewSection extends PureComponent<Props> {
         break;
       case 'dropdown':
         fieldSpecificComponents = <FormField name={fakeFieldId} fieldAttributes={{
-          type: "choice",
+          type: 'choice',
           required: false,
           read_only: false,
           label: get(field, 'label'),
-          choices: []
+          choices: [],
         }} disabled />;
         break;
       case 'uploadfiles':
         fieldSpecificComponents = <>
           <FormTextTitle>{get(field, 'label')}</FormTextTitle>
-          <AddButtonThird label={"Liitä tiedosto"} onClick={() => {}} disabled />
+          <AddButtonThird label={'Liitä tiedosto'} onClick={() => {}} disabled />
         </>;
         break;
       case 'textbox':
         fieldSpecificComponents = <FormField name={fakeFieldId} fieldAttributes={{
-          type: "string",
+          type: 'string',
           required: false,
           read_only: false,
-          label: get(field, 'label')
+          label: get(field, 'label'),
         }} disabled />;
         columnWidths = {
           small: 6,
           medium: 4,
-          large: 3
+          large: 3,
         };
         break;
       default:
@@ -180,7 +186,7 @@ class ApplicationPreviewSection extends PureComponent<Props> {
   }
 
   render() {
-    const { section, handleToggle, defaultOpen, openEditPlotApplicationSectionModal, disabled } = this.props;
+    const {section, handleToggle, defaultOpen, openEditPlotApplicationSectionModal, disabled} = this.props;
 
     return <Row className='summary__content-wrapper'>
       <Column small={12} style={{marginTop: 15}}>
@@ -200,7 +206,7 @@ class ApplicationPreviewSection extends PureComponent<Props> {
         >
           {section.visible
             ? this.renderSection(section, true)
-            : <div style={{ marginBottom: 15 }}>
+            : <div style={{marginBottom: 15}}>
               <em>Osio on piilotettu kokonaisuudessaan.</em></div>}
         </Collapse>
       </Column>
@@ -208,15 +214,15 @@ class ApplicationPreviewSection extends PureComponent<Props> {
   }
 }
 
-export default flowRight(
+export default (flowRight(
   connect(
     (state) => {
       return {
-        attributes: getFormAttributes(state)
-      }
+        attributes: getFormAttributes(state),
+      };
     }
   ),
   reduxForm({
-    form: FormNames.PLOT_APPLICATION_PREVIEW
+    form: FormNames.PLOT_APPLICATION_PREVIEW,
   })
-)(ApplicationPreviewSection);
+)(ApplicationPreviewSection): React$ComponentType<OwnProps>);

--- a/src/plotSearch/components/plotSearchSections/application/EditPlotApplicationSectionForm.js
+++ b/src/plotSearch/components/plotSearchSections/application/EditPlotApplicationSectionForm.js
@@ -1,23 +1,24 @@
 // @flow
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import {formValueSelector, reduxForm, getFormValues} from 'redux-form';
 import {Row, Column} from 'react-foundation';
 import flowRight from 'lodash/flowRight';
 import get from 'lodash/get';
 import classNames from 'classnames';
-
 import {FieldArray} from 'redux-form';
+
 import Button from '$components/button/Button';
 import FormField from '$components/form/FormField';
 import ModalButtonWrapper from '$components/modal/ModalButtonWrapper';
 import {FormNames} from '$src/enums';
 import {ButtonColors} from '$components/enums';
 import {getFormAttributes} from '$src/plotSearch/selectors';
-import SectionField from './SectionField';
-import Collapse from "../../../../components/collapse/Collapse";
+import SectionField from '$src/plotSearch/components/plotSearchSections/application/SectionField';
+import Collapse from '$src/components/collapse/Collapse';
 import type {Attributes} from '$src/types';
-import SubTitle from "../../../../components/content/SubTitle";
+import SubTitle from '$src/components/content/SubTitle';
+import type {FormSection} from '$src/plotSearch/types';
 
 type SectionFieldProps = {
   disabled: boolean,
@@ -60,7 +61,7 @@ const EditPlotApplicationSectionFormSectionSubsections = ({
   form,
   attributes,
   level,
-  stagedSectionValues
+  stagedSectionValues,
 }: SectionSubsectionProps): React$Element<*> => {
   return fields.map(
     (ss, i) => <EditPlotApplicationSectionFormSubsection
@@ -71,17 +72,25 @@ const EditPlotApplicationSectionFormSectionSubsections = ({
       attributes={attributes}
       key={i}
     />);
-}
+};
 
 type SubsectionProps = {
   attributes: Attributes,
   level: number,
   sectionPath: string,
   form: string,
-  stagedSectionValues: Object
+  stagedSectionValues: Object,
 }
 
-const EditPlotApplicationSectionFormSubsectionFirstLevelWrapper = ({children, level}) => <div className={classNames(
+type SubsectionWrapperProps = {
+  level: number,
+  attributes: Attributes,
+  sectionPath: string,
+  subsection: FormSection,
+  children: React$Node,
+}
+
+const EditPlotApplicationSectionFormSubsectionFirstLevelWrapper = ({children, level}: SubsectionWrapperProps) => <div className={classNames(
   'edit-plot-application-section-form__section',
   `edit-plot-application-section-form__section--level-${level}`
 )}>{children}</div>;
@@ -91,8 +100,8 @@ const EditPlotApplicationSectionFormSubsectionSecondLevelWrapper = ({
   attributes,
   sectionPath,
   level,
-  subsection
-}) => <Collapse
+  subsection,
+}: SubsectionWrapperProps) => <Collapse
   defaultOpen
   headerTitle={subsection.title}
   headerExtras={<div className="edit-plot-application-section-form__subsection-header-options">
@@ -100,7 +109,7 @@ const EditPlotApplicationSectionFormSubsectionSecondLevelWrapper = ({
       fieldAttributes={get(attributes, 'sections.child.children.visible')}
       name={`${sectionPath}.visible`}
       overrideValues={{
-        label: 'Lohko käytössä'
+        label: 'Lohko käytössä',
       }}
       className="edit-plot-application-section-form__subsection-header-visible-field"
     />
@@ -112,9 +121,9 @@ const EditPlotApplicationSectionFormSubsectionSecondLevelWrapper = ({
         options: [
           {
             label: 'Monistettava lohko',
-            value: true
-          }
-        ]
+            value: true,
+          },
+        ],
       }}
       className="edit-plot-application-section-form__subsection-header-add-new-allowed-field"
       invisibleLabel
@@ -125,7 +134,7 @@ const EditPlotApplicationSectionFormSubsectionSecondLevelWrapper = ({
     `edit-plot-application-section-form__section--level-${level}`,
     {
       'collapse__secondary': level === 2,
-      'collapse__third': level > 2
+      'collapse__third': level > 2,
     }
   )}
 >{children}</Collapse>;
@@ -135,7 +144,7 @@ const EditPlotApplicationSectionFormSubsection: React$ComponentType<SubsectionPr
   level,
   form,
   attributes,
-  stagedSectionValues
+  stagedSectionValues,
 }: SubsectionProps) => {
   const subsection = get(stagedSectionValues, sectionPath);
 
@@ -160,15 +169,19 @@ const EditPlotApplicationSectionFormSubsection: React$ComponentType<SubsectionPr
       stagedSectionValues={stagedSectionValues}
     />
   </Wrapper>;
-}
+};
 
-type Props = {
-  attributes: Attributes,
+type OwnProps = {
   onClose: Function,
   onSubmit: Function,
+  sectionIndex: number,
+};
+
+type Props = {
+  ...OwnProps,
+  attributes: Attributes,
   valid: boolean,
   name: string,
-  sectionIndex: number,
   section: Object,
   parentFormSection: Object,
   initialize: Function,
@@ -193,11 +206,11 @@ class EditPlotApplicationSectionForm extends Component<Props> {
     const {
       sectionIndex,
       parentFormSection,
-      initialize
+      initialize,
     } = this.props;
     if (sectionIndex !== undefined) {
       initialize({
-        section: parentFormSection
+        section: parentFormSection,
       });
     }
   }
@@ -206,11 +219,11 @@ class EditPlotApplicationSectionForm extends Component<Props> {
     const {
       sectionIndex,
       parentFormSection,
-      initialize
+      initialize,
     } = this.props;
     if (sectionIndex !== prevProps.sectionIndex) {
       initialize({
-        section: parentFormSection
+        section: parentFormSection,
       });
     }
   }
@@ -219,7 +232,7 @@ class EditPlotApplicationSectionForm extends Component<Props> {
     const {
       onSubmit,
       onClose,
-      stagedSectionValues
+      stagedSectionValues,
     } = this.props;
     onSubmit(stagedSectionValues.section);
     onClose();
@@ -250,7 +263,7 @@ class EditPlotApplicationSectionForm extends Component<Props> {
               fieldAttributes={get(attributes, 'sections.child.children.visible')}
               name={'section.visible'}
               overrideValues={{
-                label: 'Osio käytössä'
+                label: 'Osio käytössä',
               }}
             />
           </Column>
@@ -259,7 +272,7 @@ class EditPlotApplicationSectionForm extends Component<Props> {
               fieldAttributes={get(attributes, 'sections.child.children.add_new_allowed')}
               name={'section.add_new_allowed'}
               overrideValues={{
-                label: 'Monistettava osio'
+                label: 'Monistettava osio',
               }}
             />
           </Column>
@@ -293,13 +306,13 @@ const parentSelector = formValueSelector(parentFormName);
 
 const formName = FormNames.PLOT_SEARCH_APPLICATION_SECTION_STAGING;
 
-export default flowRight(
+export default (flowRight(
   connect(
     (state, props: Props) => {
       return {
         attributes: getFormAttributes(state),
         parentFormSection: parentSelector(state, `form.sections[${props.sectionIndex}]`),
-        stagedSectionValues: getFormValues(formName)(state)
+        stagedSectionValues: getFormValues(formName)(state),
       };
     },
     null,
@@ -309,4 +322,4 @@ export default flowRight(
   reduxForm({
     form: formName,
   }),
-)(EditPlotApplicationSectionForm);
+)(EditPlotApplicationSectionForm): React$ComponentType<OwnProps>);

--- a/src/plotSearch/components/plotSearchSections/application/EditPlotApplicationSectionModal.js
+++ b/src/plotSearch/components/plotSearchSections/application/EditPlotApplicationSectionModal.js
@@ -2,12 +2,13 @@
 import React, {Component} from 'react';
 
 import Modal from '$components/modal/Modal';
-import EditPlotApplicationSectionForm from './EditPlotApplicationSectionForm';
+import EditPlotApplicationSectionForm from '$src/plotSearch/components/plotSearchSections/application/EditPlotApplicationSectionForm';
 
 type Props = {
   isOpen: boolean,
   onClose: Function,
   onSubmit: Function,
+  sectionIndex: number,
 }
 
 class EditPlotApplicationSectionModal extends Component<Props> {
@@ -19,16 +20,16 @@ class EditPlotApplicationSectionModal extends Component<Props> {
     }
   }
 
-  setRefForForm = (element: any) => {
+  setRefForForm: Function = (element: any): void => {
     this.form = element;
   }
 
-  render () {
+  render(): React$Node {
     const {
       isOpen,
       onClose,
       onSubmit,
-      ...rest
+      sectionIndex,
     } = this.props;
 
     return (
@@ -41,7 +42,7 @@ class EditPlotApplicationSectionModal extends Component<Props> {
           ref={this.setRefForForm}
           onClose={onClose}
           onSubmit={onSubmit}
-          {...rest}
+          sectionIndex={sectionIndex}
         />
       </Modal>
     );

--- a/src/plotSearch/components/plotSearchSections/application/SectionField.js
+++ b/src/plotSearch/components/plotSearchSections/application/SectionField.js
@@ -4,28 +4,28 @@ import {connect} from 'react-redux';
 import {Row, Column} from 'react-foundation';
 import get from 'lodash/get';
 
-import Authorization from '$components/authorization/Authorization';
 import FormField from '$components/form/FormField';
-import RemoveButton from '$components/form/RemoveButton';
 import {
   getFormAttributes,
 } from '$src/plotSearch/selectors';
 
 import type {Attributes} from '$src/types';
 
-type Props = {
+type OwnProps = {
+
   disabled: boolean,
   field: any,
-  formName: string,
+};
+
+type Props = {
+  ...OwnProps,
   attributes: Attributes,
-  onRemove: Function,
 }
 
 const SectionField = ({
   disabled,
   field,
   attributes,
-  change,
 }: Props) => {
   return (
     <Fragment>
@@ -35,17 +35,19 @@ const SectionField = ({
             fieldAttributes={get(attributes, 'sections.child.children.fields.child.children.enabled')}
             name={`${field}.enabled`}
             overrideValues={{
-              fieldType: 'checkbox'
+              fieldType: 'checkbox',
             }}
             invisibleLabel
+            disabled={disabled}
           />
           <FormField
             fieldAttributes={get(attributes, 'sections.child.children.fields.child.children.label')}
             name={`${field}.label`}
             overrideValues={{
-              allowEdit: false
+              allowEdit: false,
             }}
             invisibleLabel
+            disabled={disabled}
           />
         </Column>
         <Column large={3}>
@@ -57,12 +59,13 @@ const SectionField = ({
               options: [
                 {
                   label: 'Pakollinen tieto',
-                  value: true
-                }
-              ]
+                  value: true,
+                },
+              ],
             }}
             className="edit-plot-application-section-form__field-required-field"
             invisibleLabel
+            disabled={disabled}
           />
         </Column>
       </Row>
@@ -70,10 +73,10 @@ const SectionField = ({
   );
 };
 
-export default connect(
+export default (connect(
   (state) => {
     return {
       attributes: getFormAttributes(state),
     };
   }
-)(SectionField);
+)(SectionField): React$ComponentType<OwnProps>);

--- a/src/plotSearch/components/plotSearchSections/basicInfo/BasicInfo.js
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/BasicInfo.js
@@ -38,11 +38,11 @@ import {
   fetchPlanUnitAttributes,
   fetchCustomDetailedPlanAttributes,
 } from '$src/plotSearch/actions';
-import {getRouteById, Routes} from '../../../../root/routes';
-import PlotSearchTargetListing from './PlotSearchTargetListing';
+import {getRouteById, Routes} from '$src/root/routes';
+import PlotSearchTargetListing from '$src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchTargetListing';
 
 type OwnProps = {
-  
+
 }
 
 type Props = {
@@ -285,4 +285,4 @@ export default (connect(
     fetchCustomDetailedPlanAttributes,
     fetchPlanUnit,
   }
-)(BasicInfo): React$AbstractComponent<OwnProps, mixed>);
+)(BasicInfo): React$ComponentType<OwnProps>);

--- a/src/plotSearch/components/plotSearchSections/basicInfo/BasicInfoDecisionEdit.js
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/BasicInfoDecisionEdit.js
@@ -13,8 +13,8 @@ import {
 } from '$src/plotSearch/selectors';
 import type {Attributes} from '$src/types';
 import type {UsersPermissions as UsersPermissionsType} from '$src/usersPermissions/types';
-import DecisionSelectInput from '../../../../components/form/DecisionSelectInput';
-import {formatDecisionName} from '../../../helpers';
+import DecisionSelectInput from '$components/form/DecisionSelectInput';
+import {formatDecisionName} from '$src/plotSearch/helpers';
 
 type OwnProps = {
   disabled: boolean,
@@ -102,4 +102,4 @@ export default (connect(
       usersPermissions: getUsersPermissions(state),
     };
   },
-)(BasicInfoDecisionEdit): React$AbstractComponent<OwnProps, mixed>);
+)(BasicInfoDecisionEdit): React$ComponentType<OwnProps>);

--- a/src/plotSearch/components/plotSearchSections/basicInfo/BasicInfoEdit.js
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/BasicInfoEdit.js
@@ -11,8 +11,8 @@ import Authorization from '$components/authorization/Authorization';
 import {ConfirmationModalTexts, FieldTypes, FormNames, ViewModes} from '$src/enums';
 import {ActionTypes, AppConsumer} from '$src/app/AppContext';
 import AddButtonThird from '$components/form/AddButtonThird';
-import ErrorField from '../../../../components/form/ErrorField';
-import BasicInfoDecisionEdit from './BasicInfoDecisionEdit';
+import ErrorField from '$components/form/ErrorField';
+import BasicInfoDecisionEdit from '$src/plotSearch/components/plotSearchSections/basicInfo/BasicInfoDecisionEdit';
 import {ButtonColors} from '$components/enums';
 import Collapse from '$components/collapse/Collapse';
 import FormTextTitle from '$components/form/FormTextTitle';
@@ -49,13 +49,13 @@ import {
   filterSubTypes,
 } from '$src/plotSearch/helpers';
 
-import PlotSearchSiteEdit from './PlotSearchSiteEdit';
+import PlotSearchSiteEdit from '$src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSiteEdit';
 
 import type {Attributes} from '$src/types';
 import {hasMinimumRequiredFieldsFilled} from '$src/plotSearch/helpers';
 import WarningField from '$components/form/WarningField';
 import {getCurrentPlotSearch, getCurrentPlotSearchStage, getStages, isLockedForModifications} from '$src/plotSearch/selectors';
-import PlotSearchTargetListing from './PlotSearchTargetListing';
+import PlotSearchTargetListing from '$src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchTargetListing';
 import {AUTOMATIC_PLOT_SEARCH_STAGES} from '$src/plotSearch/constants';
 import {PlotSearchStageTypes} from '$src/plotSearch/enums';
 
@@ -635,4 +635,4 @@ export default (flowRight(
     destroyOnUnmount: false,
     change,
   }),
-)(BasicInfoEdit): React$AbstractComponent<OwnProps, mixed>);
+)(BasicInfoEdit): React$ComponentType<OwnProps>);

--- a/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSiteCustomDetailedPlan.js
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSiteCustomDetailedPlan.js
@@ -6,7 +6,7 @@ import {Row, Column} from 'react-foundation';
 import get from 'lodash/get';
 import {receiveCollapseStates} from '$src/plotSearch/actions';
 import {FormNames, ViewModes} from '$src/enums';
-import {Routes, getRouteById} from '../../../../root/routes';
+import {Routes, getRouteById} from '$src/root/routes';
 import Loader from '$components/loader/Loader';
 import LoaderWrapper from '$components/loader/LoaderWrapper';
 import Collapse from '$components/collapse/Collapse';
@@ -102,7 +102,7 @@ class PlotSearchSiteCustomDetailedPlan extends PureComponent<Props, State> {
             {isFetchingCustomDetailedPlanAttributes &&
               <LoaderWrapper className='relative-overlay-wrapper'><Loader isLoading={true} /></LoaderWrapper>
             }
-            {currentCustomDetailedPlan && 
+            {currentCustomDetailedPlan &&
             <Fragment>
               <Column small={6} medium={4} large={3}>
                 <FormTextTitle>
@@ -290,4 +290,4 @@ export default (connect(
   {
     receiveCollapseStates,
   }
-)(PlotSearchSiteCustomDetailedPlan): React$AbstractComponent<OwnProps, mixed>);
+)(PlotSearchSiteCustomDetailedPlan): React$ComponentType<OwnProps>);

--- a/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSiteEdit.js
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSiteEdit.js
@@ -58,9 +58,9 @@ import {
 } from '$src/plotSearch/selectors';
 import type {Attributes} from '$src/types';
 import type {UsersPermissions as UsersPermissionsType} from '$src/usersPermissions/types';
-import SuggestedEdit from './SuggestedEdit';
+import SuggestedEdit from '$src/plotSearch/components/plotSearchSections/basicInfo/SuggestedEdit';
 import RemoveButton from '$src/components/form/RemoveButton';
-import PlotSearchSiteEditCustomDetailedPlan from './PlotSearchSiteEditCustomDetailedPlan';
+import PlotSearchSiteEditCustomDetailedPlan from '$src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSiteEditCustomDetailedPlan';
 
 
 type SuggestedProps = {
@@ -465,16 +465,15 @@ class PlotSearchSiteEdit extends Component<Props, State> {
         planUnitNew: toPlotSearch,
         customDetailedPlanNew: null,
       });
- 
+
       fetchPlanUnit(toPlotSearch);
       this.changePlanUnitValue(toPlotSearch);
-      return;
     } else {
       this.setState({
         customDetailedPlanNew: toPlotSearch,
         planUnitNew: null,
       });
-      
+
       fetchCustomDetailedPlan(toPlotSearch);
       this.changeCustomDetailedPlanValue(toPlotSearch);
     }
@@ -602,7 +601,7 @@ class PlotSearchSiteEdit extends Component<Props, State> {
     const label = get(currentTarget, 'message_label');
 
     const planUnitTitle = get(planUnitNew, 'label') ? `${get(planUnitNew, 'label') || ''} ${get(planUnitByValue, 'plan_unit_status') || ''}` : 'Uusi kohde';
-    
+
     if (customDetailedPlanByValue) {
       return <PlotSearchSiteEditCustomDetailedPlan
         handleNew={this.handleNew}
@@ -860,4 +859,4 @@ export default (flowRight(
       fetchCustomDetailedPlan,
     }
   ),
-)(PlotSearchSiteEdit): React$AbstractComponent<OwnProps, mixed>);
+)(PlotSearchSiteEdit): React$ComponentType<OwnProps>);

--- a/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSiteEditCustomDetailedPlan.js
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSiteEditCustomDetailedPlan.js
@@ -277,4 +277,4 @@ class PlotSearchSiteEditCustomDetailedPlan extends Component<Props, State> {
   }
 }
 
-export default (PlotSearchSiteEditCustomDetailedPlan: React$AbstractComponent<Props, mixed>);
+export default (PlotSearchSiteEditCustomDetailedPlan: React$ComponentType<Props>);

--- a/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSitePlanUnit.js
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSitePlanUnit.js
@@ -15,7 +15,7 @@ import ExternalLink from '$components/links/ExternalLink';
 import WarningContainer from '$components/content/WarningContainer';
 import WarningField from '$components/form/WarningField';
 import {createPaikkatietovipunenUrl} from '$util/helpers';
-import {Routes, getRouteById} from '../../../../root/routes';
+import {Routes, getRouteById} from '$src/root/routes';
 import {
   formatDate,
   getFieldOptions,
@@ -344,4 +344,4 @@ export default (connect(
   {
     receiveCollapseStates,
   }
-)(PlotSearchSitePlanUnit): React$AbstractComponent<OwnProps, mixed>);
+)(PlotSearchSitePlanUnit): React$ComponentType<OwnProps>);

--- a/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchTargetListing.js
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchTargetListing.js
@@ -14,8 +14,8 @@ import WhiteBox from '$src/components/content/WhiteBox';
 import SubTitle from '$src/components/content/SubTitle';
 import {PlotSearchTargetType} from '$src/plotSearch/enums';
 import type {Attributes} from '$src/types';
-import PlotSearchSitePlanUnit from './PlotSearchSitePlanUnit';
-import PlotSearchSiteCustomDetailedPlan from './PlotSearchSiteCustomDetailedPlan';
+import PlotSearchSitePlanUnit from '$src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSitePlanUnit';
+import PlotSearchSiteCustomDetailedPlan from '$src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSiteCustomDetailedPlan';
 
 type OwnProps = {};
 type Props = {
@@ -44,7 +44,7 @@ const PlotSearchTargetListing = ({plotSearch, planUnitAttributes, customDetailed
           </SubTitle>
           {searchableTargets.map((target, index) =>
             <Row key={index}>
-              {target.plan_unit ? 
+              {target.plan_unit ?
                 <PlotSearchSitePlanUnit
                   plotSearchSite={target}
                   index={index}
@@ -68,7 +68,7 @@ const PlotSearchTargetListing = ({plotSearch, planUnitAttributes, customDetailed
           </SubTitle>
           {proceduralReservationTargets.map((target, index) =>
             <Row key={index}>
-              {target.plan_unit ? 
+              {target.plan_unit ?
                 <PlotSearchSitePlanUnit
                   plotSearchSite={target}
                   index={index}
@@ -92,7 +92,7 @@ const PlotSearchTargetListing = ({plotSearch, planUnitAttributes, customDetailed
           </SubTitle>
           {directReservationTargets.map((target, index) =>
             <Row key={index}>
-              {target.plan_unit ? 
+              {target.plan_unit ?
                 <PlotSearchSitePlanUnit
                   plotSearchSite={target}
                   index={index}
@@ -117,4 +117,4 @@ export default (connect((state) => ({
   plotSearch: getCurrentPlotSearch(state),
   planUnitAttributes: getPlanUnitAttributes(state),
   customDetailedPlanAttributes: getCustomDetailedPlanAttributes(state),
-}))(PlotSearchTargetListing): React$AbstractComponent<OwnProps, mixed>);
+}))(PlotSearchTargetListing): React$ComponentType<OwnProps>);

--- a/src/plotSearch/components/plotSearchSections/basicInfo/SuggestedEdit.js
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/SuggestedEdit.js
@@ -59,7 +59,7 @@ const SuggestedEdit = ({
           invisibleLabel
         />
       </Column>
-      <Column large={1.5}> 
+      <Column large={1.5}>
         <FormField
           disableTouched={isSaveClicked}
           fieldAttributes={get(attributes, 'plotSearch_sites.child.children.suggested.child.children.share_numerator')}
@@ -105,4 +105,4 @@ export default (connect(
       usersPermissions: getUsersPermissions(state),
     };
   },
-)(SuggestedEdit): React$AbstractComponent<OwnProps, mixed>);
+)(SuggestedEdit): React$ComponentType<OwnProps>);

--- a/src/plotSearch/components/plotSearchSections/map/ApplicationMap.js
+++ b/src/plotSearch/components/plotSearchSections/map/ApplicationMap.js
@@ -12,13 +12,17 @@ import {
   hasPermissions,
 } from '$util/helpers';
 import {getAreaNoteList} from '$src/areaNote/selectors';
-import {getAttributes as getRentBasisAttributes, getRentBasis} from '$src/rentbasis/selectors';
 import {getUsersPermissions} from '$src/usersPermissions/selectors';
 
 import type {AreaNoteList} from '$src/areaNote/types';
 import type {UsersPermissions as UsersPermissionsType} from '$src/usersPermissions/types';
 
+type OwnProps = {
+
+};
+
 type Props = {
+  ...OwnProps,
   areaNotes: AreaNoteList,
   fetchAreaNoteList: Function,
   usersPermissions: UsersPermissionsType,
@@ -66,13 +70,11 @@ class ApplicationMap extends Component<Props> {
   }
 }
 
-export default flowRight(
+export default (flowRight(
   connect(
     (state) => {
       return {
         areaNotes: getAreaNoteList(state),
-        rentBasis: getRentBasis(state),
-        rentBasisAttributes: getRentBasisAttributes(state),
         usersPermissions: getUsersPermissions(state),
       };
     },
@@ -80,4 +82,4 @@ export default flowRight(
       fetchAreaNoteList,
     }
   )
-)(ApplicationMap);
+)(ApplicationMap): React$ComponentType<OwnProps>);

--- a/src/plotSearch/components/plotSearchSections/plotSearchInfo/PlotSearchInfo.js
+++ b/src/plotSearch/components/plotSearchSections/plotSearchInfo/PlotSearchInfo.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import {connect} from 'react-redux';
 import {Row, Column} from 'react-foundation';
 
 type Props = {
@@ -9,7 +8,7 @@ type Props = {
 
 const PlotSearchInfo = ({
   title,
-}: Props) => {
+}: Props): React$Node => {
 
   return (
     <div className='lease-info'>
@@ -22,5 +21,4 @@ const PlotSearchInfo = ({
   );
 };
 
-export default connect(
-)(PlotSearchInfo);
+export default PlotSearchInfo;

--- a/src/plotSearch/components/search/Search.js
+++ b/src/plotSearch/components/search/Search.js
@@ -8,6 +8,7 @@ import debounce from 'lodash/debounce';
 import flowRight from 'lodash/flowRight';
 import isEqual from 'lodash/isEqual';
 import isEmpty from 'lodash/isEmpty';
+import type {ContextRouter} from 'react-router';
 
 import {getFieldOptions, getUrlParams} from '$util/helpers';
 import {getAttributes} from '$src/plotSearch/selectors';
@@ -26,16 +27,19 @@ import {
 
 import type {Attributes} from '$src/types';
 
-type Props = {
-  formValues: Object,
+type OwnProps = {|
   handleSubmit: Function,
   isSearchInitialized: boolean,
   onSearch: Function,
   states: Array<Object>,
+|}
+
+type Props = {
+  ...OwnProps,
+  ...ContextRouter,
+  formValues: Object,
   attributes: Attributes,
-  location: Object,
-  router: Object,
-}
+};
 
 type State = {
   isBasicSearch: boolean,
@@ -74,7 +78,8 @@ class Search extends Component<Props, State> {
 
     const keys = Object.keys(searchQuery);
 
-    if(!keys.length || (keys.length === 1 && Object.prototype.hasOwnProperty.call(searchQuery, 'search'))) {
+    // $FlowFixMe[method-unbinding] https://github.com/facebook/flow/issues/8689
+    if (!keys.length || (keys.length === 1 && Object.prototype.hasOwnProperty.call(searchQuery, 'search'))) {
       return true;
     }
 
@@ -277,7 +282,7 @@ class Search extends Component<Props, State> {
 
 const formName = FormNames.PLOT_SEARCH_SEARCH;
 
-export default flowRight(
+export default (flowRight(
   withRouter,
   connect(
     state => {
@@ -290,4 +295,4 @@ export default flowRight(
   reduxForm({
     form: formName,
   }),
-)(Search);
+)(Search): React$ComponentType<OwnProps>);

--- a/src/plotSearch/constants.js
+++ b/src/plotSearch/constants.js
@@ -1,6 +1,6 @@
 // @flow
 import {TableSortOrder} from '$src/enums';
-import {PlotSearchStageTypes} from './enums';
+import {PlotSearchStageTypes} from '$src/plotSearch/enums';
 
 /**
  * Default plotSearch states value for plotSearch list search

--- a/src/plotSearch/helpers.js
+++ b/src/plotSearch/helpers.js
@@ -3,16 +3,16 @@ import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 
 import {getContentUser} from '$src/users/helpers';
-import type {PlotSearch, Form, PlotSearchState} from './types';
+import type {PlotSearch, Form, PlotSearchState} from '$src/plotSearch/types';
 import {removeSessionStorageItem} from '$util/storage';
 import {FormNames} from '$src/enums';
 import {
   getApiResponseResults,
 } from '$util/helpers';
-import {formatDate} from '../util/helpers';
+import {formatDate} from '$util/helpers';
 import {formValueSelector} from 'redux-form';
-import {PlotSearchTargetType, TargetIdentifierTypes} from './enums';
-import type {Attributes} from '../types';
+import {PlotSearchTargetType, TargetIdentifierTypes} from '$src/plotSearch/enums';
+import type {Attributes} from '$src/types';
 
 /**
  * Get plotSearch basic information content

--- a/src/plotSearch/reducer.js
+++ b/src/plotSearch/reducer.js
@@ -28,8 +28,8 @@ import type {
   RemovePlanUnitDecisionsAction,
   ReceiveSingleCustomDetailedPlanAction,
   PlotSearchState,
-} from './types';
-import {annotatePlanUnitDecision} from './helpers';
+} from '$src/plotSearch/types';
+import {annotatePlanUnitDecision} from '$src/plotSearch/helpers';
 
 const attributesReducer: Reducer<Attributes> = handleActions({
   ['mvj/plotSearch/RECEIVE_ATTRIBUTES']: (state: Attributes, {payload: attributes}: ReceiveAttributesAction) => {

--- a/src/plotSearch/requests.js
+++ b/src/plotSearch/requests.js
@@ -1,6 +1,6 @@
 // @flow
-import callApi from '../api/callApi';
-import createUrl from '../api/createUrl';
+import callApi from '$src/api/callApi';
+import createUrl from '$src/api/createUrl';
 
 import type {PlotSearch} from '$src/plotSearch/types';
 
@@ -64,12 +64,12 @@ export const fetchTemplateFormsRequest = (): Generator<any, any, any> => {
   })));
 };
 
-export const fetchFormRequest = (id: any): Generator<any, any, any> => {
+export const fetchFormRequest = (id: number): Generator<any, any, any> => {
   return callApi(new Request(createUrl(`form/${id}/`)));
 };
 
-export const fetchFormAttributesRequest = (id: any): Generator<any, any, any> => {
-  return callApi(new Request(createUrl(`form/${id}/`), {method: 'OPTIONS'}));
+export const fetchFormAttributesRequest = (): Generator<any, any, any> => {
+  return callApi(new Request(createUrl(`form/1/`), {method: 'OPTIONS'}));
 };
 
 export const editFormRequest = (form: Object): Generator<any, any, any> => {
@@ -81,4 +81,10 @@ export const editFormRequest = (form: Object): Generator<any, any, any> => {
 
 export const fetchStagesRequest = (params: ?Object): Generator<any, any, any> => {
   return callApi(new Request(createUrl('plot_search_stage/', params)));
+};
+
+export const fetchPlotSearchApplicationsRequest = (id: number): Generator<any, any, any> => {
+  return callApi(new Request(createUrl('answer/', {
+    plot_search_id: id,
+  })));
 };

--- a/src/plotSearch/saga.js
+++ b/src/plotSearch/saga.js
@@ -39,7 +39,7 @@ import {
   receiveStages,
   stagesNotFound,
   fetchStages,
-} from './actions';
+} from '$src/plotSearch/actions';
 import {receiveError} from '$src/api/actions';
 import {getRouteById, Routes} from '$src/root/routes';
 
@@ -60,7 +60,7 @@ import {
   fetchTemplateFormsRequest,
   editFormRequest,
   fetchStagesRequest,
-} from './requests';
+} from '$src/plotSearch/requests';
 
 function* fetchAttributesSaga(): Generator<any, any, any> {
   try {

--- a/src/plotSearch/selectors.js
+++ b/src/plotSearch/selectors.js
@@ -2,7 +2,7 @@
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 
-import type {Attributes, Selector, Methods} from '../types';
+import type {Attributes, Selector, Methods} from '$src/types';
 import type {RootState} from '$src/root/types';
 
 import type {
@@ -10,10 +10,10 @@ import type {
   PlotSearchList,
   PlanUnit,
   CustomDetailedPlan,
-} from './types';
+} from '$src/plotSearch/types';
 import {formValueSelector} from 'redux-form';
-import {FormNames} from '../enums';
-import {PlotSearchStageTypes} from './enums';
+import {FormNames} from '$src/enums';
+import {PlotSearchStageTypes} from '$src/plotSearch/enums';
 
 export const getAttributes: Selector<Attributes, void> = (state: RootState): Attributes =>
   state.plotSearch.attributes;

--- a/src/plotSearch/spec.js
+++ b/src/plotSearch/spec.js
@@ -39,17 +39,17 @@ import {
   addPlanUnitDecisions,
   resetPlanUnitDecisions,
   receiveFormAttributes,
-} from './actions';
+} from '$src/plotSearch/actions';
 
-import mockData from './mock-data.json';
-import mockAttributes from './attributes-mock-data.json';
-import mockFormAttributes from './form-attributes-mock-data.json';
+import mockData from '$src/plotSearch/mock-data.json';
+import mockAttributes from '$src/plotSearch/attributes-mock-data.json';
+import mockFormAttributes from '$src/plotSearch/form-attributes-mock-data.json';
 
-import plotSearchReducer from './reducer';
+import plotSearchReducer from '$src/plotSearch/reducer';
 
-import type {PlotSearchState} from './types';
-import {isLockedForModifications} from './selectors';
-import {getTestRootState} from '../util/testUtil';
+import type {PlotSearchState} from '$src/plotSearch/types';
+import {isLockedForModifications} from '$src/plotSearch/selectors';
+import {getTestRootState} from '$util/testUtil';
 
 const mockForm = mockData[0].form;
 

--- a/src/plotSearch/types.js
+++ b/src/plotSearch/types.js
@@ -1,5 +1,5 @@
 // @flow
-import type {Action, Attributes, Methods} from '../types';
+import type {Action, Attributes, Methods} from '$src/types';
 
 export type PlotSearchState = {
   attributes: Attributes,
@@ -88,7 +88,7 @@ export type FormFieldChoice = {
 
 export type FetchSinglePlotSearchAfterEditPayload = {
   id: any,
-  callbackFuntions?: Array<Object | Function>,
+  callbackFunctions?: Array<Object | Function>,
 }
 
 export type FetchAttributesAction = Action<'mvj/plotSearch/FETCH_ATTRIBUTES', void>;

--- a/src/util/storage.js
+++ b/src/util/storage.js
@@ -7,7 +7,7 @@ import isString from 'lodash/isString';
  * @param {string} key
  * @returns {*}
  */
-export const getStorageItem = (key: string) => {
+export const getStorageItem = (key: string): string | null => {
   const [root, ...rest] = key.split('.');
   const item = localStorage.getItem(buildStorageKey(root)) || '';
   const value = isJson(item) ? JSON.parse(item) : item;
@@ -116,7 +116,7 @@ const isJson = (value: any) => {
  * Get redirect address stored to session storage
  * @returns {string}
  */
-export const getRedirectUrlFromSessionStorage = () => {
+export const getRedirectUrlFromSessionStorage = (): any => {
   return getSessionStorageItem('redirectURL');
 };
 


### PR DESCRIPTION
- Fix all found Flow errors
- Fix all found eslint errors
- Convert remaining relative imports to absolute ones
- Replace remaining React$AbstractComponents with React$ComponentTypes

----

I thought it'd be better to separate these into their own PR so that if you happen to return to work on this UI before I have any actually complete other features to throw in, these fixes can already be used as a foundation for both.