### PR TITLE
receivable types: fetch beyond page limit

### DIFF
--- a/src/api/callApiPaginated.ts
+++ b/src/api/callApiPaginated.ts
@@ -1,0 +1,46 @@
+import callApi from "./callApi";
+
+function* callApiPaginated(request: Request): Generator<any, any, any> {
+  let { response, bodyAsJson } = yield callApi(request);
+  const allResults = [...bodyAsJson.results];
+
+  if (bodyAsJson.next) {
+    let nextUrl = bodyAsJson.next;
+    while (nextUrl !== null) {
+      request = new Request(nextUrl, {
+        method: 'GET'
+      });
+      ({ response, bodyAsJson } = yield callApi(request));
+      const status = response.status;
+
+      switch (status) {
+        case 200:
+          allResults.push(...bodyAsJson.results);
+          break;
+        case 204:
+          return {
+            response
+          };
+          break;
+      
+        default:
+          return {
+            response,
+            bodyAsJson: {
+              exception: response.status,
+              message: response.statusText
+            }
+          };
+          break;
+      }
+      
+      nextUrl = bodyAsJson.next || null;
+    }
+  }
+
+  bodyAsJson.results = allResults;
+
+  return { response, bodyAsJson };
+}
+
+export default callApiPaginated;

--- a/src/leaseCreateCharge/helpers.ts
+++ b/src/leaseCreateCharge/helpers.ts
@@ -37,7 +37,9 @@ export const getPayloadLeaseCreateCharge = (invoice: Record<string, any>): Recor
  * @returns {Object}
  */
 export const receivableTypesFromAttributes = (fieldAttributes: Record<string, any>, receivableTypes: Record<string, any>): Record<string, any> => {
-  const newChoices = fieldAttributes.choices.filter(choice => receivableTypes.find(type => type.is_active && type.id === choice.value));
+  const newChoices = fieldAttributes.choices
+    .filter(choice => receivableTypes.find(type => type.is_active && type.id === choice.value))
+    .sort((a, b) => a.display_name.localeCompare(b.display_name));
   const newFieldAttributes = { ...fieldAttributes,
     choices: newChoices
   };

--- a/src/leaseCreateCharge/requests.ts
+++ b/src/leaseCreateCharge/requests.ts
@@ -7,10 +7,15 @@ export const fetchAttributes = (): Generator<any, any, any> => {
     method: 'OPTIONS'
   }));
 };
