### PR TITLE
change type for formatDecimalNumber to take in string

### DIFF
--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -237,11 +237,11 @@ export const formatNumberWithThousandSeparator = (x: any, separator: string = ' 
 
 /**
  * Format decimal number
- * @param {number} x
+ * @param {string} x
  * @param {number} decimals
  * @returns {string}
  */
-export const formatDecimalNumber = (x: number | null | undefined, decimals: number | null | undefined = 2): string | null | undefined => !isEmptyValue(x) ? x.toFixed(decimals || undefined).toString().replace('.', ',') : null;
+export const formatDecimalNumber = (x: string | null | undefined, decimals: number | null | undefined = 2): string | null | undefined => !isEmptyValue(x) ? parseFloat(x).toFixed(decimals || undefined).toString().replace('.', ',') : null;
 
 /**
  * Format number to show on UI

--- a/src/util/spec.ts
+++ b/src/util/spec.ts
@@ -564,8 +564,8 @@ describe('utils', () => {
       expect(formatNumberWithThousandSeparator('10000000,1234', '.')).to.deep.equal('10.000.000,1234');
     });
     it('should format decimal number', () => {
-      expect(formatDecimalNumber(10000000.1234)).to.deep.equal('10000000,12');
-      expect(formatDecimalNumber(10000000)).to.deep.equal('10000000,00');
+      expect(formatDecimalNumber('10000000.1234')).to.deep.equal('10000000,12');
+      expect(formatDecimalNumber('10000000')).to.deep.equal('10000000,00');
       expect(formatDecimalNumber(null)).to.deep.equal(null);
     });
     it('should format number', () => {


### PR DESCRIPTION
Please check if this makes sense, I encoutered errors on `vuokra-alue` page due to how this type was previously. I'm not sure how this changed, or if it was wrong to begin with