### PR TITLE
Fix getting targetIdentifier if plan_unit falsy

### DIFF
--- a/src/plotSearch/components/directReservationLinkModal/DirectReservationLinkModal.js
+++ b/src/plotSearch/components/directReservationLinkModal/DirectReservationLinkModal.js
@@ -47,7 +47,7 @@ const renderTargets = ({
   formValues,
 }: RenderTargetProps): React$Node => <Fragment>
   {!!targets && targets.map((target) => {
-    const targetIdentifier = target.plan_unit.identifier || target.custom_detailed_plan.identifier;
+    const targetIdentifier = target.plan_unit && target.plan_unit.identifier || target.custom_detailed_plan && target.custom_detailed_plan.identifier;
 
     let isChecked = false;
     if (formValues) {


### PR DESCRIPTION
Code seems to intend to pick `target.custom_detailed_plan` if `target.plan_unit` does not exist. The code failed on `target.plan_unit` being falsy, so couldn't get the identifier.