### PR TITLE
Mvj 536 map tool icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-dual-listbox": "^2.0.0",
     "react-foundation": "^0.9.7",
     "react-leaflet": "^2.8.0",
-    "react-leaflet-draw": "^0.19.0",
+    "react-leaflet-draw": "0.19.0",
     "react-leaflet-fullscreen": "^1.0.2",
     "react-redux": "^7.1.0",
     "react-redux-toastr": "^7.6.12",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "typescript-eslint": "^8.1.0",
     "vite": "^5.3.5",
     "vite-plugin-commonjs": "^0.10.1",
+    "vite-plugin-static-copy": "^2.0.0",
     "vitest": "^2.0.5"
   },
   "resolutions": {

--- a/src/components/collapse/_collapse.scss
+++ b/src/components/collapse/_collapse.scss
@@ -65,7 +65,7 @@
     }
 
     .collapse__header_error-badge {
-      background-image: url(../assets/icons/icon_error.svg);
+      background-image: url(/assets/icons/icon_error.svg);
       height: 14px;
       width: 14px;
       display: inline-block;
@@ -132,7 +132,7 @@
         height: rem-calc(20px);
         width: rem-calc(20px);
         vertical-align: text-bottom;
-        background-image: url(../assets/icons/icon_minus.svg);
+        background-image: url(/assets/icons/icon_minus.svg);
         display: inline-block;
         margin-right: 0.4rem;
         background-position: center;
@@ -144,7 +144,7 @@
         color: $dark-gray;
 
         i {
-          background-image: url(../assets/icons/icon_minus.svg);
+          background-image: url(/assets/icons/icon_minus.svg);
         }
       }
 
@@ -152,7 +152,7 @@
         color: $red;
 
         i {
-          background-image: url(../assets/icons/icon-alert.svg);
+          background-image: url(/assets/icons/icon-alert.svg);
         }
       }
 
@@ -160,7 +160,7 @@
         color: $blue;
 
         i {
-          background-image: url(../assets/icons/icon_checked.svg);
+          background-image: url(/assets/icons/icon_checked.svg);
         }
       }
 
@@ -168,7 +168,7 @@
         color: $yellow-enquiry-sent;
 
         i {
-          background-image: url(../assets/icons/icon_question.svg);
+          background-image: url(/assets/icons/icon_question.svg);
         }
       }
     }
@@ -323,7 +323,7 @@
     height: rem-calc(20px);
     width: rem-calc(20px);
     vertical-align: text-bottom;
-    background-image: url(../assets/icons/icon-alert.svg);
+    background-image: url(/assets/icons/icon-alert.svg);
     display: inline-block;
     margin-right: 0.4rem;
   }

--- a/src/components/content/_content.scss
+++ b/src/components/content/_content.scss
@@ -249,7 +249,7 @@
       height: rem-calc(20px);
       width: rem-calc(20px);
       vertical-align: text-bottom;
-      background-image: url(../assets/icons/icon-alert.svg);
+      background-image: url(/assets/icons/icon-alert.svg);
       display: inline-block;
       margin-left: 0.4rem;
     }
@@ -267,7 +267,7 @@
 
     &--success {
       i {
-        background-image: url(../assets/icons/icon_checked.svg);
+        background-image: url(/assets/icons/icon_checked.svg);
       }
     }
   }

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -290,7 +290,7 @@
       height: 20px;
       width: 20px;
       background-size: cover;
-      background-image: url(../assets/icons/icon-search.svg);
+      background-image: url(/assets/icons/icon-search.svg);
       cursor: pointer;
     }
   }

--- a/src/components/inputs/_search-input.scss
+++ b/src/components/inputs/_search-input.scss
@@ -23,7 +23,7 @@
       height: 20px;
       width: 20px;
       background-size: cover;
-      background-image: url(../assets/icons/icon-search.svg);
+      background-image: url(/assets/icons/icon-search.svg);
       cursor: pointer;
     }
   }

