### PR TITLE
Add launch configuration for VS Code internal debugger

### DIFF
--- a/.vscode/launch.example.json
+++ b/.vscode/launch.example.json
@@ -1,0 +1,17 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // Launches Chrome browser, where your actions can be detected in VSCode internal debugger.
+      // Before this, you need to run the frontend in terminal with `yarn start`.
+      "type": "chrome",
+      "request": "launch",
+      "name": "Attach to localhost for debugging",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}/src",
+    }
+  ]
+}


### PR DESCRIPTION
Allows you to debug inside VS Code, if you prefer that over browser tools.