### PR TITLE
Allow changing only preparer in areasearch list view

### DIFF
--- a/src/areaSearch/components/AreaSearchApplicationListPage.js
+++ b/src/areaSearch/components/AreaSearchApplicationListPage.js
@@ -296,7 +296,7 @@ class AreaSearchApplicationListPage extends PureComponent<Props, State> {
         <Button
           className={ButtonColors.LINK}
           onClick={() => this.openAreaSearchEditModal(row.id)}
-          text={val} />
+          text={val || 'Avoin'} />
       </span>,
     });
 
@@ -345,7 +345,7 @@ class AreaSearchApplicationListPage extends PureComponent<Props, State> {
 
     editAreaSearch({
       id: data.id,
-      preparer: data.preparer?.id,
+      preparer: data.preparer?.id || null,
       lessor: data.lessor,
       area_search_status: {
         status_notes: data.status_notes ? [

--- a/src/areaSearch/components/EditAreaSearchPreparerForm.js
+++ b/src/areaSearch/components/EditAreaSearchPreparerForm.js
@@ -84,7 +84,7 @@ class EditAreaSearchPreparerForm extends Component<Props> {
               overrideValues={{
                 fieldType: FieldTypes.USER,
                 label: AreaSearchFieldTitles.PREPARER,
-                required: true,
+                required: false,
               }}
             />
           </Column>
@@ -102,7 +102,7 @@ class EditAreaSearchPreparerForm extends Component<Props> {
             />
           </Column>
         </Row>
-        <Row>
+        <Row className='statusNotes'>
           <Column small={12} medium={12} large={12}>
             {(areaSearchData?.area_search_status?.status_notes && areaSearchData.area_search_status.status_notes.length > 0) &&
               <AreaSearchStatusNoteHistory statusNotes={areaSearchData.area_search_status.status_notes} />}
@@ -112,8 +112,7 @@ class EditAreaSearchPreparerForm extends Component<Props> {
           <Button onClick={onClose} className={ButtonColors.SECONDARY} text="Peruuta" />
           <Button
             onClick={() => onSubmit(formValues)}
-            text={areaSearchData?.preparer ? 'Vaihda käsittelijä' : 'Ota työn alle'}
-            disabled={!formValues?.preparer?.value}
+            text={'Tallenna'}
           />
         </ModalButtonWrapper>
       </form>

--- a/src/areaSearch/components/_edit-area-search-preparer-modal.scss
+++ b/src/areaSearch/components/_edit-area-search-preparer-modal.scss
@@ -8,4 +8,9 @@
   .AreaSearchStatusNoteHistory {
     background-color: transparent;
   }
+  // Due to .modal__wrapper having overflow: visible, this makes long lists of status notes scrollable.
+  .row.statusNotes {
+    overflow: auto;
+    max-height: 50vh;
+  }
 }


### PR DESCRIPTION
- Makes no fields required
- Renames buttons to simply "save"
- Fixes issue when long list of status notes appear, they would not be scrollable, making the modals buttons appear outside of the screen
- Set default value for lessor, so that it can be clicked to edit when it is empty
- Allow saving null preparer, as previously you could not change preparer to null (requires change to backend to allow null value)