### PR TITLE
Fix hint text tooltip cutting off in some cases

### DIFF
--- a/src/plotSearch/components/plotSearchSections/application/_application.scss
+++ b/src/plotSearch/components/plotSearchSections/application/_application.scss
@@ -91,6 +91,10 @@
     margin-bottom: rem-calc(8px);
   }
 
+  .collapse.collapse__third.open:not(.is-expanding) > .collapse__content {
+    overflow: visible !important;
+  }
+
   .collapse.collapse__third .edit-plot-application-form__section-fields-container {
     margin-bottom: 0;
   }


### PR DESCRIPTION
If the first field of a second-level subsection (e.g. company details) was considered to open upwards towards the section header, it would get cut off. This change makes it visible in that uncommon case as well.