### PR TITLE
Fix: stringify form field default_value for multiple selection feature

### DIFF
--- a/src/plotSearch/components/plotSearchSections/application/EditPlotApplicationSectionFieldForm.js
+++ b/src/plotSearch/components/plotSearchSections/application/EditPlotApplicationSectionFieldForm.js
@@ -398,26 +398,20 @@ const EditPlotApplicationSectionFieldForm = ({
       change(
         FormNames.PLOT_SEARCH_APPLICATION_SECTION_STAGING,
         `${field}.default_value`,
-        JSON.stringify( // default_value must be a string
-          fieldValues.default_value?.[0] || ''
-        ),
+        fieldValues.default_value?.[0] || ''
       );
     } else if (newIsMultiSelect && !prevIsMultiSelect) {
       if (fieldValues.choices.length > 0) {
         change(
           FormNames.PLOT_SEARCH_APPLICATION_SECTION_STAGING,
           `${field}.default_value`,
-          JSON.stringify( // default_value must be a string
-            fieldValues.default_value ? [fieldValues.default_value] : []
-          ),
+          fieldValues.default_value ? [fieldValues.default_value] : []
         );
       } else {
         change(
           FormNames.PLOT_SEARCH_APPLICATION_SECTION_STAGING,
           `${field}.default_value`,
-          JSON.stringify( // default_value must be a string
-            false
-          ),
+          false
         );
       }
     }
@@ -429,27 +423,21 @@ const EditPlotApplicationSectionFieldForm = ({
         change(
           FormNames.PLOT_SEARCH_APPLICATION_SECTION_STAGING,
           `${field}.default_value`,
-          JSON.stringify( // default_value must be a string
-            false
-          ),
+          false,
         );
       } else {
         if (fieldValues.default_value instanceof Array) {
           change(
             FormNames.PLOT_SEARCH_APPLICATION_SECTION_STAGING,
             `${field}.default_value`,
-            JSON.stringify( // default_value must be a string
-              fieldValues.default_value.map((choiceValue) => dataMap[choiceValue])
-                .filter((choiceValue) => choiceValue !== null) || []
-            ),
+            fieldValues.default_value.map((choiceValue) => dataMap[choiceValue])
+              .filter((choiceValue) => choiceValue !== null) || [],
           );
         } else {
           change(
             FormNames.PLOT_SEARCH_APPLICATION_SECTION_STAGING,
             `${field}.default_value`,
-            JSON.stringify( // default_value must be a string
-              []
-            ),
+            [],
           );
         }
       }
@@ -458,9 +446,7 @@ const EditPlotApplicationSectionFieldForm = ({
         change(
           FormNames.PLOT_SEARCH_APPLICATION_SECTION_STAGING,
           `${field}.default_value`,
-          JSON.stringify( // default_value must be a string
-            dataMap[fieldValues.default_value]
-          ),
+          dataMap[fieldValues.default_value],
         );
       }
     }

--- a/src/plotSearch/components/plotSearchSections/application/EditPlotApplicationSectionFieldForm.js
+++ b/src/plotSearch/components/plotSearchSections/application/EditPlotApplicationSectionFieldForm.js
@@ -423,21 +423,27 @@ const EditPlotApplicationSectionFieldForm = ({
         change(
           FormNames.PLOT_SEARCH_APPLICATION_SECTION_STAGING,
           `${field}.default_value`,
-          false,
+          JSON.stringify( // default_value must be a string
+            false
+          ),
         );
       } else {
         if (fieldValues.default_value instanceof Array) {
           change(
             FormNames.PLOT_SEARCH_APPLICATION_SECTION_STAGING,
             `${field}.default_value`,
-            fieldValues.default_value.map((choiceValue) => dataMap[choiceValue])
-              .filter((choiceValue) => choiceValue !== null) || [],
+            JSON.stringify( // default_value must be a string
+              fieldValues.default_value.map((choiceValue) => dataMap[choiceValue])
+                .filter((choiceValue) => choiceValue !== null) || []
+            ),
           );
         } else {
           change(
             FormNames.PLOT_SEARCH_APPLICATION_SECTION_STAGING,
             `${field}.default_value`,
-            [],
+            JSON.stringify( // default_value must be a string
+              []
+            ),
           );
         }
       }
@@ -446,7 +452,9 @@ const EditPlotApplicationSectionFieldForm = ({
         change(
           FormNames.PLOT_SEARCH_APPLICATION_SECTION_STAGING,
           `${field}.default_value`,
-          dataMap[fieldValues.default_value],
+          JSON.stringify( // default_value must be a string
+            dataMap[fieldValues.default_value]
+          ),
         );
       }
     }

--- a/src/plotSearch/components/plotSearchSections/application/EditPlotApplicationSectionFieldForm.js
+++ b/src/plotSearch/components/plotSearchSections/application/EditPlotApplicationSectionFieldForm.js
@@ -398,20 +398,26 @@ const EditPlotApplicationSectionFieldForm = ({
       change(
         FormNames.PLOT_SEARCH_APPLICATION_SECTION_STAGING,
         `${field}.default_value`,
-        fieldValues.default_value?.[0] || ''
+        JSON.stringify( // default_value must be a string
+          fieldValues.default_value?.[0] || ''
+        ),
       );
     } else if (newIsMultiSelect && !prevIsMultiSelect) {
       if (fieldValues.choices.length > 0) {
         change(
           FormNames.PLOT_SEARCH_APPLICATION_SECTION_STAGING,
           `${field}.default_value`,
-          fieldValues.default_value ? [fieldValues.default_value] : []
+          JSON.stringify( // default_value must be a string
+            fieldValues.default_value ? [fieldValues.default_value] : []
+          ),
         );
       } else {
         change(
           FormNames.PLOT_SEARCH_APPLICATION_SECTION_STAGING,
           `${field}.default_value`,
-          false
+          JSON.stringify( // default_value must be a string
+            false
+          ),
         );
       }
     }

--- a/src/plotSearch/helpers.js
+++ b/src/plotSearch/helpers.js
@@ -289,10 +289,10 @@ export const getInitialFormSectionEditorData = (fieldTypeMapping: Object, sectio
       collapseInitialState[`field-${temporaryId}`] = false;
     }
 
-    if (typeof defaultValue === 'string' && fieldFeatures.includes(FieldTypeFeatures.MULTIPLE_SELECTION_OPTIONS)) {
+    if (fieldFeatures.includes(FieldTypeFeatures.MULTIPLE_SELECTION_OPTIONS)) {
       try {
         defaultValue = JSON.parse(defaultValue);
-        if (!(defaultValue instanceof Array)) {
+        if (!(defaultValue instanceof Array) && !(typeof defaultValue === 'boolean')) {
           defaultValue = [defaultValue];
         }
       } catch {
@@ -387,7 +387,6 @@ export const transformCommittedFormSectionEditorData = (section: Object): FormSe
   const transformChoice = (choice: Object, index: number): Object => {
     const {
       text,
-      default_value,
       ...rest
     } = choice;
 
@@ -395,7 +394,6 @@ export const transformCommittedFormSectionEditorData = (section: Object): FormSe
       ...cloneDeep(rest),
       sort_order: index,
       text,
-      default_value: default_value instanceof Array ? JSON.stringify(default_value) : default_value,
       text_fi: text,
     };
   };
@@ -405,6 +403,7 @@ export const transformCommittedFormSectionEditorData = (section: Object): FormSe
       // eslint-disable-next-line no-unused-vars
       auto_fill_identifier, auto_fill_choice_values, is_protected, protected_values, temporary_id,
 
+      default_value,
       choices,
       label,
       ...rest
@@ -414,6 +413,7 @@ export const transformCommittedFormSectionEditorData = (section: Object): FormSe
       ...cloneDeep(rest),
       sort_order: index,
       choices: choices?.map(transformChoice) || null,
+      default_value: typeof default_value === 'string' ? default_value : (JSON.stringify(default_value) || ''),
       label,
       label_fi: label,
     };


### PR DESCRIPTION
API expects `default_value` to be of type string.
This ensures that all values are stringified.