### PR TITLE
Fix plot search list page filtering

### DIFF
--- a/src/plotSearch/components/PlotSearchListPage.js
+++ b/src/plotSearch/components/PlotSearchListPage.js
@@ -73,9 +73,9 @@ const visualizationTypeOptions = [
   {value: VisualizationTypes.MAP, label: 'Kartta', icon: <MapIcon className='icon-medium' />},
 ];
 
-type OwnProps = {
+type OwnProps = {|
 
-};
+|};
 
 type Props = {
   ...OwnProps,


### PR DESCRIPTION
- Change redux-form names to match the backend
- Reflect the above in simple mode detection on pageload
- Add proper subtype handling (only show subtypes of selected type, clear subtype on type change, disable dropdown with no type selected)

Matching backend: https://github.com/City-of-Helsinki/mvj/pull/556