### PR TITLE
rename tasotarkistus type variables

### DIFF
--- a/src/leases/components/leaseSections/rent/OldDwellingsInHousingCompaniesPriceIndex.tsx
+++ b/src/leases/components/leaseSections/rent/OldDwellingsInHousingCompaniesPriceIndex.tsx
@@ -4,7 +4,7 @@ import { getCurrentLeaseStartDate, getAttributes as getLeaseAttributes } from '@
 import { flowRight } from 'lodash';
 import { connect } from 'react-redux';
 import type { 
-  OldDwellingsInHousingCompaniesPriceIndexType,
+  PeriodicRentAdjustmentType,
 } from '@/leases/types';
 import type { 
   OldDwellingsInHousingCompaniesPriceIndex as OldDwellingsInHousingCompaniesPriceIndexProps,
@@ -14,14 +14,14 @@ import BoxItemContainer from '@/components/content/BoxItemContainer';
 import { withWindowResize } from '@/components/resize/WindowResizeHandler';
 import FormText from "@/components/form/FormText";
 import FormTextTitle from '@/components/form/FormTextTitle';
-import { LeaseFieldTitles, LeaseRentOldDwellingsInHousingCompaniesPriceIndexFieldPaths, LeaseRentOldDwellingsInHousingCompaniesPriceIndexFieldTitles, LeaseRentsFieldPaths, oldDwellingsInHousingCompaniesPriceIndexTypes } from '@/leases/enums';
+import { LeaseFieldTitles, LeaseRentOldDwellingsInHousingCompaniesPriceIndexFieldPaths, LeaseRentOldDwellingsInHousingCompaniesPriceIndexFieldTitles, LeaseRentsFieldPaths, periodicRentAdjustmentTypes } from '@/leases/enums';
 import { getUiDataLeaseKey } from '@/uiData/helpers';
 import { formatDate } from '@/util/helpers';
 import { getReviewDays } from '@/leases/helpers';
 
 type Props = {
   oldDwellingsInHousingCompaniesPriceIndex: OldDwellingsInHousingCompaniesPriceIndexProps;
-  oldDwellingsInHousingCompaniesPriceIndexType: OldDwellingsInHousingCompaniesPriceIndexType;
+  periodicRentAdjustmentType: PeriodicRentAdjustmentType;
   leaseStartDate: string;
 };
 
@@ -35,7 +35,7 @@ class OldDwellingsInHousingCompaniesPriceIndexView extends PureComponent<Props> 
   render() {
     const {
       oldDwellingsInHousingCompaniesPriceIndex,
-      oldDwellingsInHousingCompaniesPriceIndexType,
+      periodicRentAdjustmentType,
       leaseStartDate
     } = this.props;
     const {
@@ -46,10 +46,10 @@ class OldDwellingsInHousingCompaniesPriceIndexView extends PureComponent<Props> 
       <BoxItemContainer>
         <Row>
           <Column>
-            <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseRentsFieldPaths.OLD_DWELLINGS_IN_HOUSING_COMPANIES_PRICE_INDEX_TYPE)}>
+            <FormTextTitle uiDataKey={getUiDataLeaseKey(LeaseRentsFieldPaths.PERIODIC_RENT_ADJUSTMENT_TYPE)}>
               {LeaseRentOldDwellingsInHousingCompaniesPriceIndexFieldTitles.TYPE}
             </FormTextTitle>
-            <FormText>{oldDwellingsInHousingCompaniesPriceIndexTypes[oldDwellingsInHousingCompaniesPriceIndexType]}</FormText>
+            <FormText>{periodicRentAdjustmentTypes[periodicRentAdjustmentType]}</FormText>
           </Column>
           <Column>
             <FormTextTitle>
@@ -70,7 +70,7 @@ class OldDwellingsInHousingCompaniesPriceIndexView extends PureComponent<Props> 
                 </FormTextTitle>
                   <>
                     {leaseStartDate ? 
-                      getReviewDays(leaseStartDate, oldDwellingsInHousingCompaniesPriceIndexType).map(
+                      getReviewDays(leaseStartDate, periodicRentAdjustmentType).map(
                         (date: string, index: number) => {
                           return <FormText key={LeaseRentOldDwellingsInHousingCompaniesPriceIndexFieldTitles.REVIEW_DAYS + `[${index}]`}>
                             {date}

--- a/src/leases/components/leaseSections/rent/OldDwellingsInHousingCompaniesPriceIndexEdit.tsx
+++ b/src/leases/components/leaseSections/rent/OldDwellingsInHousingCompaniesPriceIndexEdit.tsx
@@ -7,7 +7,7 @@ import {
 import { flowRight } from "lodash";
 import { connect } from "react-redux";
 import type {
-  OldDwellingsInHousingCompaniesPriceIndexType,
+  PeriodicRentAdjustmentType,
 } from "@/leases/types";
 import type {
   OldDwellingsInHousingCompaniesPriceIndex as OldDwellingsInHousingCompaniesPriceIndexProps,
@@ -32,7 +32,7 @@ import AddButton from "@/components/form/AddButton";
 
 type Props = {
   oldDwellingsInHousingCompaniesPriceIndex: OldDwellingsInHousingCompaniesPriceIndexProps | null;
-  oldDwellingsInHousingCompaniesPriceIndexType: OldDwellingsInHousingCompaniesPriceIndexType;
+  periodicRentAdjustmentType: PeriodicRentAdjustmentType;
   addOldDwellingsInHousingCompaniesPriceIndex: () => void;
   field: string;
   leaseAttributes: Attributes;
@@ -57,7 +57,7 @@ class OldDwellingsInHousingCompaniesPriceIndexEdit extends PureComponent<Props> 
   render() {
     const {
       oldDwellingsInHousingCompaniesPriceIndex,
-      oldDwellingsInHousingCompaniesPriceIndexType,
+      periodicRentAdjustmentType,
       addOldDwellingsInHousingCompaniesPriceIndex,
       field,
       leaseAttributes,
@@ -80,14 +80,14 @@ class OldDwellingsInHousingCompaniesPriceIndexEdit extends PureComponent<Props> 
                 disableTouched={isSaveClicked}
                 fieldAttributes={getFieldAttributes(
                   leaseAttributes,
-                  LeaseRentsFieldPaths.OLD_DWELLINGS_IN_HOUSING_COMPANIES_PRICE_INDEX_TYPE,
+                  LeaseRentsFieldPaths.PERIODIC_RENT_ADJUSTMENT_TYPE,
                 )}
-                name={`${field}.old_dwellings_in_housing_companies_price_index_type`}
+                name={`${field}.periodic_rent_adjustment_type`}
                 overrideValues={{
                   label: LeaseRentOldDwellingsInHousingCompaniesPriceIndexFieldTitles.TYPE,
                 }}
                 enableUiDataEdit
-                uiDataKey={getUiDataLeaseKey(LeaseRentOldDwellingsInHousingCompaniesPriceIndexFieldPaths.OLD_DWELLINGS_IN_HOUSING_COMPANIES_PRICE_INDEX_TYPE)}
+                uiDataKey={getUiDataLeaseKey(LeaseRentOldDwellingsInHousingCompaniesPriceIndexFieldPaths.PERIODIC_RENT_ADJUSTMENT_TYPE)}
               />
             </Column>
             <Column>
@@ -116,7 +116,7 @@ class OldDwellingsInHousingCompaniesPriceIndexEdit extends PureComponent<Props> 
               </FormTextTitle>
               <>
                 {leaseStartDate ? 
-                  getReviewDays(leaseStartDate, oldDwellingsInHousingCompaniesPriceIndexType).map(
+                  getReviewDays(leaseStartDate, periodicRentAdjustmentType).map(
                     (date: string, index: number) => {
                       return <FormText key={LeaseRentOldDwellingsInHousingCompaniesPriceIndexFieldPaths.POINT_FIGURES + `[${index}]`}>
                         {date}

--- a/src/leases/components/leaseSections/rent/RentItem.tsx
+++ b/src/leases/components/leaseSections/rent/RentItem.tsx
@@ -101,7 +101,7 @@ const RentItem = ({
         archived = isArchived(rent),
         rentType = get(rent, 'type'),
         oldDwellingsInHousingCompaniesPriceIndex = get(rent, 'old_dwellings_in_housing_companies_price_index', {}),
-        oldDwellingsInHousingCompaniesPriceIndexType = get(rent, 'old_dwellings_in_housing_companies_price_index_type'),
+        periodicRentAdjustmentType = get(rent, 'periodic_rent_adjustment_type'),
         fixedInitialYearRents = get(rent, 'fixed_initial_year_rents', []),
         contractRents = get(rent, 'contract_rents', []),
         indexAdjustedRents = get(rent, 'index_adjusted_rents', []),
@@ -126,7 +126,7 @@ const RentItem = ({
       <Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseRentsFieldPaths.OLD_DWELLINGS_IN_HOUSING_COMPANIES_PRICE_INDEX)}>
       {oldDwellingsInHousingCompaniesPriceIndex && isATypedLease(leaseTypeIdentifier) &&
           <Collapse className='collapse__secondary' defaultOpen={oldDwellingsInHousingCompaniesPriceIndexCollapseState !== undefined ? oldDwellingsInHousingCompaniesPriceIndexCollapseState : true} headerTitle='Tasotarkistus'>
-            <OldDwellingsInHousingCompaniesPriceIndexView oldDwellingsInHousingCompaniesPriceIndex={oldDwellingsInHousingCompaniesPriceIndex} oldDwellingsInHousingCompaniesPriceIndexType={oldDwellingsInHousingCompaniesPriceIndexType} />
+            <OldDwellingsInHousingCompaniesPriceIndexView oldDwellingsInHousingCompaniesPriceIndex={oldDwellingsInHousingCompaniesPriceIndex} periodicRentAdjustmentType={periodicRentAdjustmentType} />
           </Collapse>}
       </Authorization>
 

--- a/src/leases/components/leaseSections/rent/RentItemEdit.tsx
+++ b/src/leases/components/leaseSections/rent/RentItemEdit.tsx
@@ -284,7 +284,7 @@ class RentItemEdit extends PureComponent<Props, State> {
           rentTypeIsIndex2022 = rentType === RentTypes.INDEX2022,
           rentTypeIsManual = rentType === RentTypes.MANUAL,
           rentTypeIsFixed = rentType === RentTypes.FIXED;
-    const oldDwellingsInHousingCompaniesPriceIndexType = get(savedRent, 'old_dwellings_in_housing_companies_price_index_type');
+    const periodicRentAdjustmentType = get(savedRent, 'periodic_rent_adjustment_type');
     return <Collapse archived={archived} defaultOpen={rentCollapseState !== undefined ? rentCollapseState : active || rents.length === 1 && !archived} hasErrors={isSaveClicked && !isEmpty(rentErrors)} headerTitle={<Authorization allow={isFieldAllowedToRead(leaseAttributes, LeaseRentsFieldPaths.TYPE)}>
             {getLabelOfOption(typeOptions, get(savedRent, 'type')) || '-'}
           </Authorization>} headerSubtitles={<Column small={6} medium={8} large={10}>
@@ -303,7 +303,7 @@ class RentItemEdit extends PureComponent<Props, State> {
             <Collapse className='collapse__secondary' defaultOpen={oldDwellingsInHousingCompaniesPriceIndexCollapseState !== undefined ? oldDwellingsInHousingCompaniesPriceIndexCollapseState : true} hasErrors={/*TODO: Error handling*/false} headerTitle={`${LeaseRentOldDwellingsInHousingCompaniesPriceIndexFieldTitles.OLD_DWELLINGS_IN_HOUSING_COMPANIES_PRICE_INDEX}`} onToggle={this.handleFixedInitialYearRentsCollapseToggle}>
               <OldDwellingsInHousingCompaniesPriceIndexEdit 
                 oldDwellingsInHousingCompaniesPriceIndex={rentOldDwellingsInHousingCompaniesPriceIndex}
-                oldDwellingsInHousingCompaniesPriceIndexType={oldDwellingsInHousingCompaniesPriceIndexType}
+                periodicRentAdjustmentType={periodicRentAdjustmentType}
                 addOldDwellingsInHousingCompaniesPriceIndex={this.addOldDwellingsInHousingCompaniesPriceIndex}
                 field={field}
               />

--- a/src/leases/enums.ts
+++ b/src/leases/enums.ts
@@ -869,7 +869,7 @@ export const LeaseRentsFieldPaths = {
   Y_VALUE_START: 'rents.child.children.y_value_start',
   OVERRIDE_RECEIVABLE_TYPE: 'rents.child.children.override_receivable_type',
   OLD_DWELLINGS_IN_HOUSING_COMPANIES_PRICE_INDEX: 'rents.child.children.old_dwellings_in_housing_companies_price_index',
-  OLD_DWELLINGS_IN_HOUSING_COMPANIES_PRICE_INDEX_TYPE: 'rents.child.children.old_dwellings_in_housing_companies_price_index_type',
+  PERIODIC_RENT_ADJUSTMENT_TYPE: 'rents.child.children.periodic_rent_adjustment_type',
 };
 
 /**
@@ -924,14 +924,13 @@ export const LeaseRentDueDatesFieldTitles = {
   MONTH: 'Kuukausi'
 };
 
-
 /**
  * Lease rent old dwellings in housing companies price index field paths enumerable.
  *
  * @type {{}}
  */
 export const LeaseRentOldDwellingsInHousingCompaniesPriceIndexFieldPaths = {
-  OLD_DWELLINGS_IN_HOUSING_COMPANIES_PRICE_INDEX_TYPE: 'rents.child.children.old_dwellings_in_housing_companies_price_index_type',
+  PERIODIC_RENT_ADJUSTMENT_TYPE: 'rents.child.children.periodic_rent_adjustment_type',
   POINT_FIGURES: 'rents.child.children.old_dwellings_in_housing_companies_price_index.point_figures',
 };
 
@@ -1612,7 +1611,7 @@ export const calculatorTypeOptions = [{
   label: 'Laitekaappi'
 }];
 
-export const oldDwellingsInHousingCompaniesPriceIndexTypes = {
+export const periodicRentAdjustmentTypes = {
   TASOTARKISTUS_20_20: "Tasotarkistus 20v/20v",
   TASOTARKISTUS_20_10: "Tasotarkistus 20v/10v",
 }

--- a/src/leases/helpers.ts
+++ b/src/leases/helpers.ts
@@ -18,7 +18,7 @@ import { addEmptyOption, convertStrToDecimalNumber, fixedLengthNumber, formatDat
 import { getCoordinatesOfGeometry } from "@/util/map";
 import { getIsEditMode } from "./selectors";
 import { removeSessionStorageItem } from "@/util/storage";
-import type { Lease, LeaseArea, LeaseAreaAddress, IntendedUse, OldDwellingsInHousingCompaniesPriceIndexType } from "./types";
+import type { Lease, LeaseArea, LeaseAreaAddress, IntendedUse, PeriodicRentAdjustmentType } from "./types";
 import type { CommentList } from "@/comments/types";
 import type { Attributes, LeafletFeature, LeafletGeoJson } from "types";
 import type { RootState } from "@/root/types";
@@ -1639,7 +1639,7 @@ export const getContentRents = (lease: Lease): Array<Record<string, any>> => get
     yearly_due_dates: getContentRentDueDate(rent, 'yearly_due_dates'),
     override_receivable_type: get(rent, 'override_receivable_type.id') || rent.override_receivable_type,
     old_dwellings_in_housing_companies_price_index: rent.old_dwellings_in_housing_companies_price_index,
-    old_dwellings_in_housing_companies_price_index_type: rent.old_dwellings_in_housing_companies_price_index_type,
+    periodic_rent_adjustment_type: rent.periodic_rent_adjustment_type,
   };
 }).sort(sortByStartAndEndDateDesc);
 
@@ -2682,7 +2682,7 @@ export const addRentsFormValuesToPayload = (payload: Record<string, any>, formVa
       end_date: rent.end_date,
       note: rent.note,
       old_dwellings_in_housing_companies_price_index: rent.old_dwellings_in_housing_companies_price_index?.id,
-      old_dwellings_in_housing_companies_price_index_type: rent.old_dwellings_in_housing_companies_price_index_type,
+      periodic_rent_adjustment_type: rent.periodic_rent_adjustment_type,
     };
 
     // Patch amount only if rent type is one time
@@ -2940,10 +2940,10 @@ export const sortRelatedHistoryItems = (a: Record<string, any>, b: Record<string
 /**
  * Get check days for old_dwellings_in_housing_companies_price_index of the given start date.
  * @param {string} startDate
- * @param {OldDwellingsInHousingCompaniesPriceIndexType} priceIndexType
+ * @param {PeriodicRentAdjustmentType} priceIndexType
  * @returns {Array<string>}
  */
-export const getReviewDays = (startDate: string, priceIndexType: OldDwellingsInHousingCompaniesPriceIndexType): Array<string> => {
+export const getReviewDays = (startDate: string, priceIndexType: PeriodicRentAdjustmentType): Array<string> => {
   const checkDays = [];
   let increments: Array<number>;
 

--- a/src/leases/types.ts
+++ b/src/leases/types.ts
@@ -92,7 +92,7 @@ export type IntendedUse = {
   service_unit: ServiceUnit["id"];
 };
 
-export type OldDwellingsInHousingCompaniesPriceIndexType = "TASOTARKISTUS_20_20" | "TASOTARKISTUS_20_10";
+export type PeriodicRentAdjustmentType = "TASOTARKISTUS_20_20" | "TASOTARKISTUS_20_10";
 
 export type FetchAttributesAction = Action<string, void>;
 export type ReceiveAttributesAction = Action<string, Attributes>;


### PR DESCRIPTION
Previously, tasotarkistus type for rent was named as `old_dwellings_in_housing_companies_price_index_type`, but in this change, it is renamed as `periodic_rent_adjustment_type`.
 
The related API changes are here: https://github.com/City-of-Helsinki/mvj/pull/801