### PR TITLE
bugfix: not possible to add tasotarkistus if page refreshed in single lease view

### DIFF
--- a/src/leases/components/LeaseListPage.tsx
+++ b/src/leases/components/LeaseListPage.tsx
@@ -55,12 +55,6 @@ import type { LeaseList } from "@/leases/types";
 import type { LessorList } from "@/lessor/types";
 import type { ServiceUnits } from "@/serviceUnits/types";
 import type { UsersPermissions as UsersPermissionsType, UserServiceUnit } from "@/usersPermissions/types";
-import { 
-  getOldDwellingsInHousingCompaniesPriceIndex,
-  getIsFetching as getIsFetchingOldDwellingsInHousingCompaniesPriceIndex
-} from "@/oldDwellingsInHousingCompaniesPriceIndex/selectors";
-import { OldDwellingsInHousingCompaniesPriceIndex } from "@/oldDwellingsInHousingCompaniesPriceIndex/types";
-import { fetchOldDwellingsInHousingCompaniesPriceIndex } from "@/oldDwellingsInHousingCompaniesPriceIndex/actions";
 
 const VisualizationTypes = {
   MAP: 'map',
@@ -83,20 +77,17 @@ type Props = {
   fetchLeasesByBBox: (...args: Array<any>) => any;
   fetchLessors: (...args: Array<any>) => any;
   fetchServiceUnits: (...args: Array<any>) => any;
-  fetchOldDwellingsInHousingCompaniesPriceIndex: (...args: Array<any>) => any;
   history: Record<string, any>;
   initialize: (...args: Array<any>) => any;
   isFetching: boolean;
   isFetchingByBBox: boolean;
   isFetchingLeaseAttributes: boolean;
   isFetchingServiceUnits: boolean;
-  isFetchingOldDwellingsInHousingCompaniesPriceIndex: boolean;
   leaseAttributes: Attributes;
   leaseMethods: MethodsType;
   leases: LeaseList;
   lessors: LessorList;
   location: Record<string, any>;
-  oldDwellingsInHousingCompaniesPriceIndex: OldDwellingsInHousingCompaniesPriceIndex | null;
   receiveTopNavigationSettings: (...args: Array<any>) => any;
   serviceUnits: ServiceUnits;
   userActiveServiceUnit: UserServiceUnit;
@@ -140,11 +131,8 @@ class LeaseListPage extends PureComponent<Props, State> {
       fetchAreaNoteList,
       fetchLessors,
       fetchServiceUnits,
-      fetchOldDwellingsInHousingCompaniesPriceIndex,
       isFetchingServiceUnits,
-      isFetchingOldDwellingsInHousingCompaniesPriceIndex,
       lessors,
-      oldDwellingsInHousingCompaniesPriceIndex,
       receiveTopNavigationSettings,
       serviceUnits,
       leaseAttributes
@@ -168,10 +156,6 @@ class LeaseListPage extends PureComponent<Props, State> {
       fetchLessors({
         limit: 10000
       });
-    }
-
-    if (!isFetchingOldDwellingsInHousingCompaniesPriceIndex && !oldDwellingsInHousingCompaniesPriceIndex) {
-      fetchOldDwellingsInHousingCompaniesPriceIndex();
     }
 
     window.addEventListener('popstate', this.handlePopState);
@@ -740,12 +724,10 @@ export default flowRight(withLeaseAttributes, withUiDataList, connect(state => {
     isFetching: getIsFetching(state),
     isFetchingByBBox: getIsFetchingByBBox(state),
     isFetchingServiceUnits: getIsFetchingServiceUnits(state),
-    isFetchingOldDwellingsInHousingCompaniesPriceIndex: getIsFetchingOldDwellingsInHousingCompaniesPriceIndex(state),
     leases: getLeasesList(state),
     lessors: getLessorList(state),
     serviceUnits: getServiceUnits(state),
     userActiveServiceUnit: getUserActiveServiceUnit(state),
-    oldDwellingsInHousingCompaniesPriceIndex: getOldDwellingsInHousingCompaniesPriceIndex(state),
     usersPermissions: getUsersPermissions(state)
   };
 }, {
@@ -755,7 +737,6 @@ export default flowRight(withLeaseAttributes, withUiDataList, connect(state => {
   fetchLeasesByBBox,
   fetchLessors,
   fetchServiceUnits,
-  fetchOldDwellingsInHousingCompaniesPriceIndex,
   initialize,
   receiveTopNavigationSettings
 }))(LeaseListPage);

--- a/src/leases/components/LeasePage.tsx
+++ b/src/leases/components/LeasePage.tsx
@@ -68,8 +68,15 @@ import type { Lease } from "@/leases/types";
 import type { LeaseTypeList } from "@/leaseType/types";
 import type { UsersPermissions as UsersPermissionsType, UserServiceUnit } from "@/usersPermissions/types";
 import type { VatList } from "@/vat/types";
+import { 
+  getOldDwellingsInHousingCompaniesPriceIndex,
+  getIsFetching as getIsFetchingOldDwellingsInHousingCompaniesPriceIndex
+} from "@/oldDwellingsInHousingCompaniesPriceIndex/selectors";
 import { getIsFetchingReceivableTypes } from "@/leaseCreateCharge/selectors";
 import { fetchReceivableTypes } from '@/leaseCreateCharge/actions';
+import { fetchOldDwellingsInHousingCompaniesPriceIndex } from "@/oldDwellingsInHousingCompaniesPriceIndex/actions";
+import { OldDwellingsInHousingCompaniesPriceIndex } from "@/oldDwellingsInHousingCompaniesPriceIndex/types";
+
 type Props = {
   areasFormValues: Record<string, any>;
   change: (...args: Array<any>) => any;
@@ -88,6 +95,7 @@ type Props = {
   fetchInvoicesByLease: (...args: Array<any>) => any;
   fetchLeaseTypes: (...args: Array<any>) => any;
   fetchSingleLease: (...args: Array<any>) => any;
+  fetchOldDwellingsInHousingCompaniesPriceIndex: (...args: Array<any>) => any;
   fetchReceivableTypes: (...args: Array<any>) => any;
   fetchVats: (...args: Array<any>) => any;
   hideEditMode: (...args: Array<any>) => any;
@@ -99,6 +107,7 @@ type Props = {
   isFetching: boolean;
   isFetchingLeasePageAttributes: boolean;
   isFetchingReceivableTypes: boolean;
+  isFetchingOldDwellingsInHousingCompaniesPriceIndex: boolean;
   // get via withLeasePageAttributes HOC
   isFormValidFlags: Record<string, any>;
   isConstructabilityFormDirty: boolean;
@@ -127,6 +136,7 @@ type Props = {
   match: {
     params: Record<string, any>;
   };
+  oldDwellingsInHousingCompaniesPriceIndex: OldDwellingsInHousingCompaniesPriceIndex | null;
   patchLease: (...args: Array<any>) => any;
   receiveSingleLease: (...args: Array<any>) => any;
   receiveFormValidFlags: (...args: Array<any>) => any;
@@ -171,7 +181,10 @@ class LeasePage extends Component<Props, State> {
       location: {
         search
       },
-      receiveTopNavigationSettings
+      fetchOldDwellingsInHousingCompaniesPriceIndex,
+      isFetchingOldDwellingsInHousingCompaniesPriceIndex,
+      receiveTopNavigationSettings,
+      oldDwellingsInHousingCompaniesPriceIndex,
     } = this.props;
     const query = getUrlParams(search);
     this.setPageTitle();
@@ -189,6 +202,11 @@ class LeasePage extends Component<Props, State> {
 
     this.fetchCurrentLeaseData();
     this.fetchLeaseRelatedData();
+    
+    if (!isFetchingOldDwellingsInHousingCompaniesPriceIndex && !oldDwellingsInHousingCompaniesPriceIndex) {
+      fetchOldDwellingsInHousingCompaniesPriceIndex();
+    }
+
     hideEditMode();
     window.addEventListener('beforeunload', this.handleLeavePage);
     window.addEventListener('popstate', this.handlePopState);
@@ -998,6 +1016,7 @@ export default flowRight(withLeasePageAttributes, withUiDataList, withRouter, co
     isContractsFormValid: getIsFormValidById(state, FormNames.LEASE_CONTRACTS),
     isDecisionsFormDirty: isDirty(FormNames.LEASE_DECISIONS)(state),
     isDecisionsFormValid: getIsFormValidById(state, FormNames.LEASE_DECISIONS),
+    isFetchingOldDwellingsInHousingCompaniesPriceIndex: getIsFetchingOldDwellingsInHousingCompaniesPriceIndex(state),
     isFetchingReceivableTypes: getIsFetchingReceivableTypes(state),
     isInspectionsFormDirty: isDirty(FormNames.LEASE_INSPECTIONS)(state),
     isInspectionsFormValid: getIsFormValidById(state, FormNames.LEASE_INSPECTIONS),
@@ -1014,6 +1033,7 @@ export default flowRight(withLeasePageAttributes, withUiDataList, withRouter, co
     isSaveClicked: getIsSaveClicked(state),
     leaseTypeList: getLeaseTypeList(state),
     loggedUser: getLoggedInUser(state),
+    oldDwellingsInHousingCompaniesPriceIndex: getOldDwellingsInHousingCompaniesPriceIndex(state),
     rentsFormValues: getFormValues(FormNames.LEASE_RENTS)(state),
     summaryFormValues: getFormValues(FormNames.LEASE_SUMMARY)(state),
     tenantsFormValues: getFormValues(FormNames.LEASE_TENANTS)(state),
@@ -1029,6 +1049,7 @@ export default flowRight(withLeasePageAttributes, withUiDataList, withRouter, co
   fetchCommentsByLease,
   fetchInvoicesByLease,
   fetchLeaseTypes,
+  fetchOldDwellingsInHousingCompaniesPriceIndex,
   fetchSingleLease,
   fetchReceivableTypes,
   fetchVats,


### PR DESCRIPTION
This fixes the bug that prevents the user from adding tasotarkistus if they refresh the browser when a single lease is opened. Now the `oldDwellingsInHousingCompaniesPriceIndex` is fetched when the LeasePage is loaded so that it can be used for adding tasotarkistus if needed.