### PR TITLE
remove prop type check

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,7 +14,8 @@ export default [
     languageOptions: { globals: globals.browser },
     files: ["src/**/*.{js,mjs,cjs,ts,jsx,tsx}"],
     rules: {
-      "@typescript-eslint/no-explicit-any": "off"
+      "@typescript-eslint/no-explicit-any": "off",
+      "react/prop-types": "off"
     }
   }
 ];


### PR DESCRIPTION
eslint gives an unnecessary error about missing React prop types.  For example,

```code
'fetchServiceUnits' is missing in props validation eslint[react/prop-types](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/prop-types.md)
```

This creates a lot of errors in the editor, making development and finding bugs harder. We don't use React's typing but that of TypeScript, so we can disable prop-types. TypeScript will still generate error for missing props.