### PR TITLE
sorting for seasonal dueDates

### DIFF
--- a/src/leases/components/leaseSections/rent/BasicInfo.tsx
+++ b/src/leases/components/leaseSections/rent/BasicInfo.tsx
@@ -5,7 +5,7 @@ import Authorization from "@/components/authorization/Authorization";
 import FormText from "@/components/form/FormText";
 import FormTextTitle from "@/components/form/FormTextTitle";
 import { LeaseRentDueDatesFieldPaths, LeaseRentDueDatesFieldTitles, LeaseRentsFieldPaths, LeaseRentsFieldTitles, RentCycles, RentTypes, RentDueDateTypes } from "@/leases/enums";
-import { formatDueDates, formatSeasonalDate } from "@/leases/helpers";
+import { formatDueDates, formatSeasonalDate, sortDueDates } from "@/leases/helpers";
 import { getUiDataLeaseKey } from "@/uiData/helpers";
 import { formatDate, formatNumber, getFieldOptions, getLabelOfOption, isEmptyValue, isFieldAllowedToRead } from "@/util/helpers";
 import { getAttributes as getLeaseAttributes } from "@/leases/selectors";
@@ -120,7 +120,7 @@ const BasicInfoIndexOrManual = ({
               <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseRentDueDatesFieldPaths.DUE_DATES)}>
                 {LeaseRentDueDatesFieldTitles.DUE_DATES}
               </FormTextTitle>
-              <FormText>{rent.due_dates && !!rent.due_dates.length ? formatDueDates(rent.due_dates) : 'Ei eräpäiviä'}</FormText>
+              <FormText>{rent.due_dates && !!rent.due_dates.length ? formatDueDates(sortDueDates(rent.due_dates)) : 'Ei eräpäiviä'}</FormText>
               </>
             </Authorization>
           </Column>}
@@ -371,7 +371,7 @@ const BasicInfoFixed = ({
               <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseRentDueDatesFieldPaths.DUE_DATES)}>
                 {LeaseRentDueDatesFieldTitles.DUE_DATES}
               </FormTextTitle>
-              <FormText>{rent.due_dates && !!rent.due_dates.length ? formatDueDates(rent.due_dates) : 'Ei eräpäiviä'}</FormText>
+              <FormText>{rent.due_dates && !!rent.due_dates.length ? formatDueDates(sortDueDates(rent.due_dates)) : 'Ei eräpäiviä'}</FormText>
               </>
             </Authorization>
           </Column>}

--- a/src/leases/components/leaseSections/rent/BasicInfoEdit.tsx
+++ b/src/leases/components/leaseSections/rent/BasicInfoEdit.tsx
@@ -15,7 +15,7 @@ import { rentCustomDateOptions } from "@/leases/constants";
 import { FieldTypes, FormNames } from "@/enums";
 import { DueDatesPositions, FixedDueDates, LeaseRentDueDatesFieldPaths, LeaseRentDueDatesFieldTitles, LeaseRentsFieldPaths, LeaseRentsFieldTitles, RentCycles, RentTypes, RentDueDateTypes } from "@/leases/enums";
 import { UsersPermissions } from "@/usersPermissions/enums";
-import { formatDueDates, formatSeasonalDate } from "@/leases/helpers";
+import { formatDueDates, formatSeasonalDate, sortDueDates } from "@/leases/helpers";
 import { getUiDataLeaseKey } from "@/uiData/helpers";
 import { getFieldAttributes, hasPermissions, isFieldAllowedToEdit, isFieldAllowedToRead, isFieldRequired } from "@/util/helpers";
 import { getAttributes as getLeaseAttributes, getCurrentLease } from "@/leases/selectors";
@@ -23,7 +23,7 @@ import { getLeaseTypeList } from "@/leaseType/selectors";
 import { getUsersPermissions } from "@/usersPermissions/selectors";
 import { PlotSearchFieldPaths } from "@/plotSearch/enums";
 import type { Attributes } from "types";
-import type { Lease } from "@/leases/types";
+import type { DueDate, Lease } from "@/leases/types";
 import type { LeaseTypeList } from "@/leaseType/types";
 import type { UsersPermissions as UsersPermissionsType } from "@/usersPermissions/types";
 const formName = FormNames.LEASE_RENTS;
@@ -37,6 +37,7 @@ type SeasonalDatesProps = {
   seasonalStartDay: string | null | undefined;
   seasonalStartMonth: string | null | undefined;
 };