-export const fetchReceivableTypes = (): Generator<any, any, any> => {
+export const fetchReceivableTypes = (nextUrl: string): Generator<any, any, any> => {
   const state = store.getState();
   const lease = getCurrentLease(state);
   const serviceUnit = lease.service_unit;
+  if (nextUrl) {
+    return callApi(new Request(nextUrl, {
+      method: 'GET'
+    }));
+  }
   return callApi(new Request(createUrl(`receivable_type/`, {
     service_unit: serviceUnit.id
   }), {

--- a/src/leaseCreateCharge/requests.ts
+++ b/src/leaseCreateCharge/requests.ts
@@ -1,4 +1,5 @@
 import callApi from "@/api/callApi";
+import callApiPaginated from "@/api/callApiPaginated";
 import createUrl from "@/api/createUrl";
 import { store } from "@/index";
 import { getCurrentLease } from '@/leases/selectors';
@@ -7,16 +8,11 @@ export const fetchAttributes = (): Generator<any, any, any> => {
     method: 'OPTIONS'
   }));
 };
-export const fetchReceivableTypes = (nextUrl: string): Generator<any, any, any> => {
+export const fetchReceivableTypes = (): Generator<any, any, any> => {
   const state = store.getState();
   const lease = getCurrentLease(state);
   const serviceUnit = lease.service_unit;
-  if (nextUrl) {
-    return callApi(new Request(nextUrl, {
-      method: 'GET'
-    }));
-  }
-  return callApi(new Request(createUrl(`receivable_type/`, {
+  return callApiPaginated(new Request(createUrl(`receivable_type/`, {
     service_unit: serviceUnit.id
   }), {
     method: 'GET'

--- a/src/leaseCreateCharge/saga.ts
+++ b/src/leaseCreateCharge/saga.ts
@@ -3,6 +3,8 @@ import { receiveAttributes, attributesNotFound, receiveReceivableTypes, receivab
 import { receiveError } from "@/api/actions";
 import { fetchAttributes, fetchReceivableTypes } from "./requests";
 
+const SAFETY_CAP_FOR_WHILE_LOOP_ITERATIONS = 20;
+
 function* fetchAttributesSaga(): Generator<any, any, any> {
   try {
     const {
@@ -31,9 +33,10 @@ function* fetchAttributesSaga(): Generator<any, any, any> {
 
 function* fetchReceivableTypesSaga(): Generator<any, any, any> {
   let nextUrl = ''
+  let iterationCounter = 0;
   const allReceivableTypes = []
   try {
-    while (typeof nextUrl === 'string') {
+    while (typeof nextUrl === 'string' && iterationCounter < SAFETY_CAP_FOR_WHILE_LOOP_ITERATIONS) {
       const {
         response: {
           status: statusCode
@@ -52,6 +55,7 @@ function* fetchReceivableTypesSaga(): Generator<any, any, any> {
           nextUrl = null;
           break;
       }
+      iterationCounter++;
     }
     yield put(receiveReceivableTypes(allReceivableTypes));
   } catch (error) {

--- a/src/leaseCreateCharge/saga.ts
+++ b/src/leaseCreateCharge/saga.ts
@@ -30,29 +30,61 @@ function* fetchAttributesSaga(): Generator<any, any, any> {
 }
 
 function* fetchReceivableTypesSaga(): Generator<any, any, any> {
+  let nextUrl = ''
+  const allReceivableTypes = []
   try {
-    const {
-      response: {
-        status: statusCode
-      },
-      bodyAsJson
-    } = yield call(fetchReceivableTypes);
+    while (typeof nextUrl === 'string') {
+      const {
+        response: {
+          status: statusCode
+        },
+        bodyAsJson
+      } = yield call(fetchReceivableTypes, nextUrl);
 
-    switch (statusCode) {
-      case 200:
-        const receivableTypes = bodyAsJson.results;
-        yield put(receiveReceivableTypes(receivableTypes));
-        break;
+      switch (statusCode) {
+        case 200:
+          allReceivableTypes.push(...bodyAsJson.results);
+          nextUrl = bodyAsJson.next;
+          break;
 
-      default:
-        yield put(receivableTypesNotFound());
-        break;
+        default:
+          yield put(receivableTypesNotFound());
+          nextUrl = null;
+          break;
+      }
     }
-  } catch (error) {
-    console.error('Failed to fetch receivable types with error "%s"', error);
-    yield put(receivableTypesNotFound());
-    yield put(receiveError(error));
-  }
+    yield put(receiveReceivableTypes(allReceivableTypes));
+    } catch (error) {
+      console.error('Failed to fetch receivable types with error "%s"', error);
+      yield put(receivableTypesNotFound());
+      yield put(receiveError(error));
+      nextUrl = null;
+    }
+
+
+  // try {
+  //   const {
+  //     response: {
+  //       status: statusCode
+  //     },
+  //     bodyAsJson
+  //   } = yield call(fetchReceivableTypes);
+
+  //   switch (statusCode) {
+  //     case 200:
+  //       const receivableTypes = bodyAsJson.results;
+  //       yield put(receiveReceivableTypes(receivableTypes));
+  //       break;
+
+  //     default:
+  //       yield put(receivableTypesNotFound());
+  //       break;
+  //   }
+  // } catch (error) {
+  //   console.error('Failed to fetch receivable types with error "%s"', error);
+  //   yield put(receivableTypesNotFound());
+  //   yield put(receiveError(error));
+  // }
 }
 
 export default function* (): Generator<any, any, any> {

--- a/src/leaseCreateCharge/saga.ts
+++ b/src/leaseCreateCharge/saga.ts
@@ -54,37 +54,12 @@ function* fetchReceivableTypesSaga(): Generator<any, any, any> {
       }
     }
     yield put(receiveReceivableTypes(allReceivableTypes));
-    } catch (error) {
-      console.error('Failed to fetch receivable types with error "%s"', error);
-      yield put(receivableTypesNotFound());
-      yield put(receiveError(error));
-      nextUrl = null;
-    }
-
-
-  // try {
-  //   const {
-  //     response: {
-  //       status: statusCode
-  //     },
-  //     bodyAsJson
-  //   } = yield call(fetchReceivableTypes);
-
-  //   switch (statusCode) {
-  //     case 200:
-  //       const receivableTypes = bodyAsJson.results;
-  //       yield put(receiveReceivableTypes(receivableTypes));
-  //       break;
-
-  //     default:
-  //       yield put(receivableTypesNotFound());
-  //       break;
-  //   }
-  // } catch (error) {
-  //   console.error('Failed to fetch receivable types with error "%s"', error);
-  //   yield put(receivableTypesNotFound());
-  //   yield put(receiveError(error));
-  // }
+  } catch (error) {
+    console.error('Failed to fetch receivable types with error "%s"', error);
+    yield put(receivableTypesNotFound());
+    yield put(receiveError(error));
+    nextUrl = null;
+  }
 }
 
 export default function* (): Generator<any, any, any> {

--- a/src/leaseCreateCharge/saga.ts
+++ b/src/leaseCreateCharge/saga.ts
@@ -36,7 +36,7 @@ function* fetchReceivableTypesSaga(): Generator<any, any, any> {
   let iterationCounter = 0;
   const allReceivableTypes = []
   try {
-    while (typeof nextUrl === 'string' && iterationCounter < SAFETY_CAP_FOR_WHILE_LOOP_ITERATIONS) {
+    while (nextUrl !== null && iterationCounter < SAFETY_CAP_FOR_WHILE_LOOP_ITERATIONS) {
       const {
         response: {
           status: statusCode

--- a/src/leaseCreateCharge/saga.ts
+++ b/src/leaseCreateCharge/saga.ts
@@ -44,7 +44,7 @@ function* fetchReceivableTypesSaga(): Generator<any, any, any> {
       switch (statusCode) {
         case 200:
           allReceivableTypes.push(...bodyAsJson.results);
-          nextUrl = bodyAsJson.next;
+          nextUrl = bodyAsJson.next || null;
           break;
 
         default:


### PR DESCRIPTION
The default limit for receivable_type/ request is 30, but there are more receivable types for AKV than 30. This change makes the request in the mvj-ui to make several requests in order to get all the available receivable types for the given service unit.