--- a/src/components/inputs/_select-input.scss
+++ b/src/components/inputs/_select-input.scss
@@ -83,13 +83,13 @@
 
     &__dropdown-indicator {
       display: block;
-      background-image: url(../assets/icons/icon_arrow_down.svg);
+      background-image: url(/assets/icons/icon_arrow_down.svg);
       height: rem-calc(14px);
       width: rem-calc(14px);
       margin: rem-calc(0 2px);
 
       &.menu-is-open {
-        background-image: url(../assets/icons/icon_arrow_up.svg);
+        background-image: url(/assets/icons/icon_arrow_up.svg);
       }
     }
 

--- a/src/components/multi-select/_multi-select.scss
+++ b/src/components/multi-select/_multi-select.scss
@@ -114,7 +114,7 @@
 
       &-down {
         display: block;
-        background-image: url(../assets/icons/icon_arrow_down.svg);
+        background-image: url(/assets/icons/icon_arrow_down.svg);
         height: 12px;
         width: 12px;
         background-size: 12px 12px;
@@ -124,7 +124,7 @@
 
       &-up {
         display: block;
-        background-image: url(../assets/icons/icon_arrow_up.svg);
+        background-image: url(/assets/icons/icon_arrow_up.svg);
         height: 12px;
         width: 12px;
         background-size: 12px 12px;

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -66,7 +66,7 @@
   }
 
   &__error-badge {
-    background-image: url(../assets/icons/icon_error.svg);
+    background-image: url(/assets/icons/icon_error.svg);
     height: 14px;
     width: 14px;
     background-size: contain;
@@ -79,7 +79,7 @@
   }
 
   &__dirty-badge {
-    background-image: url(../assets/icons/icon_unsaved.svg);
+    background-image: url(/assets/icons/icon_unsaved.svg);
     height: 14px;
     width: 14px;
     background-size: contain;

--- a/src/leases/components/leaseSections/rent/_rent.scss
+++ b/src/leases/components/leaseSections/rent/_rent.scss
@@ -8,7 +8,7 @@
       color: $blue;
 
       .link-icon {
-        background-image: url(../assets/icons/icon_link_green.svg);
+        background-image: url(/assets/icons/icon_link_green.svg);
         height: rem-calc(20px);
         width: rem-calc(20px);
         margin-left: rem-calc(8px);

--- a/src/main.scss
+++ b/src/main.scss
@@ -4,15 +4,15 @@
 @include foundation-everything(true);
 @include foundation-flex-grid;
 
-@import "../node_modules/react-leaflet-fullscreen/dist/styles.css";
+@import "node_modules/react-leaflet-fullscreen/dist/styles";
 @import "styles/mixins";
 
 // Vendor
-@import "../node_modules/react-redux-toastr/src/styles/index";
-@import "../node_modules/react-datepicker/dist/react-datepicker.css";
-@import "../node_modules/leaflet-draw/dist/leaflet.draw.css";
-@import "../node_modules/react-dual-listbox/src/scss/react-dual-listbox.scss";
-@import "../node_modules/font-awesome/css/font-awesome.css";
+@import "node_modules/react-redux-toastr/src/styles/index";
+@import "node_modules/react-datepicker/dist/react-datepicker";
+@import "node_modules/leaflet-draw/dist/leaflet.draw";
+@import "node_modules/react-dual-listbox/src/scss/react-dual-listbox.scss";
+@import "node_modules/font-awesome/css/font-awesome";
 
 // Components
 @import "components/authorization/authorization";

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,7 +13,7 @@ export default defineConfig({
       targets: [
         { // copy leaflet-draw images to dist
           src: 'node_modules/leaflet-draw/dist/images/*',
-          dest: 'images'
+          dest: 'assets/images'
         },
       ]
     }),
@@ -35,7 +35,16 @@ export default defineConfig({
   css: {
     postcss: {
       plugins: [
-        postcssUrl({}),
+        postcssUrl({
+          url: (asset) => {
+            // transform urls from `node_modules/leaflet-draw/dist/leaflet.draw.css`
+            // change those urls to point from `/images` to `/assets/images`
+            if (asset.relativePath && asset.relativePath.startsWith('images/')) {
+              return `/assets/${asset.url}`;
+            }
+            return asset.url;
+          }
+        }),
       ]
     }
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import commonjs from 'vite-plugin-commonjs';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
 import path from 'path';
 import postcssUrl from 'postcss-url';
 import babel from '@rollup/plugin-babel';
@@ -8,6 +9,14 @@ import babel from '@rollup/plugin-babel';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
+    viteStaticCopy({
+      targets: [
+        { // copy leaflet-draw images to dist
+          src: 'node_modules/leaflet-draw/dist/images/*',
+          dest: 'images'
+        },
+      ]
+    }),
     react({
       jsxRuntime: 'classic',
     }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -5556,7 +5556,7 @@ react-is@^17.0.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-leaflet-draw@^0.19.0:
+react-leaflet-draw@0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/react-leaflet-draw/-/react-leaflet-draw-0.19.0.tgz#95de33054016db27e171f8f8f646f6bad17106f3"
   integrity sha512-aOB7Nqgl79l62L7vHxhdyKJD6ep+1Q+qTfnrYfmcgF+yK0A1lQA2fUv9N4C0HCbejcyiqx1XYchSCw9Q+Vtc3A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2643,7 +2643,7 @@ check-error@^2.1.1:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.1.tgz#87eb876ae71ee388fa0471fe423f494be1d96ccc"
   integrity sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==
 
-"chokidar@>=3.0.0 <4.0.0":
+"chokidar@>=3.0.0 <4.0.0", chokidar@^3.5.3:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
   integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
@@ -3549,7 +3549,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.12, fast-glob@^3.2.9, fast-glob@^3.3.2:
+fast-glob@^3.2.11, fast-glob@^3.2.12, fast-glob@^3.2.9, fast-glob@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
   integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
@@ -3694,6 +3694,15 @@ foundation-sites@6.5.3:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/foundation-sites/-/foundation-sites-6.5.3.tgz#85373aaed72233ca0d16fdfcb034e976cc6943c9"
   integrity sha512-ZwI0idjHHjezh6jRjpPxkczvmtUuJ1uGatZHpyloX0MvsFHfM0BFoxrqdXryXugGPdmb+yJi3JYMnz6+5t3K1A==
+
+fs-extra@^11.1.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.2.0.tgz#e70e17dfad64232287d01929399e0ea7c86b0e5b"
+  integrity sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -3886,6 +3895,11 @@ graceful-fs@^4.1.2:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
+
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
+  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
 graphemer@^1.4.0:
   version "1.4.0"
@@ -4624,6 +4638,15 @@ json5@^2.1.1, json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.3.5"
@@ -6846,6 +6869,11 @@ universalify@^0.2.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
   integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
 
+universalify@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
+  integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
+
 update-browserslist-db@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz#7ca61c0d8650766090728046e416a8cde682859e"
@@ -6932,6 +6960,16 @@ vite-plugin-dynamic-import@^1.5.0:
     es-module-lexer "^1.2.1"
     fast-glob "^3.2.12"
     magic-string "^0.30.1"
+
+vite-plugin-static-copy@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/vite-plugin-static-copy/-/vite-plugin-static-copy-2.0.0.tgz#064a0792290992629dcfbc740b9fcddcaba4798f"
+  integrity sha512-b/quFjTUa/RY9t3geIyeeT2GtWEoRI0GawYFFjys5iMLGgVP638NTGu0RoMjwmi8MoZZ3BQw4OQvb1GpVcXZDA==
+  dependencies:
+    chokidar "^3.5.3"
+    fast-glob "^3.2.11"
+    fs-extra "^11.1.0"
+    picocolors "^1.0.0"
 
 vite@^5.0.0:
   version "5.4.0"


### PR DESCRIPTION
What this does to fix certain images for leaflet-draw, is that it copies the images of leaflet-draw to the build.
Since _in current version of leaflet-draw_ its css points the images to `image/xxx` but vite wants them to be in `assets`, we will transform the css `url()`'s that start with `images/` to `assets/images/`.

If you know of a better way let me know. Would maybe prefer inline of the images base64 in the css or something, but not sure how to accomplish it with this specific library. Maybe it is not worth any extra time to spend more fighting it.

On top of this, I also changed some css `url()`'s to point to `/assets/` instead of `../assets` - seems more correct and didn't see any issues with that. Those svg's seems to endup in the css files as inline in any case.