### PR TITLE
MVJ-565 Fix service unit ids in report query params

### DIFF
--- a/src/leaseStatisticReport/helpers.ts
+++ b/src/leaseStatisticReport/helpers.ts
@@ -111,6 +111,13 @@ export const getQueryParams = (formValues: Record<string, any>): any => {
   if (formValues) Object.entries(formValues).map(([key, value]) => {
     if (key.includes('date')) {
       query += `${key}=${format(value, 'yyyy-MM-dd')}&`;
+    } else if (key.includes('service_unit')) {
+      const serviceUnitIds = value
+      serviceUnitIds.forEach(id => {
+        if (id) {
+          query += `service_unit=${id}&`;
+        };
+      });
     } else query += `${key}=${value}&`;
   });
   return query.slice(0, -1);
@@ -148,27 +155,5 @@ export const formatType = (value: Record<string, any>): string => {
 
     default:
       return formattedValue;
-  }
-};
-
-/**
- * Parses the query params from service_unit=num1,num2 format
- * into service_unit=num1&service_unit=num2 format
- * @param {string} query
- * @return {string}
- */
-export const parseServiceUnitQuery = (query: string): string => {
-  const queryArray = query.split('&');
-  const serviceUnitIndex = queryArray.findIndex((item: string) => item.includes("service_unit"));
-
-  if (serviceUnitIndex !== -1) {
-    const serviceUnitQuery = queryArray.splice(serviceUnitIndex, 1);
-    const serviceUnitIds = serviceUnitQuery[0].split('=')[1].split(',');
-    serviceUnitIds.forEach(id => {
-      if (id) queryArray.push(`service_unit=${id}`);
-    });
-    return queryArray.join('&');
-  } else {
-    return query;
   }
 };

--- a/src/leaseStatisticReport/requests.ts
+++ b/src/leaseStatisticReport/requests.ts
@@ -1,6 +1,5 @@
 import callApi from "@/api/callApi";
 import createUrl from "@/api/createUrl";
-import { parseServiceUnitQuery } from "./helpers";
 
 export const fetchAttributes = (): Generator<any, any, any> => {
   return callApi(new Request(createUrl(`lease_create_collection_letter/`), {
@@ -19,12 +18,10 @@ export const fetchReports = (): Generator<any, any, any> => {
   return callApi(new Request(createUrl('report/')));
 };
 export const fetchReportData = (payload: Record<string, any>): Generator<any, any, any> => {
-  const parsedQuery = parseServiceUnitQuery(payload.query) || '';
-  return callApi(new Request(`${payload.url}?${parsedQuery}`));
+  return callApi(new Request(`${payload.url}?${payload.query}`));
 };
 export const sendReportToMail = (payload: Record<string, any>): Generator<any, any, any> => {
-  const parsedQuery = parseServiceUnitQuery(payload.query) || '';
-  return callApi(new Request(`${payload.url}?${parsedQuery}`));
+  return callApi(new Request(`${payload.url}?${payload.query}`));
 };
 export const fetchOptions = (payload: any): Generator<any, any, any> => {
   return callApi(new Request(payload, {


### PR DESCRIPTION
Report Excel link formulated the service unit query parameter like `service_unit=`, `service_unit=1`, and `service_unit=1,2`. API instead expects service unit IDs in query parameters in format `service_unit=1&service_unit=2`, or no parameter at all if no service units are selected.

Because now all report payloads align with the same format, there is no more need to separately fix the service unit param in the payload.