### PR TITLE
invoice edit: fetch receivable types by lease's service unit

### DIFF
--- a/src/leaseCreateCharge/requests.ts
+++ b/src/leaseCreateCharge/requests.ts
@@ -1,7 +1,7 @@
 import callApi from "../api/callApi";
 import createUrl from "../api/createUrl";
 import { store } from "../root/startApp";
-import { getUserActiveServiceUnit } from "../usersPermissions/selectors";
+import { getCurrentLease } from '../leases/selectors';
 export const fetchAttributes = (): Generator<any, any, any> => {
   return callApi(new Request(createUrl(`lease_create_charge/`), {
     method: 'OPTIONS'
@@ -9,7 +9,8 @@ export const fetchAttributes = (): Generator<any, any, any> => {
 };
 export const fetchReceivableTypes = (): Generator<any, any, any> => {
   const state = store.getState();
-  const serviceUnit = getUserActiveServiceUnit(state);
+  const lease = getCurrentLease(state);
+  const serviceUnit = lease.service_unit;
   return callApi(new Request(createUrl(`receivable_type/`, {
     service_unit: serviceUnit.id
   }), {


### PR DESCRIPTION
Previously, receivable types (saamislaji) were filtered by user's active service unit in Vuokraus => Laskutus tab, both in the invoice edit view and create new invoice view. However, they should be filtered by the current lease's service unit in order to make sure that it is not possible to give a receivable type for the lease's invoice that belongs to a wrong service unit.

Notice that saving the changes to the invoice does not work. That issue will be handled separately.