### PR TITLE
Changed wrongly typed 'small' -parameter in Column element

### DIFF
--- a/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchReservationRecipients.js
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/PlotSearchReservationRecipients.js
@@ -22,7 +22,7 @@ const PlotSearchReservationRecipients = ({reservationRecipients}: Props): React$
           {PlotSearchFieldTitles.RESERVATION_RECIPIENT_SHARE_OF_RENTAL}
         </FormTextTitle>
       </Column>
-      {reservationRecipients.length === 0 && <Column small="12">
+      {reservationRecipients.length === 0 && <Column small={12}>
         <FormText>
           Ei ehdotettuja varauksensaajia.
         </FormText>


### PR DESCRIPTION
I made own branch for this small error, because no other fixes in this ui needed for fixing the issue1807 and this was the only I ended up doing.