### PR TITLE
Receivable types: increase response limit to 50

### DIFF
--- a/src/leaseCreateCharge/requests.ts
+++ b/src/leaseCreateCharge/requests.ts
@@ -12,7 +12,8 @@ export const fetchReceivableTypes = (): Generator<any, any, any> => {
   const lease = getCurrentLease(state);
   const serviceUnit = lease.service_unit;
   return callApi(new Request(createUrl(`receivable_type/`, {
-    service_unit: serviceUnit.id
+    service_unit: serviceUnit.id,
+    limit: 50
   }), {
     method: 'GET'
   }));


### PR DESCRIPTION
The default limit for `receivable_type/` request is 30, but there are more receivable types for AKV than 30. The limit of response objects is increased to 50, so that all AKV receivable types could be shown.