### PR TITLE
Fix problem editing rent adjustments

### DIFF
--- a/src/leases/components/leaseSections/rent/RentAdjustmentEdit.js
+++ b/src/leases/components/leaseSections/rent/RentAdjustmentEdit.js
@@ -40,6 +40,7 @@ import {
   calculateReLeaseDiscountPercent,
   calculateRentAdjustmentSubventionPercentCumulative,
   getDecisionById,
+  hasSubventionDataChanged,
 } from '$src/leases/helpers';
 import {getUiDataLeaseKey} from '$src/uiData/helpers';
 import {
@@ -270,11 +271,7 @@ class RentAdjustmentsEdit extends PureComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if(this.props.subventionType !== prevProps.subventionType ||
-      this.props.subventionBasePercent !== prevProps.subventionBasePercent ||
-      this.props.subventionGraduatedPercent !== prevProps.subventionGraduatedPercent ||
-      this.props.managementSubventions !== prevProps.managementSubventions ||
-      this.props.temporarySubventions !== prevProps.temporarySubventions) {
+    if (typeof this.props !== "undefined" && hasSubventionDataChanged(prevProps, this.props)) {
       const {change, field} = this.props;
 
       change(formName, `${field}.full_amount`, formatNumber(this.calculateTotalSubventionPercent())); // TODO 

--- a/src/leases/components/leaseSections/rent/RentAdjustmentEdit.js
+++ b/src/leases/components/leaseSections/rent/RentAdjustmentEdit.js
@@ -41,6 +41,7 @@ import {
   calculateRentAdjustmentSubventionPercentCumulative,
   getDecisionById,
   hasSubventionDataChanged,
+  hasSubventionValues,
 } from '$src/leases/helpers';
 import {getUiDataLeaseKey} from '$src/uiData/helpers';
 import {
@@ -265,9 +266,21 @@ class RentAdjustmentsEdit extends PureComponent<Props> {
 
   componentDidUpdate(prevProps: Props) {
     if (this.props && hasSubventionDataChanged(prevProps, this.props)) {
-      const {change, field} = this.props;
+      const {
+        change,
+        field,
+        fullAmount,
+        managementSubventions,
+        temporarySubventions
+      } = this.props;
+
+      let newFullAmount = fullAmount
+
+      if (hasSubventionValues(managementSubventions, temporarySubventions)) {
+        newFullAmount = this.calculateTotalSubventionPercent()
+      }
       
-      change(formName, `${field}.full_amount`, formatNumber(this.calculateTotalSubventionPercent())); // TODO 
+      change(formName, `${field}.full_amount`, formatNumber(newFullAmount)); // TODO 
     }
   }
 

--- a/src/leases/components/leaseSections/rent/RentAdjustmentEdit.js
+++ b/src/leases/components/leaseSections/rent/RentAdjustmentEdit.js
@@ -261,19 +261,12 @@ type Props = {
   usersPermissions: UsersPermissionsType,
 }
 
-type State = {
-  showSubventions: boolean,
-}
-
-class RentAdjustmentsEdit extends PureComponent<Props, State> {
-  state = {
-    showSubventions: this.props.subventionType ? true : false,
-  }
+class RentAdjustmentsEdit extends PureComponent<Props> {
 
   componentDidUpdate(prevProps: Props) {
-    if (typeof this.props !== "undefined" && hasSubventionDataChanged(prevProps, this.props)) {
+    if (this.props && hasSubventionDataChanged(prevProps, this.props)) {
       const {change, field} = this.props;
-
+      
       change(formName, `${field}.full_amount`, formatNumber(this.calculateTotalSubventionPercent())); // TODO 
     }
   }
@@ -296,7 +289,10 @@ class RentAdjustmentsEdit extends PureComponent<Props, State> {
   };
 
   handleAddSubventions = () => {
-    this.setState({showSubventions: true});
+    const {change, field} = this.props;
+
+    // To make the subvention form visible: null => ""
+    change(formName, `${field}.subvention_type`, "");
   }
 
   handleRemoveSubventions = () => {
@@ -304,9 +300,7 @@ class RentAdjustmentsEdit extends PureComponent<Props, State> {
 
     change(formName, `${field}.subvention_type`, null);
     change(formName, `${field}.management_subventions`, []);
-    change(formName, `${field}.temporary_subventions`, []);
-    
-    this.setState({showSubventions: false});
+    change(formName, `${field}.temporary_subventions`, []);    
   }
 
   calculateReLeaseDiscountPercent = () => {
@@ -338,7 +332,7 @@ class RentAdjustmentsEdit extends PureComponent<Props, State> {
       type,
       usersPermissions,
     } = this.props;
-    const {showSubventions} = this.state;
+    const showSubventions = typeof subventionType === "string"
     const totalSubventionPercent = this.calculateTotalSubventionPercent();
 
     return (

--- a/src/leases/helpers.js
+++ b/src/leases/helpers.js
@@ -1079,6 +1079,55 @@ export const getContentEqualizedRents = (rent: Object): Array<Object> =>
     });
 
 /**
+ * Check if subvention data has changed for rent adjustments.
+ * If current props are undefined, they are not considered changed.
+ * @param {Object} props
+ * @param {Object} prevProps
+ * @return {boolean}
+ */
+export const hasSubventionDataChanged = (prevProps: Object, props: Object): boolean => {
+  const {
+      subventionType,
+      subventionBasePercent,
+      subventionGraduatedPercent,
+      managementSubventions,
+      temporarySubventions,
+  } = props
+  
+  if (
+      typeof subventionType === "undefined" ||
+      typeof subventionBasePercent === "undefined" ||
+      typeof subventionGraduatedPercent === "undefined" ||
+      typeof managementSubventions === "undefined" ||
+      typeof temporarySubventions === "undefined"
+  ) {
+      return false
+  }
+  
+  const {
+      subventionType: prevSubventionType = null,
+      subventionBasePercent: prevSubventionBasePercent = null,
+      subventionGraduatedPercent: prevSubventionGraduatedPercent = null,
+      managementSubventions: prevManagementSubventions = null,
+      temporarySubventions: prevTemporarySubventions = null,
+  } = prevProps
+
+  if (
+      subventionType !== prevSubventionType ||
+      subventionBasePercent !== prevSubventionBasePercent ||
+      subventionGraduatedPercent !== prevSubventionGraduatedPercent ||
+      managementSubventions !== prevManagementSubventions ||
+      temporarySubventions !== prevTemporarySubventions
+  ) {
+      return true
+
+  } else {
+      return false
+
+  }
+};
+
+/**
  * Calculate re-lease discount percent for rent adjustment subvention
  * @param {string} subventionBasePercent
  * @param {string} subventionGraduatedPercent

--- a/src/leases/helpers.js
+++ b/src/leases/helpers.js
@@ -1081,28 +1081,18 @@ export const getContentEqualizedRents = (rent: Object): Array<Object> =>
 /**
  * Check if subvention data has changed for rent adjustments.
  * If current props are undefined, they are not considered changed.
- * @param {Object} props
  * @param {Object} prevProps
+ * @param {Object} props
  * @return {boolean}
  */
 export const hasSubventionDataChanged = (prevProps: Object, props: Object): boolean => {
   const {
-      subventionType,
-      subventionBasePercent,
-      subventionGraduatedPercent,
-      managementSubventions,
-      temporarySubventions,
-  } = props
-  
-  if (
-      typeof subventionType === "undefined" ||
-      typeof subventionBasePercent === "undefined" ||
-      typeof subventionGraduatedPercent === "undefined" ||
-      typeof managementSubventions === "undefined" ||
-      typeof temporarySubventions === "undefined"
-  ) {
-      return false
-  }
+      subventionType = null,
+      subventionBasePercent = null,
+      subventionGraduatedPercent = null,
+      managementSubventions = null,
+      temporarySubventions = null,
+  } = props;
   
   const {
       subventionType: prevSubventionType = null,
@@ -1110,21 +1100,13 @@ export const hasSubventionDataChanged = (prevProps: Object, props: Object): bool
       subventionGraduatedPercent: prevSubventionGraduatedPercent = null,
       managementSubventions: prevManagementSubventions = null,
       temporarySubventions: prevTemporarySubventions = null,
-  } = prevProps
+  } = prevProps;
 
-  if (
-      subventionType !== prevSubventionType ||
+  return subventionType !== prevSubventionType ||
       subventionBasePercent !== prevSubventionBasePercent ||
       subventionGraduatedPercent !== prevSubventionGraduatedPercent ||
       managementSubventions !== prevManagementSubventions ||
-      temporarySubventions !== prevTemporarySubventions
-  ) {
-      return true
-
-  } else {
-      return false
-
-  }
+      temporarySubventions !== prevTemporarySubventions;
 };
 
 /**

--- a/src/leases/helpers.js
+++ b/src/leases/helpers.js
@@ -1086,27 +1086,21 @@ export const getContentEqualizedRents = (rent: Object): Array<Object> =>
  * @return {boolean}
  */
 export const hasSubventionDataChanged = (prevProps: Object, props: Object): boolean => {
-  const {
-      subventionType = null,
-      subventionBasePercent = null,
-      subventionGraduatedPercent = null,
-      managementSubventions = null,
-      temporarySubventions = null,
-  } = props;
+  if (
+    typeof props.subventionType === "undefined" ||
+    typeof props.subventionBasePercent === "undefined" ||
+    typeof props.subventionGraduatedPercent === "undefined" ||
+    typeof props.managementSubventions === "undefined" ||
+    typeof props.temporarySubventions === "undefined"
+  ) {
+    return false
+  }
   
-  const {
-      subventionType: prevSubventionType = null,
-      subventionBasePercent: prevSubventionBasePercent = null,
-      subventionGraduatedPercent: prevSubventionGraduatedPercent = null,
-      managementSubventions: prevManagementSubventions = null,
-      temporarySubventions: prevTemporarySubventions = null,
-  } = prevProps;
-
-  return subventionType !== prevSubventionType ||
-      subventionBasePercent !== prevSubventionBasePercent ||
-      subventionGraduatedPercent !== prevSubventionGraduatedPercent ||
-      managementSubventions !== prevManagementSubventions ||
-      temporarySubventions !== prevTemporarySubventions;
+  return props.subventionType !== prevProps.subventionType ||
+      props.subventionBasePercent !== prevProps.subventionBasePercent ||
+      props.subventionGraduatedPercent !== prevProps.subventionGraduatedPercent ||
+      props.managementSubventions !== prevProps.managementSubventions ||
+      props.temporarySubventions !== prevProps.temporarySubventions
 };
 
 /**

--- a/src/leases/helpers.js
+++ b/src/leases/helpers.js
@@ -1532,6 +1532,19 @@ export const calculateSubventionDiscountTotal = (initialYearRent: number, manage
 };
 
 /**
+ * Check if subventions have values for calculation
+ * @param {number} initialYearRent
+ * @param {Object[]} managementSubventions
+ * @param {number} currentAmountPerArea
+ * @return {number}
+ */
+export const hasSubventionValues = (managementSubventions: ?Array<Object>, temporarySubventions: ?Array<Object>): boolean => {
+  let msWithValues = managementSubventions.filter((subvention) => !!subvention.subvention_amount)
+  let tsWithValues = temporarySubventions.filter((subvention) => !!subvention.subvention_percent)
+  return !!(msWithValues.length || tsWithValues.length)
+};
+
+/**
  * Calculate basis of rent subvention percent
  * @param {number} initialYearRent
  * @param {number} reLeaseDiscountPercent


### PR DESCRIPTION
Vuokrat tab under "Alennukset ja korotukset" there was a following problem: when there were several rent adjustments, and an adjustment was removed from somewhere else than the last index, the Määrä (full_amount) of the adjustment that took the place of the removed item changed into zero.

Also, the RentAdjustmentEdit component had a separate state for showing and hiding the subventions, which caused the subvention form to hide in cases when the adjustment had subventions, and to show when the subvention did not have any subvention data. This state handling problem is also fixed by tying it to whether the subvention_type is null or string.