+
 const SeasonalDates = connect((state, props: Props) => {
   return {
     seasonalEndDay: selector(state, `${props.field}.seasonal_end_day`),
@@ -105,7 +106,7 @@ const SeasonalDates = connect((state, props: Props) => {
     </Authorization>;
 });
 type DueDatesProps = {
-  dueDates: Array<Record<string, any>>;
+  dueDates: Array<DueDate>;
   fields: any;
   isSaveClicked: boolean;
   leaseAttributes: Attributes;
@@ -132,7 +133,7 @@ const renderDueDates = ({
           </FormTextTitle>
         </Column>
       </Row>
-      <Authorization allow={isFieldAllowedToEdit(leaseAttributes, LeaseRentDueDatesFieldPaths.DAY) || isFieldAllowedToEdit(leaseAttributes, LeaseRentDueDatesFieldPaths.MONTH)} errorComponent={<FormText>{formatDueDates(dueDates) || '-'}</FormText>}>
+      <Authorization allow={isFieldAllowedToEdit(leaseAttributes, LeaseRentDueDatesFieldPaths.DAY) || isFieldAllowedToEdit(leaseAttributes, LeaseRentDueDatesFieldPaths.MONTH)} errorComponent={<FormText>{formatDueDates(sortDueDates(dueDates)) || '-'}</FormText>}>
         {fields && !!fields.length && fields.map((due_date, index) => {
         const handleRemove = () => {
           fields.remove(index);
@@ -196,7 +197,7 @@ const BasicInfoEmpty = ({
 
 type BasicInfoIndexOrManualProps = {
   cycle: string | null | undefined;
-  dueDates: Array<Record<string, any>>;
+  dueDates: Array<DueDate>;
   dueDatesType: string | null | undefined;
   field: string;
   rentType: string;
@@ -268,7 +269,7 @@ const BasicInfoIndexOrManual = ({
             {
           /* Authorization is done on renderDueDates component */
         }
-            <FieldArray component={renderDueDates} dueDates={dueDates} isSaveClicked={isSaveClicked} leaseAttributes={leaseAttributes} name="due_dates" usersPermissions={usersPermissions} />
+            <FieldArray component={renderDueDates} dueDates={sortDueDates(dueDates)} isSaveClicked={isSaveClicked} leaseAttributes={leaseAttributes} name="due_dates" usersPermissions={usersPermissions} />
           </Column>}
         {dueDatesType === RentDueDateTypes.FIXED && <Column small={6} medium={4} large={1}>
             <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseRentsFieldPaths.DUE_DATES_PER_YEAR)}>
@@ -327,7 +328,7 @@ const BasicInfoIndexOrManual = ({
 };
 
 type BasicInfoOneTimeProps = {
-  dueDates: Array<Record<string, any>>;
+  dueDates: Array<DueDate>;
   dueDatesType: string | null | undefined;
   isSaveClicked: boolean;
   leaseAttributes: Attributes;
@@ -383,7 +384,7 @@ const BasicInfoOneTime = ({
 };
 
 type BasicInfoFixedProps = {
-  dueDates: Array<Record<string, any>>;
+  dueDates: Array<DueDate>;
   dueDatesType: string | null | undefined;
   field: string;
   isSaveClicked: boolean;
@@ -435,7 +436,7 @@ const BasicInfoFixed = ({
             {
           /* Authorization is done on renderDueDates component */
         }
-            <FieldArray component={renderDueDates} dueDates={dueDates} isSaveClicked={isSaveClicked} leaseAttributes={leaseAttributes} name="due_dates" usersPermissions={usersPermissions} />
+            <FieldArray component={renderDueDates} dueDates={sortDueDates(dueDates)} isSaveClicked={isSaveClicked} leaseAttributes={leaseAttributes} name="due_dates" usersPermissions={usersPermissions} />
           </Column>}
         {dueDatesType === RentDueDateTypes.FIXED && <Column small={6} medium={4} large={1}>
             <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseRentsFieldPaths.DUE_DATES_PER_YEAR)}>
@@ -526,7 +527,7 @@ type Props = {
   change: (...args: Array<any>) => any;
   currentLease: Lease;
   cycle: string;
-  dueDates: Array<Record<string, any>>;
+  dueDates: Array<DueDate>;
   dueDatesPerYear: number | null | undefined;
   dueDatesType: string | null | undefined;
   field: string;

--- a/src/leases/helpers.ts
+++ b/src/leases/helpers.ts
@@ -22,7 +22,7 @@ import type { Lease, IntendedUse } from "./types";
 import type { CommentList } from "@/comments/types";
 import type { Attributes, LeafletFeature, LeafletGeoJson } from "types";
 import type { RootState } from "@/root/types";
-import type { LeaseList } from "@/leases/types";
+import type { LeaseList, DueDate } from "@/leases/types";
 
 /**
  * Test is lease empty
@@ -2853,21 +2853,34 @@ export const formatSeasonalDate = (day: string | null | undefined, month: string
 
 /**
  * Format single due date as string
- * @param {Object} date
+ * @param {DueDate} date
  * @returns {string}
  */
-const formatDueDate = (date: Record<string, any>): string => {
+const formatDueDate = (date: DueDate): string => {
   return `${date.day}.${date.month}.`;
 };
 
 /**
  * Format due dates as string
- * @param {Object[]} dates
+ * @param {Array<DueDate>} dates
  * @returns {string}
  */
-export const formatDueDates = (dates: Array<Record<string, any>>): string => {
+export const formatDueDates = (dates: Array<DueDate>): string => {
   return dates.map(date => formatDueDate(date)).join(', ');
 };
+
+/**
+ * Sort due dates by month and day
+ * @param {Array<DueDate>} dueDates 
+ * @returns {Array<DueDate>} Sorted array of due date objects with day and month properties.
+ */
+export const sortDueDates = (dueDates: Array<DueDate>): Array<DueDate> => {
+  return dueDates.sort((a, b) => {
+    if (a.month !== b.month) {
+      return a.month - b.month;
+    }
+    return a.day - b.day;
+})};
 
 /**
  * Test is any lease page form dirty

--- a/src/leases/types.ts
+++ b/src/leases/types.ts
@@ -84,3 +84,8 @@ export type ClearFormValidFlagsAction = Action<string, void>;
 export type ReceiveCollapseStatesAction = Action<string, Record<string, any>>;
 export type FetchLeasesForContractNumberAction = Action<string, Record<string, any>>;
 export type ReceiveLeasesForContractNumbersAction = Action<string, LeaseList>;
+export type DueDate = {
+  id: number;
+  day: number;
+  month: number;
+}


### PR DESCRIPTION
Sort due dates correctly in the UI. Currently they are not shown in correct order, sorting needs to be done first by month then by date