### PR TITLE
fix icons in send email modal

### DIFF
--- a/src/leases/components/leaseSections/constructability/SendEmailModal.tsx
+++ b/src/leases/components/leaseSections/constructability/SendEmailModal.tsx
@@ -127,7 +127,12 @@ class SendEmailModal extends PureComponent<Props, State> {
     } = this.state;
     return <Modal className='modal-autoheight' title='Lähetä sähköposti' isOpen={isOpen} onClose={onClose}>
         <FormText>Valitse sähköpostin vastaanottajat</FormText>
-        <DualListBox availableRef={ref => this.dualListBox = ref} canFilter filter={filter} filterPlaceholder='Hae vastaanottajia...' onChange={this.handleUserListChange} onFilterChange={this.handleFilterChange} options={userOptions} selected={selectedUsers} simpleValue={false} />
+        <DualListBox icons={{
+          moveLeft: '<',
+          moveAllLeft: '<<',
+          moveRight: '>',
+          moveAllRight: '>>'
+        }} availableRef={ref => this.dualListBox = ref} canFilter filter={filter} filterPlaceholder='Hae vastaanottajia...' onChange={this.handleUserListChange} onFilterChange={this.handleFilterChange} options={userOptions} selected={selectedUsers} simpleValue={false} />
 
         <FormText><label htmlFor='send-email_text'> Sähköpostiin liittyvä kommentti</label></FormText>
         <TextAreaInput className="no-margin" id='send-email_text' onChange={this.handleTextChange} placeholder='' rows={4} value={text} />


### PR DESCRIPTION
I couldn't get the awesome-font icons to load in the send email modal. It should work, I just don't understand why not. Therefore, I made a bit of a different solution by using text instead of icons but I think it looks quite good like this as well.

![send-email-modal-screenshot](https://github.com/user-attachments/assets/bb6b2379-cd83-4a6f-be78-9ec7765ca586)
