### PR TITLE
Fix adding subventions for newly added rent adjustments

### DIFF
--- a/src/leases/components/leaseSections/rent/RentAdjustmentEdit.js
+++ b/src/leases/components/leaseSections/rent/RentAdjustmentEdit.js
@@ -42,6 +42,7 @@ import {
   getDecisionById,
   hasSubventionDataChanged,
   hasSubventionValues,
+  isSubventionTypeSpecified,
 } from '$src/leases/helpers';
 import {getUiDataLeaseKey} from '$src/uiData/helpers';
 import {
@@ -270,6 +271,7 @@ class RentAdjustmentsEdit extends PureComponent<Props> {
         change,
         field,
         fullAmount,
+        subventionType,
         managementSubventions,
         temporarySubventions,
         subventionBasePercent,
@@ -278,7 +280,15 @@ class RentAdjustmentsEdit extends PureComponent<Props> {
 
       let newFullAmount = fullAmount
 
-      if (hasSubventionValues(managementSubventions, temporarySubventions, subventionBasePercent, subventionGraduatedPercent)) {
+      if (
+        isSubventionTypeSpecified(subventionType)
+        && hasSubventionValues(
+          managementSubventions,
+          temporarySubventions,
+          subventionBasePercent,
+          subventionGraduatedPercent
+        )
+      ) {
         newFullAmount = this.calculateTotalSubventionPercent()
       }
       
@@ -306,8 +316,8 @@ class RentAdjustmentsEdit extends PureComponent<Props> {
   handleAddSubventions = () => {
     const {change, field} = this.props;
 
-    // To make the subvention form visible: null => ""
-    change(formName, `${field}.subvention_type`, "");
+    // To make the subvention form visible: null => "unspecified"
+    change(formName, `${field}.subvention_type`, "unspecified");
   }
 
   handleRemoveSubventions = () => {

--- a/src/leases/helpers.js
+++ b/src/leases/helpers.js
@@ -1550,11 +1550,22 @@ export const calculateSubventionDiscountTotal = (initialYearRent: number, manage
 };
 
 /**
+ * Check if subvention type is specified.
+ * The "unspecified" value is needed for rendering the subvention-related fields.
+ * @param {?string} subventionType
+ * @return {boolean}
+ */
+export const isSubventionTypeSpecified = (subventionType: ?string): boolean => {
+  return !!subventionType && subventionType !== "unspecified";
+};
+
+/**
  * Check if subventions have values for calculation
- * @param {number} initialYearRent
- * @param {Object[]} managementSubventions
- * @param {number} currentAmountPerArea
- * @return {number}
+ * @param {?Array<Object>} managementSubventions
+ * @param {?Array<Object>} temporarySubventions
+ * @param {?string} subventionBasePercent
+ * @param {?string} subventionGraduatedPercent
+ * @return {boolean}
  */
 export const hasSubventionValues = (managementSubventions: ?Array<Object>, temporarySubventions: ?Array<Object>, subventionBasePercent: ?string, subventionGraduatedPercent: ?string): boolean => {
   let msWithValues = managementSubventions.filter((subvention) => !!subvention.subvention_amount)


### PR DESCRIPTION
When a user adds a rent adjustment in Vuokraus => Vuokrat tab, and then tries to add a subvention, the subvention form does not open. The user needs to save the changes first, open the edit view again and then they could add a subvention. These changes fix that bug.

The problem was that the `subventionType` has been set from `null` to `""` when the user clicks the "Lisää subventio" button, which does not make the subvention form to open. The `componentDidUpdate` does not fire. Seems to be caused by type coercion. Now when the subvention form is opened, `subventionType` is set to `"unspecified"`, which works because it is truthy.

The value `"unspecified"` also makes the full amount recalculation to skip applying subvention values, which prevents changing the full amount to 0 when the subvention is removed.