### PR TITLE
MVJ-421 Tasotarkistus Add New

### DIFF
--- a/src/leases/components/LeaseListPage.tsx
+++ b/src/leases/components/LeaseListPage.tsx
@@ -55,6 +55,13 @@ import type { LeaseList } from "@/leases/types";
 import type { LessorList } from "@/lessor/types";
 import type { ServiceUnits } from "@/serviceUnits/types";
 import type { UsersPermissions as UsersPermissionsType, UserServiceUnit } from "@/usersPermissions/types";
+import { 
+  getOldDwellingsInHousingCompaniesPriceIndex,
+  getIsFetching as getIsFetchingOldDwellingsInHousingCompaniesPriceIndex
+} from "@/oldDwellingsInHousingCompaniesPriceIndex/selectors";
+import { OldDwellingsInHousingCompaniesPriceIndex } from "@/oldDwellingsInHousingCompaniesPriceIndex/types";
+import { fetchOldDwellingsInHousingCompaniesPriceIndex } from "@/oldDwellingsInHousingCompaniesPriceIndex/actions";
+
 const VisualizationTypes = {
   MAP: 'map',
   TABLE: 'table'
@@ -76,6 +83,7 @@ type Props = {
   fetchLeasesByBBox: (...args: Array<any>) => any;
   fetchLessors: (...args: Array<any>) => any;
   fetchServiceUnits: (...args: Array<any>) => any;
+  fetchOldDwellingsInHousingCompaniesPriceIndex: (...args: Array<any>) => any;
   history: Record<string, any>;
   initialize: (...args: Array<any>) => any;
   isFetching: boolean;
@@ -87,6 +95,7 @@ type Props = {
   leases: LeaseList;
   lessors: LessorList;
   location: Record<string, any>;
+  oldDwellingsInHousingCompaniesPriceIndex: OldDwellingsInHousingCompaniesPriceIndex | null;
   receiveTopNavigationSettings: (...args: Array<any>) => any;
   serviceUnits: ServiceUnits;
   userActiveServiceUnit: UserServiceUnit;
@@ -130,8 +139,11 @@ class LeaseListPage extends PureComponent<Props, State> {
       fetchAreaNoteList,
       fetchLessors,
       fetchServiceUnits,
+      fetchOldDwellingsInHousingCompaniesPriceIndex,
       isFetchingServiceUnits,
+      isFetchingOldDwellingsInHousingCompaniesPriceIndex,
       lessors,
+      oldDwellingsInHousingCompaniesPriceIndex,
       receiveTopNavigationSettings,
       serviceUnits,
       leaseAttributes
@@ -155,6 +167,10 @@ class LeaseListPage extends PureComponent<Props, State> {
       fetchLessors({
         limit: 10000
       });
+    }
+
+    if (!isFetchingOldDwellingsInHousingCompaniesPriceIndex && !oldDwellingsInHousingCompaniesPriceIndex) {
+      fetchOldDwellingsInHousingCompaniesPriceIndex();
     }
 
     window.addEventListener('popstate', this.handlePopState);
@@ -723,10 +739,12 @@ export default flowRight(withLeaseAttributes, withUiDataList, connect(state => {
     isFetching: getIsFetching(state),
     isFetchingByBBox: getIsFetchingByBBox(state),
     isFetchingServiceUnits: getIsFetchingServiceUnits(state),
+    isFetchingOldDwellingsInHousingCompaniesPriceIndex: getIsFetchingOldDwellingsInHousingCompaniesPriceIndex(state),
     leases: getLeasesList(state),
     lessors: getLessorList(state),
     serviceUnits: getServiceUnits(state),
     userActiveServiceUnit: getUserActiveServiceUnit(state),
+    oldDwellingsInHousingCompaniesPriceIndex: getOldDwellingsInHousingCompaniesPriceIndex(state),
     usersPermissions: getUsersPermissions(state)
   };
 }, {
@@ -736,6 +754,7 @@ export default flowRight(withLeaseAttributes, withUiDataList, connect(state => {
   fetchLeasesByBBox,
   fetchLessors,
   fetchServiceUnits,
+  fetchOldDwellingsInHousingCompaniesPriceIndex,
   initialize,
   receiveTopNavigationSettings
 }))(LeaseListPage);

--- a/src/leases/components/LeaseListPage.tsx
+++ b/src/leases/components/LeaseListPage.tsx
@@ -90,6 +90,7 @@ type Props = {
   isFetchingByBBox: boolean;
   isFetchingLeaseAttributes: boolean;
   isFetchingServiceUnits: boolean;
+  isFetchingOldDwellingsInHousingCompaniesPriceIndex: boolean;
   leaseAttributes: Attributes;
   leaseMethods: MethodsType;
   leases: LeaseList;

--- a/src/leases/components/leaseSections/rent/OldDwellingsInHousingCompaniesPriceIndex.tsx
+++ b/src/leases/components/leaseSections/rent/OldDwellingsInHousingCompaniesPriceIndex.tsx
@@ -4,10 +4,12 @@ import { getCurrentLeaseStartDate, getAttributes as getLeaseAttributes } from '@
 import { flowRight } from 'lodash';
 import { connect } from 'react-redux';
 import type { 
-  OldDwellingsInHousingCompaniesPriceIndex as OldDwellingsInHousingCompaniesPriceIndexProps,
-  IndexPointFigureYearly as IndexPointFigureYearlyProps,
   OldDwellingsInHousingCompaniesPriceIndexType,
 } from '@/leases/types';
+import type { 
+  OldDwellingsInHousingCompaniesPriceIndex as OldDwellingsInHousingCompaniesPriceIndexProps,
+  IndexPointFigureYearly as IndexPointFigureYearlyProps,
+} from '@/oldDwellingsInHousingCompaniesPriceIndex/types';
 import BoxItemContainer from '@/components/content/BoxItemContainer';
 import { withWindowResize } from '@/components/resize/WindowResizeHandler';
 import FormText from "@/components/form/FormText";

--- a/src/leases/components/leaseSections/rent/OldDwellingsInHousingCompaniesPriceIndexEdit.tsx
+++ b/src/leases/components/leaseSections/rent/OldDwellingsInHousingCompaniesPriceIndexEdit.tsx
@@ -7,10 +7,12 @@ import {
 import { flowRight } from "lodash";
 import { connect } from "react-redux";
 import type {
-  OldDwellingsInHousingCompaniesPriceIndex as OldDwellingsInHousingCompaniesPriceIndexProps,
-  IndexPointFigureYearly as IndexPointFigureYearlyProps,
   OldDwellingsInHousingCompaniesPriceIndexType,
 } from "@/leases/types";
+import type {
+  OldDwellingsInHousingCompaniesPriceIndex as OldDwellingsInHousingCompaniesPriceIndexProps,
+  IndexPointFigureYearly as IndexPointFigureYearlyProps,
+} from "@/oldDwellingsInHousingCompaniesPriceIndex/types";
 import BoxItemContainer from "@/components/content/BoxItemContainer";
 import { withWindowResize } from "@/components/resize/WindowResizeHandler";
 import FormText from "@/components/form/FormText";

--- a/src/leases/components/leaseSections/rent/OldDwellingsInHousingCompaniesPriceIndexEdit.tsx
+++ b/src/leases/components/leaseSections/rent/OldDwellingsInHousingCompaniesPriceIndexEdit.tsx
@@ -26,11 +26,13 @@ import { formatDate, getFieldAttributes } from "@/util/helpers";
 import FormField from "@/components/form/FormField";
 import { Attributes } from "@/types";
 import { getReviewDays } from "@/leases/helpers";
+import AddButton from "@/components/form/AddButton";
 
 type Props = {
-  oldDwellingsInHousingCompaniesPriceIndex: OldDwellingsInHousingCompaniesPriceIndexProps;
+  oldDwellingsInHousingCompaniesPriceIndex: OldDwellingsInHousingCompaniesPriceIndexProps | null;
   oldDwellingsInHousingCompaniesPriceIndexType: OldDwellingsInHousingCompaniesPriceIndexType;
-  typeFieldName: string;
+  addOldDwellingsInHousingCompaniesPriceIndex: () => void;
+  field: string;
   leaseAttributes: Attributes;
   leaseStartDate: string;
   isSaveClicked: boolean;
@@ -54,21 +56,20 @@ class OldDwellingsInHousingCompaniesPriceIndexEdit extends PureComponent<Props> 
     const {
       oldDwellingsInHousingCompaniesPriceIndex,
       oldDwellingsInHousingCompaniesPriceIndexType,
-      typeFieldName,
+      addOldDwellingsInHousingCompaniesPriceIndex,
+      field,
       leaseAttributes,
       leaseStartDate,
       isSaveClicked,
     } = this.props;
 
-    if (!oldDwellingsInHousingCompaniesPriceIndex) {
-      return null;
-    }
 
     const {
       point_figures: pointFigures,
       source_table_label: sourceTableLabel,
     } = oldDwellingsInHousingCompaniesPriceIndex || {};
     return (
+      oldDwellingsInHousingCompaniesPriceIndex ?
       <Fragment>
         <BoxItemContainer>
           <Row>
@@ -79,7 +80,7 @@ class OldDwellingsInHousingCompaniesPriceIndexEdit extends PureComponent<Props> 
                   leaseAttributes,
                   LeaseRentsFieldPaths.OLD_DWELLINGS_IN_HOUSING_COMPANIES_PRICE_INDEX_TYPE,
                 )}
-                name={typeFieldName}
+                name={`${field}.old_dwellings_in_housing_companies_price_index_type`}
                 overrideValues={{
                   label: LeaseRentOldDwellingsInHousingCompaniesPriceIndexFieldTitles.TYPE,
                 }}
@@ -129,7 +130,13 @@ class OldDwellingsInHousingCompaniesPriceIndexEdit extends PureComponent<Props> 
           </Row>
         </BoxItemContainer>
       </Fragment>
-    );
+    : 
+    <AddButton
+      className={'no-top-margin'}
+      label='Lisää tasotarkistus'
+      onClick={addOldDwellingsInHousingCompaniesPriceIndex} 
+    />
+  );
   }
 }
 

--- a/src/leases/components/leaseSections/rent/RentItem.tsx
+++ b/src/leases/components/leaseSections/rent/RentItem.tsx
@@ -17,10 +17,11 @@ import { FormNames, ViewModes } from "@/enums";
 import { LeaseRentsFieldPaths, LeaseRentFixedInitialYearRentsFieldPaths, LeaseRentFixedInitialYearRentsFieldTitles, LeaseRentContractRentsFieldPaths, LeaseRentContractRentsFieldTitles, LeaseIndexAdjustedRentsFieldPaths, LeaseIndexAdjustedRentsFieldTitles, LeaseRentAdjustmentsFieldPaths, LeaseRentAdjustmentsFieldTitles, LeasePayableRentsFieldPaths, LeasePayableRentsFieldTitles, LeaseEqualizedRentsFieldPaths, LeaseEqualizedRentsFieldTitles, RentTypes } from "@/leases/enums";
 import { getUiDataLeaseKey } from "@/uiData/helpers";
 import { formatDateRange, getFieldOptions, getLabelOfOption, isActive, isArchived, isFieldAllowedToRead } from "@/util/helpers";
-import { getAttributes as getLeaseAttributes, getCollapseStateByKey } from "@/leases/selectors";
+import { getAttributes as getLeaseAttributes, getCollapseStateByKey, getCurrentLeaseTypeIdentifier } from "@/leases/selectors";
 import type { Attributes } from "types";
 import type { ServiceUnit } from "@/serviceUnits/types";
 import OldDwellingsInHousingCompaniesPriceIndexView from "./OldDwellingsInHousingCompaniesPriceIndex";
+import { isATypedLease } from "@/leases/helpers";
 
 const formName = FormNames.LEASE_RENTS;
 type Props = {
@@ -30,6 +31,7 @@ type Props = {
   fixedInitialYearRentsCollapseState: boolean;
   indexAdjustedRentsCollapseState: boolean;
   leaseAttributes: Attributes;
+  leaseTypeIdentifier: string;
   payableRentsCollapseState: boolean;
   receiveCollapseStates: (...args: Array<any>) => any;
   rent: Record<string, any>;
@@ -46,6 +48,7 @@ const RentItem = ({
   fixedInitialYearRentsCollapseState,
   indexAdjustedRentsCollapseState,
   leaseAttributes,
+  leaseTypeIdentifier,
   payableRentsCollapseState,
   receiveCollapseStates,
   rent,
@@ -121,7 +124,7 @@ const RentItem = ({
         <BasicInfo rent={rent} rentType={rentType} serviceUnit={serviceUnit} />
 
       <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseRentsFieldPaths.OLD_DWELLINGS_IN_HOUSING_COMPANIES_PRICE_INDEX)}>
-      {oldDwellingsInHousingCompaniesPriceIndex && oldDwellingsInHousingCompaniesPriceIndexType &&
+      {oldDwellingsInHousingCompaniesPriceIndex && isATypedLease(leaseTypeIdentifier) &&
           <Collapse className='collapse__secondary' defaultOpen={oldDwellingsInHousingCompaniesPriceIndexCollapseState !== undefined ? oldDwellingsInHousingCompaniesPriceIndexCollapseState : true} headerTitle='Tasotarkistus'>
             <OldDwellingsInHousingCompaniesPriceIndexView oldDwellingsInHousingCompaniesPriceIndex={oldDwellingsInHousingCompaniesPriceIndex} oldDwellingsInHousingCompaniesPriceIndexType={oldDwellingsInHousingCompaniesPriceIndexType} />
           </Collapse>}
@@ -174,6 +177,7 @@ export default connect((state, props: Props) => {
     fixedInitialYearRentsCollapseState: getCollapseStateByKey(state, `${ViewModes.READONLY}.${formName}.${id}.fixed_initial_year_rents`),
     indexAdjustedRentsCollapseState: getCollapseStateByKey(state, `${ViewModes.READONLY}.${formName}.${id}.index_adjusted_rents`),
     leaseAttributes: getLeaseAttributes(state),
+    leaseTypeIdentifier: getCurrentLeaseTypeIdentifier(state),
     payableRentsCollapseState: getCollapseStateByKey(state, `${ViewModes.READONLY}.${formName}.${id}.payable_rents`),
     rentCollapseState: getCollapseStateByKey(state, `${ViewModes.READONLY}.${formName}.${id}.rent`),
     rentAdjustmentsCollapseState: getCollapseStateByKey(state, `${ViewModes.READONLY}.${formName}.${id}.rent_adjustments`)

--- a/src/leases/components/leaseSections/rent/RentItemEdit.tsx
+++ b/src/leases/components/leaseSections/rent/RentItemEdit.tsx
@@ -21,13 +21,14 @@ import { ContractRentPeriods, LeaseRentsFieldPaths, LeaseRentFixedInitialYearRen
 import { UsersPermissions } from "@/usersPermissions/enums";
 import { getUiDataLeaseKey } from "@/uiData/helpers";
 import { formatDateRange, getFieldOptions, getLabelOfOption, hasPermissions, isActive, isArchived, isEmptyValue, isFieldAllowedToRead } from "@/util/helpers";
-import { getAttributes as getLeaseAttributes, getCollapseStateByKey, getErrorsByFormName, getIsSaveClicked } from "@/leases/selectors";
+import { getAttributes as getLeaseAttributes, getCollapseStateByKey, getErrorsByFormName, getIsSaveClicked, getCurrentLeaseTypeIdentifier } from "@/leases/selectors";
 import { getUsersPermissions } from "@/usersPermissions/selectors";
 import type { Attributes } from "types";
 import type { UsersPermissions as UsersPermissionsType } from "@/usersPermissions/types";
 import OldDwellingsInHousingCompaniesPriceIndexEdit from "./OldDwellingsInHousingCompaniesPriceIndexEdit";
 import { OldDwellingsInHousingCompaniesPriceIndex as OldDwellingsInHousingCompaniesPriceIndexProps } from "@/oldDwellingsInHousingCompaniesPriceIndex/types";
 import { getOldDwellingsInHousingCompaniesPriceIndex } from "@/oldDwellingsInHousingCompaniesPriceIndex/selectors";
+import { isATypedLease } from "@/leases/helpers";
 
 type Props = {
   change: (...args: Array<any>) => any;
@@ -47,6 +48,7 @@ type Props = {
   indexAdjustedRentsCollapseState: boolean;
   isSaveClicked: boolean;
   leaseAttributes: Attributes;
+  leaseTypeIdentifier: string;
   onRemove: (...args: Array<any>) => any;
   payableRentsCollapseState: boolean;
   receiveCollapseStates: (...args: Array<any>) => any;
@@ -256,6 +258,7 @@ class RentItemEdit extends PureComponent<Props, State> {
       indexAdjustedRentsCollapseState,
       isSaveClicked,
       leaseAttributes,
+      leaseTypeIdentifier,
       payableRentsCollapseState,
       rentAdjustments,
       rentAdjustmentsCollapseState,
@@ -296,14 +299,15 @@ class RentItemEdit extends PureComponent<Props, State> {
         </FormSection>
 
         <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseRentsFieldPaths.OLD_DWELLINGS_IN_HOUSING_COMPANIES_PRICE_INDEX)}>
-          <Collapse className='collapse__secondary' defaultOpen={oldDwellingsInHousingCompaniesPriceIndexCollapseState !== undefined ? oldDwellingsInHousingCompaniesPriceIndexCollapseState : true} hasErrors={/*TODO: Error handling*/false} headerTitle={`${LeaseRentOldDwellingsInHousingCompaniesPriceIndexFieldTitles.OLD_DWELLINGS_IN_HOUSING_COMPANIES_PRICE_INDEX}`} onToggle={this.handleFixedInitialYearRentsCollapseToggle}>
+          {isATypedLease(leaseTypeIdentifier) && 
+            <Collapse className='collapse__secondary' defaultOpen={oldDwellingsInHousingCompaniesPriceIndexCollapseState !== undefined ? oldDwellingsInHousingCompaniesPriceIndexCollapseState : true} hasErrors={/*TODO: Error handling*/false} headerTitle={`${LeaseRentOldDwellingsInHousingCompaniesPriceIndexFieldTitles.OLD_DWELLINGS_IN_HOUSING_COMPANIES_PRICE_INDEX}`} onToggle={this.handleFixedInitialYearRentsCollapseToggle}>
               <OldDwellingsInHousingCompaniesPriceIndexEdit 
                 oldDwellingsInHousingCompaniesPriceIndex={rentOldDwellingsInHousingCompaniesPriceIndex}
                 oldDwellingsInHousingCompaniesPriceIndexType={oldDwellingsInHousingCompaniesPriceIndexType}
                 addOldDwellingsInHousingCompaniesPriceIndex={this.addOldDwellingsInHousingCompaniesPriceIndex}
                 field={field}
               />
-            </Collapse>
+            </Collapse>}
         </Authorization>
 
         <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseRentFixedInitialYearRentsFieldPaths.FIXED_INITIAL_YEAR_RENTS)}>
@@ -358,6 +362,7 @@ export default connect((state: State, props: Props) => {
     fixedInitialYearRents: selector(state, `${props.field}.fixed_initial_year_rents`),
     isSaveClicked: getIsSaveClicked(state),
     leaseAttributes: getLeaseAttributes(state),
+    leaseTypeIdentifier: getCurrentLeaseTypeIdentifier(state),
     oldDwellingsInHousingCompaniesPriceIndex: getOldDwellingsInHousingCompaniesPriceIndex(state),
     rentOldDwellingsInHousingCompaniesPriceIndex: selector(state, `${props.field}.old_dwellings_in_housing_companies_price_index`),
     rentAdjustments: selector(state, `${props.field}.rent_adjustments`),

--- a/src/leases/components/leaseSections/rent/RentItemEdit.tsx
+++ b/src/leases/components/leaseSections/rent/RentItemEdit.tsx
@@ -26,7 +26,9 @@ import { getUsersPermissions } from "@/usersPermissions/selectors";
 import type { Attributes } from "types";
 import type { UsersPermissions as UsersPermissionsType } from "@/usersPermissions/types";
 import OldDwellingsInHousingCompaniesPriceIndexEdit from "./OldDwellingsInHousingCompaniesPriceIndexEdit";
-import { OldDwellingsInHousingCompaniesPriceIndex as OldDwellingsInHousingCompaniesPriceIndexProps } from "@/leases/types";
+import { OldDwellingsInHousingCompaniesPriceIndex as OldDwellingsInHousingCompaniesPriceIndexProps } from "@/oldDwellingsInHousingCompaniesPriceIndex/types";
+import { getOldDwellingsInHousingCompaniesPriceIndex } from "@/oldDwellingsInHousingCompaniesPriceIndex/selectors";
+
 type Props = {
   change: (...args: Array<any>) => any;
   contractRentsCollapseState: boolean;
@@ -36,7 +38,8 @@ type Props = {
   equalizedRentsCollapseState: boolean;
   errors: Record<string, any> | null | undefined;
   field: string;
-  oldDwellingsInHousingCompaniesPriceIndex: OldDwellingsInHousingCompaniesPriceIndexProps;
+  oldDwellingsInHousingCompaniesPriceIndex: OldDwellingsInHousingCompaniesPriceIndexProps | null;
+  rentOldDwellingsInHousingCompaniesPriceIndex: OldDwellingsInHousingCompaniesPriceIndexProps | null | undefined;
   oldDwellingsInHousingCompaniesPriceIndexCollapseState: boolean;
   fixedInitialYearRents: Array<Record<string, any>>;
   fixedInitialYearRentsCollapseState: boolean;
@@ -182,55 +185,15 @@ class RentItemEdit extends PureComponent<Props, State> {
   addOldDwellingsInHousingCompaniesPriceIndex = () => {
     const {
       change,
-      field
+      field,
+      oldDwellingsInHousingCompaniesPriceIndex,
     } = this.props;
     
     change(
       formName,
       `${field}.old_dwellings_in_housing_companies_price_index`,
-      {
-        id: 1,
-        point_figures: [
-          {
-            id: 4,
-            value: "97.4",
-            year: 2023,
-            region: "pks",
-            comment: ""
-          },
-          {
-            id: 3,
-            value: "105.7",
-            year: 2022,
-            region: "pks",
-            comment: ""
-          },
-          {
-            id: 2,
-            value: "105.6",
-            year: 2021,
-            region: "pks",
-            comment: ""
-          },
-          {
-            id: 1,
-            value: "100.0",
-            year: 2020,
-            region: "pks",
-            comment: ""
-          }
-        ],
-        created_at: "2024-11-14T15:12:50.310543+02:00",
-        modified_at: "2024-12-08T18:05:37.983780+02:00",
-        code: "ketj_P_QA_T",
-        name: "Indeksi (2020=100)",
-        comment: "Indeksi on suhdeluku, joka kuvaa jonkin muuttujan (esimerkiksi hinnan, määrän tai arvon) suhteellista muutosta perusjakson (esimerkiksi vuoden) suhteen. Kunkin ajankohdan indeksipisteluku ilmoittaa, kuinka monta prosenttia kyseisen ajankohdan tarkasteltava muuttuja on perusjakson arvosta tai määrästä. Perusjakson indeksipistelukujen keskiarvo on 100. Tilastossa julkaistavat hintaindeksit ovat laatuvakioituja ja niiden kehitys voi poiketa neliöhintojen kehityksestä.\r\n",
-        source: "Tilastokeskus, osakeasuntojen hinnat",
-        source_table_updated: "2024-05-03T08:00:00+03:00",
-        source_table_label: "Vanhojen osakeasuntojen hintaindeksi (2020=100) ja kauppojen lukumäärät, vuositasolla muuttujina Vuosi, Alue ja Tiedot",
-        url: "https://pxdata.stat.fi:443/PxWeb/api/v1/fi/StatFin/ashi/statfin_ashi_pxt_13mq.px"
-      },
-);
+      oldDwellingsInHousingCompaniesPriceIndex
+    );
   }
   handleCollapseToggle = (key: string, val: boolean) => {
     const {
@@ -287,7 +250,7 @@ class RentItemEdit extends PureComponent<Props, State> {
       equalizedRentsCollapseState,
       field,
       fixedInitialYearRents,
-      oldDwellingsInHousingCompaniesPriceIndex,
+      rentOldDwellingsInHousingCompaniesPriceIndex,
       oldDwellingsInHousingCompaniesPriceIndexCollapseState,
       fixedInitialYearRentsCollapseState,
       indexAdjustedRentsCollapseState,
@@ -335,7 +298,7 @@ class RentItemEdit extends PureComponent<Props, State> {
         <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseRentsFieldPaths.OLD_DWELLINGS_IN_HOUSING_COMPANIES_PRICE_INDEX)}>
           <Collapse className='collapse__secondary' defaultOpen={oldDwellingsInHousingCompaniesPriceIndexCollapseState !== undefined ? oldDwellingsInHousingCompaniesPriceIndexCollapseState : true} hasErrors={/*TODO: Error handling*/false} headerTitle={`${LeaseRentOldDwellingsInHousingCompaniesPriceIndexFieldTitles.OLD_DWELLINGS_IN_HOUSING_COMPANIES_PRICE_INDEX}`} onToggle={this.handleFixedInitialYearRentsCollapseToggle}>
               <OldDwellingsInHousingCompaniesPriceIndexEdit 
-                oldDwellingsInHousingCompaniesPriceIndex={oldDwellingsInHousingCompaniesPriceIndex}
+                oldDwellingsInHousingCompaniesPriceIndex={rentOldDwellingsInHousingCompaniesPriceIndex}
                 oldDwellingsInHousingCompaniesPriceIndexType={oldDwellingsInHousingCompaniesPriceIndexType}
                 addOldDwellingsInHousingCompaniesPriceIndex={this.addOldDwellingsInHousingCompaniesPriceIndex}
                 field={field}
@@ -395,7 +358,8 @@ export default connect((state: State, props: Props) => {
     fixedInitialYearRents: selector(state, `${props.field}.fixed_initial_year_rents`),
     isSaveClicked: getIsSaveClicked(state),
     leaseAttributes: getLeaseAttributes(state),
-    oldDwellingsInHousingCompaniesPriceIndex: selector(state, `${props.field}.old_dwellings_in_housing_companies_price_index`),
+    oldDwellingsInHousingCompaniesPriceIndex: getOldDwellingsInHousingCompaniesPriceIndex(state),
+    rentOldDwellingsInHousingCompaniesPriceIndex: selector(state, `${props.field}.old_dwellings_in_housing_companies_price_index`),
     rentAdjustments: selector(state, `${props.field}.rent_adjustments`),
     rentId: id,
     rentType: selector(state, `${props.field}.type`),

--- a/src/leases/components/leaseSections/rent/RentItemEdit.tsx
+++ b/src/leases/components/leaseSections/rent/RentItemEdit.tsx
@@ -318,7 +318,6 @@ class RentItemEdit extends PureComponent<Props, State> {
           rentTypeIsIndex2022 = rentType === RentTypes.INDEX2022,
           rentTypeIsManual = rentType === RentTypes.MANUAL,
           rentTypeIsFixed = rentType === RentTypes.FIXED;
-    const oldDwellingsInHousingCompaniesPriceIndex = get(savedRent, 'old_dwellings_in_housing_companies_price_index');
     const oldDwellingsInHousingCompaniesPriceIndexType = get(savedRent, 'old_dwellings_in_housing_companies_price_index_type');
     return <Collapse archived={archived} defaultOpen={rentCollapseState !== undefined ? rentCollapseState : active || rents.length === 1 && !archived} hasErrors={isSaveClicked && !isEmpty(rentErrors)} headerTitle={<Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseRentsFieldPaths.TYPE)}>
             {getLabelOfOption(typeOptions, get(savedRent, 'type')) || '-'}

--- a/src/leases/components/leaseSections/rent/RentItemEdit.tsx
+++ b/src/leases/components/leaseSections/rent/RentItemEdit.tsx
@@ -26,6 +26,7 @@ import { getUsersPermissions } from "@/usersPermissions/selectors";
 import type { Attributes } from "types";
 import type { UsersPermissions as UsersPermissionsType } from "@/usersPermissions/types";
 import OldDwellingsInHousingCompaniesPriceIndexEdit from "./OldDwellingsInHousingCompaniesPriceIndexEdit";
+import { OldDwellingsInHousingCompaniesPriceIndex as OldDwellingsInHousingCompaniesPriceIndexProps } from "@/leases/types";
 type Props = {
   change: (...args: Array<any>) => any;
   contractRentsCollapseState: boolean;
@@ -35,6 +36,7 @@ type Props = {
   equalizedRentsCollapseState: boolean;
   errors: Record<string, any> | null | undefined;
   field: string;
+  oldDwellingsInHousingCompaniesPriceIndex: OldDwellingsInHousingCompaniesPriceIndexProps;
   oldDwellingsInHousingCompaniesPriceIndexCollapseState: boolean;
   fixedInitialYearRents: Array<Record<string, any>>;
   fixedInitialYearRentsCollapseState: boolean;
@@ -177,6 +179,59 @@ class RentItemEdit extends PureComponent<Props, State> {
       change(formName, `${field}.due_dates`, [{}]);
     }
   };
+  addOldDwellingsInHousingCompaniesPriceIndex = () => {
+    const {
+      change,
+      field
+    } = this.props;
+    
+    change(
+      formName,
+      `${field}.old_dwellings_in_housing_companies_price_index`,
+      {
+        id: 1,
+        point_figures: [
+          {
+            id: 4,
+            value: "97.4",
+            year: 2023,
+            region: "pks",
+            comment: ""
+          },
+          {
+            id: 3,
+            value: "105.7",
+            year: 2022,
+            region: "pks",
+            comment: ""
+          },
+          {
+            id: 2,
+            value: "105.6",
+            year: 2021,
+            region: "pks",
+            comment: ""
+          },
+          {
+            id: 1,
+            value: "100.0",
+            year: 2020,
+            region: "pks",
+            comment: ""
+          }
+        ],
+        created_at: "2024-11-14T15:12:50.310543+02:00",
+        modified_at: "2024-12-08T18:05:37.983780+02:00",
+        code: "ketj_P_QA_T",
+        name: "Indeksi (2020=100)",
+        comment: "Indeksi on suhdeluku, joka kuvaa jonkin muuttujan (esimerkiksi hinnan, määrän tai arvon) suhteellista muutosta perusjakson (esimerkiksi vuoden) suhteen. Kunkin ajankohdan indeksipisteluku ilmoittaa, kuinka monta prosenttia kyseisen ajankohdan tarkasteltava muuttuja on perusjakson arvosta tai määrästä. Perusjakson indeksipistelukujen keskiarvo on 100. Tilastossa julkaistavat hintaindeksit ovat laatuvakioituja ja niiden kehitys voi poiketa neliöhintojen kehityksestä.\r\n",
+        source: "Tilastokeskus, osakeasuntojen hinnat",
+        source_table_updated: "2024-05-03T08:00:00+03:00",
+        source_table_label: "Vanhojen osakeasuntojen hintaindeksi (2020=100) ja kauppojen lukumäärät, vuositasolla muuttujina Vuosi, Alue ja Tiedot",
+        url: "https://pxdata.stat.fi:443/PxWeb/api/v1/fi/StatFin/ashi/statfin_ashi_pxt_13mq.px"
+      },
+);
+  }
   handleCollapseToggle = (key: string, val: boolean) => {
     const {
       receiveCollapseStates,
@@ -232,6 +287,7 @@ class RentItemEdit extends PureComponent<Props, State> {
       equalizedRentsCollapseState,
       field,
       fixedInitialYearRents,
+      oldDwellingsInHousingCompaniesPriceIndex,
       oldDwellingsInHousingCompaniesPriceIndexCollapseState,
       fixedInitialYearRentsCollapseState,
       indexAdjustedRentsCollapseState,
@@ -282,7 +338,8 @@ class RentItemEdit extends PureComponent<Props, State> {
               <OldDwellingsInHousingCompaniesPriceIndexEdit 
                 oldDwellingsInHousingCompaniesPriceIndex={oldDwellingsInHousingCompaniesPriceIndex}
                 oldDwellingsInHousingCompaniesPriceIndexType={oldDwellingsInHousingCompaniesPriceIndexType}
-                typeFieldName={`${field}.old_dwellings_in_housing_companies_price_index_type`}
+                addOldDwellingsInHousingCompaniesPriceIndex={this.addOldDwellingsInHousingCompaniesPriceIndex}
+                field={field}
               />
             </Collapse>
         </Authorization>
@@ -329,7 +386,7 @@ class RentItemEdit extends PureComponent<Props, State> {
 
 const formName = FormNames.LEASE_RENTS;
 const selector = formValueSelector(formName);
-export default connect((state, props) => {
+export default connect((state: State, props: Props) => {
   const id = selector(state, `${props.field}.id`);
   const newProps: any = {
     contractRents: selector(state, `${props.field}.contract_rents`),
@@ -339,6 +396,7 @@ export default connect((state, props) => {
     fixedInitialYearRents: selector(state, `${props.field}.fixed_initial_year_rents`),
     isSaveClicked: getIsSaveClicked(state),
     leaseAttributes: getLeaseAttributes(state),
+    oldDwellingsInHousingCompaniesPriceIndex: selector(state, `${props.field}.old_dwellings_in_housing_companies_price_index`),
     rentAdjustments: selector(state, `${props.field}.rent_adjustments`),
     rentId: id,
     rentType: selector(state, `${props.field}.type`),

--- a/src/leases/helpers.ts
+++ b/src/leases/helpers.ts
@@ -2681,6 +2681,7 @@ export const addRentsFormValuesToPayload = (payload: Record<string, any>, formVa
       start_date: rent.start_date,
       end_date: rent.end_date,
       note: rent.note,
+      old_dwellings_in_housing_companies_price_index: rent.old_dwellings_in_housing_companies_price_index?.id,
       old_dwellings_in_housing_companies_price_index_type: rent.old_dwellings_in_housing_companies_price_index_type,
     };
 

--- a/src/leases/helpers.ts
+++ b/src/leases/helpers.ts
@@ -2948,7 +2948,7 @@ export const getReviewDays = (startDate: string, priceIndexType: OldDwellingsInH
   let increments: Array<number>;
 
   if (priceIndexType === oldDwellingsInHousingCompaniesPriceIndexTypeOptions.TASOTARKISTUS_20_10) {
-    increments = [20, 10, 10];
+    increments = [20, 10, 10, 10, 10, 10];
   } else if (priceIndexType === oldDwellingsInHousingCompaniesPriceIndexTypeOptions.TASOTARKISTUS_20_20) {
     increments = [20, 20, 20];
   } else {

--- a/src/leases/helpers.ts
+++ b/src/leases/helpers.ts
@@ -2966,3 +2966,14 @@ export const getReviewDays = (startDate: string, priceIndexType: OldDwellingsInH
 
   return checkDays;
 }
+
+/**
+ * Check if the lease is an A-typed lease.
+ * old_dwellings_in_housing_companies_price_index is only available for A-typed leases.
+ * @param {Lease} lease
+ * @returns {string}
+ */
+export const isATypedLease = (leaseTypeIdentifier: string): boolean => {
+  const identifier = leaseTypeIdentifier || '';
+  return identifier[0] === 'A';
+}

--- a/src/leases/selectors.ts
+++ b/src/leases/selectors.ts
@@ -37,5 +37,6 @@ export const getCollapseStateByKey: Selector<Record<string, any> | null | undefi
 export const getLeasesForContractNumbers: Selector<LeaseList, void> = (state: RootState): LeaseList => state.lease.leasesForContractNumbers;
 export const getIsFetchingLeasesForContractNumbers: Selector<boolean, void> = (state: RootState): boolean => state.lease.isFetchingLeasesForContractNumbers;
 
-// Selectors for lease attributes
+// Selectors for lease properties
 export const getCurrentLeaseStartDate: Selector<string, void> = (state: RootState): string => get(state.lease.current, 'start_date', '');
+export const getCurrentLeaseTypeIdentifier: Selector<string, void> = (state: RootState): string => get(state.lease.current, 'type.identifier', '');

--- a/src/leases/types.ts
+++ b/src/leases/types.ts
@@ -91,22 +91,7 @@ export type IntendedUse = {
   name: string;
   service_unit: ServiceUnit["id"];
 };
-export type IndexPointFigureYearly = {
-  value: number;
-  year: number;
-  region: string;
-  comment: string;
-}
-export type OldDwellingsInHousingCompaniesPriceIndex = {
-  code: string;
-  name: string;
-  comment: string;
-  source: string;
-  source_table_updated?: string;
-  source_table_label: string;
-  url: string;
-  point_figures: IndexPointFigureYearly[];
-}
+
 export type OldDwellingsInHousingCompaniesPriceIndexType = "TASOTARKISTUS_20_20" | "TASOTARKISTUS_20_10";
 
 export type FetchAttributesAction = Action<string, void>;

--- a/src/oldDwellingsInHousingCompaniesPriceIndex/actions.ts
+++ b/src/oldDwellingsInHousingCompaniesPriceIndex/actions.ts
@@ -1,0 +1,19 @@
+import { createAction } from "redux-actions";
+import { FETCH_ACTION_STRING, NOT_FOUND_ACTION_STRING, RECEIVE_ACTION_STRING } from "./constants";
+import {
+  FetchOldDwellingsInHousingCompaniesPriceIndexAction,
+  OldDwellingsInHousingCompaniesPriceIndex,
+  OldDwellingsInHousingCompaniesPriceIndexNotFoundAction,
+  ReceiveOldDwellingsInHousingCompaniesPriceIndexAction,
+} from "./types";
+
+export const fetchOldDwellingsInHousingCompaniesPriceIndex =
+  (): FetchOldDwellingsInHousingCompaniesPriceIndexAction => createAction(FETCH_ACTION_STRING)();
+
+export const receiveOldDwellingsInHousingCompaniesPriceIndex = (
+  payload: OldDwellingsInHousingCompaniesPriceIndex,
+): ReceiveOldDwellingsInHousingCompaniesPriceIndexAction =>
+  createAction(RECEIVE_ACTION_STRING)(payload);
+
+export const notFound = (): OldDwellingsInHousingCompaniesPriceIndexNotFoundAction =>
+  createAction(NOT_FOUND_ACTION_STRING)();

--- a/src/oldDwellingsInHousingCompaniesPriceIndex/constants.ts
+++ b/src/oldDwellingsInHousingCompaniesPriceIndex/constants.ts
@@ -1,0 +1,6 @@
+export const DEFAULT_OLD_DWELLINGS_IN_HOUSING_COMPANIES_PRICE_INDEX_ID = 1;
+
+// Action type strings
+export const FETCH_ACTION_STRING = "mvj/oldDwellingsInHousingCompaniesPriceIndex/FETCH";
+export const RECEIVE_ACTION_STRING = "mvj/oldDwellingsInHousingCompaniesPriceIndex/RECEIVE";
+export const NOT_FOUND_ACTION_STRING = "mvj/oldDwellingsInHousingCompaniesPriceIndex/NOT_FOUND";

--- a/src/oldDwellingsInHousingCompaniesPriceIndex/oldDwellingsInHousingCompaniesPriceIndex.spec.ts
+++ b/src/oldDwellingsInHousingCompaniesPriceIndex/oldDwellingsInHousingCompaniesPriceIndex.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  receiveOldDwellingsInHousingCompaniesPriceIndex,
+  fetchOldDwellingsInHousingCompaniesPriceIndex,
+  notFound,
+} from "./actions";
+import oldDwellingsInHousingCompaniesPriceIndexReducer from "./reducer";
+import type {
+  OldDwellingsInHousingCompaniesPriceIndex,
+  OldDwellingsInHousingCompaniesPriceIndexState,
+} from "./types";
+const defaultState: OldDwellingsInHousingCompaniesPriceIndexState = {
+  isFetching: false,
+  latest: null,
+};
+
+describe("oldDwellingsInHousingCompaniesPriceIndex", () => {
+  describe("Reducer", () => {
+    describe("oldDwellingsInHousingCompaniesPriceIndexReducer", () => {
+      it("should update oldDwellingsInHousingCompaniesPriceIndex", () => {
+        const dummy: OldDwellingsInHousingCompaniesPriceIndex = {
+          point_figures: [
+            {
+              value: 97.4,
+              year: 2023,
+              region: "pks",
+              comment: "",
+            },
+            {
+              value: 105.7,
+              year: 2022,
+              region: "pks",
+              comment: "",
+            },
+            {
+              value: 105.6,
+              year: 2021,
+              region: "pks",
+              comment: "",
+            },
+            {
+              value: 100.0,
+              year: 2020,
+              region: "pks",
+              comment: "",
+            },
+          ],
+          created_at: "2024-11-14T15:12:50.310543+02:00",
+          modified_at: "2024-12-08T18:05:37.983780+02:00",
+          code: "ketj_P_QA_T",
+          name: "Indeksi (2020=100)",
+          comment:
+            "Indeksi on suhdeluku, joka kuvaa jonkin muuttujan (esimerkiksi hinnan, määrän tai arvon) suhteellista muutosta perusjakson (esimerkiksi vuoden) suhteen. Kunkin ajankohdan indeksipisteluku ilmoittaa, kuinka monta prosenttia kyseisen ajankohdan tarkasteltava muuttuja on perusjakson arvosta tai määrästä. Perusjakson indeksipistelukujen keskiarvo on 100. Tilastossa julkaistavat hintaindeksit ovat laatuvakioituja ja niiden kehitys voi poiketa neliöhintojen kehityksestä.\r\n",
+          source: "Tilastokeskus, osakeasuntojen hinnat",
+          source_table_updated: "2024-05-03T08:00:00+03:00",
+          source_table_label:
+            "Vanhojen osakeasuntojen hintaindeksi (2020=100) ja kauppojen lukumäärät, vuositasolla muuttujina Vuosi, Alue ja Tiedot",
+          url: "https://pxdata.stat.fi:443/PxWeb/api/v1/fi/StatFin/ashi/statfin_ashi_pxt_13mq.px",
+        };
+
+        const newState = { ...defaultState, latest: dummy };
+        const state = oldDwellingsInHousingCompaniesPriceIndexReducer(
+          {},
+          receiveOldDwellingsInHousingCompaniesPriceIndex(dummy),
+        );
+        expect(state).to.deep.equal(newState);
+      });
+      it("should update isFetching flag to true when fetching vats", () => {
+        const newState = { ...defaultState, isFetching: true };
+        const state = oldDwellingsInHousingCompaniesPriceIndexReducer(
+          {},
+          fetchOldDwellingsInHousingCompaniesPriceIndex(),
+        );
+        expect(state).to.deep.equal(newState);
+      });
+      it("should update isFetching flag to false by notFound", () => {
+        const newState = { ...defaultState };
+        let state = oldDwellingsInHousingCompaniesPriceIndexReducer(
+          {},
+          fetchOldDwellingsInHousingCompaniesPriceIndex(),
+        );
+        state = oldDwellingsInHousingCompaniesPriceIndexReducer(state, notFound());
+        expect(state).to.deep.equal(newState);
+      });
+    });
+  });
+});

--- a/src/oldDwellingsInHousingCompaniesPriceIndex/oldDwellingsInHousingCompaniesPriceIndex.spec.ts
+++ b/src/oldDwellingsInHousingCompaniesPriceIndex/oldDwellingsInHousingCompaniesPriceIndex.spec.ts
@@ -45,8 +45,6 @@ describe("oldDwellingsInHousingCompaniesPriceIndex", () => {
               comment: "",
             },
           ],
-          created_at: "2024-11-14T15:12:50.310543+02:00",
-          modified_at: "2024-12-08T18:05:37.983780+02:00",
           code: "ketj_P_QA_T",
           name: "Indeksi (2020=100)",
           comment:

--- a/src/oldDwellingsInHousingCompaniesPriceIndex/reducer.ts
+++ b/src/oldDwellingsInHousingCompaniesPriceIndex/reducer.ts
@@ -1,0 +1,36 @@
+import { combineReducers } from "redux";
+import { handleActions } from "redux-actions";
+import type { Reducer } from "@/types";
+import {
+  FETCH_ACTION_STRING,
+  NOT_FOUND_ACTION_STRING,
+  RECEIVE_ACTION_STRING,
+} from "./constants";
+import {
+  OldDwellingsInHousingCompaniesPriceIndex,
+  ReceiveOldDwellingsInHousingCompaniesPriceIndexAction,
+} from "./types";
+
+const isFetchingReducer: Reducer<boolean> = handleActions(
+  {
+    [FETCH_ACTION_STRING]: () => true,
+    [NOT_FOUND_ACTION_STRING]: () => false,
+    [RECEIVE_ACTION_STRING]: () => false,
+  },
+  false,
+);
+const latestReducer: Reducer<OldDwellingsInHousingCompaniesPriceIndex> = handleActions(
+  {
+    [RECEIVE_ACTION_STRING]: (
+      state: OldDwellingsInHousingCompaniesPriceIndex,
+      { payload }: ReceiveOldDwellingsInHousingCompaniesPriceIndexAction,
+    ) => {
+      return payload;
+    },
+  },
+  null,
+);
+export default combineReducers<Record<string, any>, any>({
+  isFetching: isFetchingReducer,
+  latest: latestReducer,
+});

--- a/src/oldDwellingsInHousingCompaniesPriceIndex/requests.ts
+++ b/src/oldDwellingsInHousingCompaniesPriceIndex/requests.ts
@@ -1,0 +1,10 @@
+import callApi from "@/api/callApi";
+import createUrl from "@/api/createUrl";
+import { DEFAULT_OLD_DWELLINGS_IN_HOUSING_COMPANIES_PRICE_INDEX_ID } from "./constants";
+
+export const fetchOldDwellingsInHousingCompaniesPriceIndex = (): Generator<any, any, any> => {
+  // As of the beginning of 2025, there is only one index.
+  const id = DEFAULT_OLD_DWELLINGS_IN_HOUSING_COMPANIES_PRICE_INDEX_ID;
+
+  return callApi(new Request(createUrl(`old_dwellings_in_housing_companies_price_index/${id}`)));
+};

--- a/src/oldDwellingsInHousingCompaniesPriceIndex/saga.ts
+++ b/src/oldDwellingsInHousingCompaniesPriceIndex/saga.ts
@@ -15,7 +15,7 @@ function* fetchOldDwellingsInHousingCompaniesPriceIndexSaga(): Generator<any, an
 
     switch (statusCode) {
       case 200:
-        yield put(receiveOldDwellingsInHousingCompaniesPriceIndex(bodyAsJson.results));
+        yield put(receiveOldDwellingsInHousingCompaniesPriceIndex(bodyAsJson));
         break;
 
       default:

--- a/src/oldDwellingsInHousingCompaniesPriceIndex/saga.ts
+++ b/src/oldDwellingsInHousingCompaniesPriceIndex/saga.ts
@@ -1,0 +1,36 @@
+import { all, call, fork, put, takeLatest } from "redux-saga/effects";
+import { notFound, receiveOldDwellingsInHousingCompaniesPriceIndex } from "./actions";
+import { fetchOldDwellingsInHousingCompaniesPriceIndex } from "./requests";
+import { receiveError } from "@/api/actions";
+import { FETCH_ACTION_STRING } from "./constants";
+
+function* fetchOldDwellingsInHousingCompaniesPriceIndexSaga(): Generator<any, any, any> {
+  try {
+    const {
+      response: {
+        status: statusCode
+      },
+      bodyAsJson
+    } = yield call(fetchOldDwellingsInHousingCompaniesPriceIndex);
+
+    switch (statusCode) {
+      case 200:
+        yield put(receiveOldDwellingsInHousingCompaniesPriceIndex(bodyAsJson.results));
+        break;
+
+      default:
+        yield put(notFound());
+        break;
+    }
+  } catch (error) {
+    console.error('Failed to fetch fetch old dwellings in housing companies price index with error "%s"', error);
+    yield put(notFound());
+    yield put(receiveError(error));
+  }
+}
+
+export default function* (): Generator<any, any, any> {
+  yield all([fork(function* (): Generator<any, any, any> {
+    yield takeLatest(FETCH_ACTION_STRING, fetchOldDwellingsInHousingCompaniesPriceIndexSaga);
+  })]);
+}

--- a/src/oldDwellingsInHousingCompaniesPriceIndex/selectors.ts
+++ b/src/oldDwellingsInHousingCompaniesPriceIndex/selectors.ts
@@ -1,0 +1,12 @@
+import type { Selector } from "@/types";
+import type { RootState } from "@/root/types";
+import type { OldDwellingsInHousingCompaniesPriceIndex } from "./types";
+
+export const getIsFetching: Selector<boolean, void> = (state: RootState): boolean =>
+  state.oldDwellingsInHousingCompaniesPriceIndex.isFetching;
+export const getOldDwellingsInHousingCompaniesPriceIndex: Selector<
+  OldDwellingsInHousingCompaniesPriceIndex,
+  void
+> = (state: RootState): OldDwellingsInHousingCompaniesPriceIndex => {
+  return state.oldDwellingsInHousingCompaniesPriceIndex.latest;
+};

--- a/src/oldDwellingsInHousingCompaniesPriceIndex/types.ts
+++ b/src/oldDwellingsInHousingCompaniesPriceIndex/types.ts
@@ -1,0 +1,29 @@
+import type { Action } from "@/types";
+
+export type IndexPointFigureYearly = {
+  value: number;
+  year: number;
+  region: string;
+  comment: string;
+}
+
+export type OldDwellingsInHousingCompaniesPriceIndex = {
+  code: string;
+  name: string;
+  comment: string;
+  source: string;
+  source_table_updated?: string;
+  source_table_label: string;
+  url: string;
+  point_figures: IndexPointFigureYearly[];
+}
+export type OldDwellingsInHousingCompaniesPriceIndexId = number;
+
+export type OldDwellingsInHousingCompaniesPriceIndexState = {
+  isFetching: boolean;
+  latest: OldDwellingsInHousingCompaniesPriceIndex;
+};
+
+export type FetchOldDwellingsInHousingCompaniesPriceIndexAction = Action<string, void>;
+export type ReceiveOldDwellingsInHousingCompaniesPriceIndexAction = Action<string, OldDwellingsInHousingCompaniesPriceIndex>;
+export type OldDwellingsInHousingCompaniesPriceIndexNotFoundAction = Action<string, void>;

--- a/src/root/createRootReducer.ts
+++ b/src/root/createRootReducer.ts
@@ -29,6 +29,7 @@ import landUseInvoiceReducer from "@/landUseInvoices/reducer";
 import landUseContractReducer from "@/landUseContract/reducer";
 import landUseAgreementAttachmentReducer from "@/landUseAgreementAttachment/reducer";
 import leaseReducer from "@/leases/reducer";
+import oldDwellingsInHousingCompaniesPriceIndexReducer from "@/oldDwellingsInHousingCompaniesPriceIndex/reducer";
 import plotSearchReducer from "@/plotSearch/reducer";
 import plotApplicationsReducer from "@/plotApplications/reducer";
 import applicationReducer from "@/application/reducer";
@@ -86,6 +87,7 @@ export default ((history: Record<string, any>): Reducer<RootState> => combineRed
   leaseStatisticReport: leaseStatisticReportReducer,
   leaseType: leaseTypeReducer,
   lessor: lessorReducer,
+  oldDwellingsInHousingCompaniesPriceIndex: oldDwellingsInHousingCompaniesPriceIndexReducer,
   penaltyInterest: penaltyInterestReducer,
   previewInvoices: previewInvoicesReducer,
   rentBasis: rentBasisReducer,

--- a/src/root/createRootSaga.ts
+++ b/src/root/createRootSaga.ts
@@ -30,6 +30,7 @@ import leaseholdTransferSaga from "@/leaseholdTransfer/saga";
 import leaseStatisticReportSaga from "@/leaseStatisticReport/saga";
 import leaseTypeSaga from "@/leaseType/saga";
 import lessorSaga from "@/lessor/saga";
+import oldDwellingsInHousingCompaniesPriceIndexSaga from "@/oldDwellingsInHousingCompaniesPriceIndex/saga";
 import penaltyInterestSaga from "@/penaltyInterest/saga";
 import previewInvoicesSaga from "@/previewInvoices/saga";
 import relatedLeaseSaga from "@/relatedLease/saga";
@@ -79,7 +80,8 @@ function* rootSaga() {
     fork(leaseInspectionAttachmentSaga), 
     fork(leaseStatisticReportSaga), 
     fork(leaseTypeSaga), 
-    fork(lessorSaga), 
+    fork(lessorSaga),
+    fork(oldDwellingsInHousingCompaniesPriceIndexSaga),
     fork(penaltyInterestSaga), 
     fork(previewInvoicesSaga), 
     fork(relatedLeaseSaga), 


### PR DESCRIPTION
These changes implement the feature of adding tasotarkistus to a rent that previously does not have it. 

The `old_dwellings_in_housing_companies_price_index` has to be fetched from the database through the API, and the best way to implement this in the MVJ-UI is to create a new reducer for it. It should fetch the latest data from the DB when the LeaseListPage is opened. That data is used for adding a tasotarkistus for the rent.

The `old_dwellings_in_housing_companies_price_index` is supposed to be shown only for A-typed leases, so there's filtering for that.

These changes depend on these changes in the API: https://github.com/City-of-Helsinki/mvj/pull/793