### PR TITLE
Hide show mark all in area search applicant info

### DIFF
--- a/src/application/components/infoCheck/ApplicantInfoCheckEdit.js
+++ b/src/application/components/infoCheck/ApplicantInfoCheckEdit.js
@@ -13,6 +13,7 @@ import {getApplicantInfoCheckFormName} from '$src/application/helpers';
 type OwnProps = {
   infoCheckIds: Array<number>,
   answer: Object,
+  showMarkAll: boolean,
   submissionErrors: Array<{
     id: number,
     kind: ?Object,
@@ -133,6 +134,7 @@ class ApplicantInfoCheckEdit extends Component<Props, State> {
       infoCheckIds,
       answer,
       submissionErrors,
+      showMarkAll = true,
     } = this.props;
 
     const applicantType = answer?.metadata?.applicantType;
@@ -152,6 +154,7 @@ class ApplicantInfoCheckEdit extends Component<Props, State> {
           infoCheck={modalCheckItem}
           businessId={applicantType === ApplicantTypes.COMPANY ? answer.metadata.identifier : undefined}
           personId={applicantType === ApplicantTypes.PERSON ? answer.metadata.identifier : undefined}
+          showMarkAll={showMarkAll}
         />
         {submissionErrors && this.renderErrors()}
       </div>

--- a/src/application/components/infoCheck/ApplicantInfoCheckForm.js
+++ b/src/application/components/infoCheck/ApplicantInfoCheckForm.js
@@ -32,6 +32,7 @@ type Props = {
   valid: boolean,
   formValues: Object,
   isPreparerDirty: boolean,
+  showMarkAll: boolean,
 };
 
 class ApplicantInfoCheckForm extends Component<Props> {
@@ -76,6 +77,7 @@ class ApplicantInfoCheckForm extends Component<Props> {
       attributes,
       valid,
       onClose,
+      showMarkAll,
     } = this.props;
 
     return (
@@ -101,16 +103,19 @@ class ApplicantInfoCheckForm extends Component<Props> {
               }}
             />
           </Column>
-          <Column small={4}>
-            <FormField
-              fieldAttributes={get(attributes, ApplicantInfoCheckFieldPaths.MARK_ALL)}
-              name={ApplicantInfoCheckFieldPaths.MARK_ALL}
-              overrideValues={{
-                label: ApplicantInfoCheckFieldTitles.MARK_ALL,
-                required: false,
-              }}
-            />
-          </Column>
+          {showMarkAll === true &&
+            <Column small={4}>
+              <FormField
+                fieldAttributes={get(attributes, ApplicantInfoCheckFieldPaths.MARK_ALL)}
+                name={ApplicantInfoCheckFieldPaths.MARK_ALL}
+                overrideValues={{
+                  label: ApplicantInfoCheckFieldTitles.MARK_ALL,
+                  required: false,
+                }}
+              />
+            </Column>
+          }
+          
         </Row>
         <Row>
           <Column small={12}>

--- a/src/application/components/infoCheck/ApplicantInfoCheckModal.js
+++ b/src/application/components/infoCheck/ApplicantInfoCheckModal.js
@@ -18,7 +18,8 @@ type Props = {
   modalPage: number,
   setPage: Function,
   businessId?: string,
-  personId?: string
+  personId?: string,
+  showMarkAll?: boolean,
 }
 
 type State = {
@@ -52,6 +53,7 @@ class ApplicantInfoCheckModal extends Component<Props, State> {
       setPage,
       businessId,
       personId,
+      showMarkAll,
     } = this.props;
 
     let title = '';
@@ -92,6 +94,7 @@ class ApplicantInfoCheckModal extends Component<Props, State> {
               onSubmit={onSubmit}
               onClose={onClose}
               infoCheck={infoCheck}
+              showMarkAll={showMarkAll}
               ref={this.setRefForForm} />
           </div>
         }

--- a/src/areaSearch/components/AreaSearchApplicantInfoCheckEdit.js
+++ b/src/areaSearch/components/AreaSearchApplicantInfoCheckEdit.js
@@ -39,6 +39,7 @@ class PlotApplicationApplicantInfoCheck extends PureComponent<Props> {
       answer={answer}
       infoCheckIds={infoCheckIds}
       submissionErrors={submissionErrors}
+      showMarkAll={false}
     />;
   }
 }


### PR DESCRIPTION
It would attempt to mark e.g. trade register check to all the applicants applications. This behavior is not desired in area search.