### PR TITLE
comment modal: fix size and icon of close button

### DIFF
--- a/src/components/button/_close-button.scss
+++ b/src/components/button/_close-button.scss
@@ -5,10 +5,6 @@
   background-image: url(/assets/icons/icon_close.svg);
   height: 20px;
   width: 20px;
-  img {
-    height: 20px;
-    width: 20px;
-  }
   &:hover {
     opacity: 0.85;
   }

--- a/src/components/button/_close-button.scss
+++ b/src/components/button/_close-button.scss
@@ -2,7 +2,9 @@
   cursor: pointer;
   position: relative;
   top: rem-calc(-1px);
-  background-image: url(/assets/icons/icon_error.svg);
+  background-image: url(/assets/icons/icon_close.svg);
+  height: 20px;
+  width: 20px;
   img {
     height: 20px;
     width: 20px;


### PR DESCRIPTION
Fix the size props of the css class for the button. It also had a wrong icon, so I changed it to an X.

Fixes the bug in both on the Yhteenveto and the Laskutus tabs.