### PR TITLE
Add dev option to compile script

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ yarn start
 ```bash
 yarn run compile
 ```
+
+There is also a script for compiling a development version, which is needed for deploying mvj-ui for dev:
+
+```bash
+yarn run compile:dev
+```
+
 ## Test
 
 #### Run the test suite

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "serve": "webpack serve",
     "start": "node scripts/start.js",
     "compile": "node scripts/compile.js",
+    "compile:dev": "node scripts/compile.js --dev",
     "precommit": "npm-run-all flow lint",
     "prepush": "npm-run-all test",
     "test": "mocha --require @babel/register --require src/test.js \"src/**/*spec.js\"",

--- a/scripts/compile.js
+++ b/scripts/compile.js
@@ -1,8 +1,14 @@
 'use strict';
 
 // Do this as the first thing so that any code reading it knows the right env.
-process.env.BABEL_ENV = 'production';
-process.env.NODE_ENV = 'production';
+const isDev = process.argv.includes('--dev');
+if (isDev) {
+  process.env.BABEL_ENV = 'development';
+  process.env.NODE_ENV = 'development';
+} else {
+  process.env.BABEL_ENV = 'production';
+  process.env.NODE_ENV = 'production';
+}
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
@@ -18,7 +24,7 @@ const path = require('path');
 const chalk = require('chalk');
 const fs = require('fs-extra');
 const webpack = require('webpack');
-const config = require('../config/webpack.config.prod');
+const config = isDev ? require('../config/webpack.config.dev') : require('../config/webpack.config.prod');
 const paths = require('../config/paths');
 const checkRequiredFiles = require('react-dev-utils/checkRequiredFiles');
 const formatWebpackMessages = require('react-dev-utils/formatWebpackMessages');
@@ -98,9 +104,9 @@ measureFileSizesBeforeBuild(paths.appBuild)
     }
   );
 
-// Create the production build and print the deployment instructions.
+// Create the build and print the deployment instructions.
 function build(previousFileSizes) {
-  console.log('Creating an optimized production build...');
+  console.log(`Creating an optimized ${isDev ? 'development' : 'production'} build...`);
 
   let compiler = webpack(config);
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
`yarn run compile` will create a production build.

Builds for the dev environment are created manually with this script too, but they need to have NODE_ENV as 'development'.

This change introduces the --dev flag to the script, so that running `yarn run compile --dev` will create a development build.