### PR TITLE
Properly split the query parameter for service unit in email reports

### DIFF
--- a/src/leaseStatisticReport/requests.ts
+++ b/src/leaseStatisticReport/requests.ts
@@ -23,7 +23,8 @@ export const fetchReportData = (payload: Record<string, any>): Generator<any, an
   return callApi(new Request(`${payload.url}?${parsedQuery}`));
 };
 export const sendReportToMail = (payload: Record<string, any>): Generator<any, any, any> => {
-  return callApi(new Request(`${payload.url}?${payload.query}`));
+  const parsedQuery = parseServiceUnitQuery(payload.query) || '';
+  return callApi(new Request(`${payload.url}?${parsedQuery}`));
 };
 export const fetchOptions = (payload: any): Generator<any, any, any> => {
   return callApi(new Request(payload, {


### PR DESCRIPTION
Service unit query parameter was previously sent as single string like "1,2,3,4", which is not a proper input for forms.ModelMultipleChoiceField. Synchronous reports already handled this query string properly, so now email reports use the same query parameter parsing for service unit.