### PR TITLE
prevent editing email identifier in application editor

### DIFF
--- a/src/plotSearch/constants.js
+++ b/src/plotSearch/constants.js
@@ -110,6 +110,7 @@ export const PROTECTED_FORM_PATHS: ProtectedFormPathsSections = {
           'etunimi',
           'Sukunimi',
           'henkilotunnus',
+          'sahkoposti'
         ],
       },
       'yrityksen-tiedot': {
@@ -117,6 +118,7 @@ export const PROTECTED_FORM_PATHS: ProtectedFormPathsSections = {
         fields: [
           'yrityksen-nimi',
           'y-tunnus',
+          'sahkoposti',
         ],
       },
     },


### PR DESCRIPTION
Editing email identifier fields in the application editor should not be allowed.