### PR TITLE
MVJ-214 auditlog: include areasearch and plotsearch

### DIFF
--- a/src/auditLog/helpers.ts
+++ b/src/auditLog/helpers.ts
@@ -33,6 +33,9 @@ export const getAuditLogActionTypeInFinnish = (action: string) => {
  */
 const getGeneralAuditLogContentLabel = (key: string) => {
   switch (key) {
+    case 'areasearch':
+      return 'Aluehaku';
+
     case 'contract':
       return 'Sopimus';
 
@@ -71,6 +74,9 @@ const getGeneralAuditLogContentLabel = (key: string) => {
 
     case 'note':
       return 'Huomautus';
+    
+    case 'plotsearch':
+      return 'Tonttihaku';
 
     case 'rent':
       return 'Vuokra';
@@ -90,20 +96,26 @@ const getGeneralAuditLogContentLabel = (key: string) => {
 
 /** 
  * Get auditlog content label
+ * @param {Object} areaSearchAttributes
  * @param {Object} leaseAttributes
  * @param {Object} commentAttributes
  * @param {Object} contactAttributes
  * @param {Object} invoiceAttributes
  * @param {Object} infillDevelopmentCompensationAttributes
+ * @param {Object} plotSearchAttributes
  * @param {string} contentType
  * @param {string} key
  * @returns {string}
  */
-export const getAuditLogContentLabel = (leaseAttributes: Attributes, commentAttributes: Attributes, contactAttributes: Attributes, invoiceAttributes: Attributes, infillDevelopmentCompensationAttributes: Attributes, contentType: string, key: string) => {
+export const getAuditLogContentLabel = (areaSearchAttributes: Attributes, leaseAttributes: Attributes, commentAttributes: Attributes, contactAttributes: Attributes, invoiceAttributes: Attributes, infillDevelopmentCompensationAttributes: Attributes, plotSearchAttributes: Attributes, contentType: string,key: string) => {
   let fieldKey = key;
   let fieldAttributes = null;
 
   switch (contentType) {
+    case 'areasearch':
+      fieldAttributes = getFieldAttributes(areaSearchAttributes, key);
+      break;
+
     case 'comment':
       fieldAttributes = getFieldAttributes(commentAttributes, key);
       break;
@@ -217,6 +229,10 @@ export const getAuditLogContentLabel = (leaseAttributes: Attributes, commentAttr
     case 'plot':
       fieldKey = `${LeasePlotsFieldPaths.PLOTS}.child.children.${key}`;
       fieldAttributes = getFieldAttributes(leaseAttributes, fieldKey);
+      break;
+
+    case 'plotsearch':
+      fieldAttributes = getFieldAttributes(plotSearchAttributes, key);
       break;
 
     case 'rent':

--- a/src/components/auditLog/AuditLogTableItemChange.tsx
+++ b/src/components/auditLog/AuditLogTableItemChange.tsx
@@ -2,11 +2,13 @@ import React from "react";
 import { connect } from "react-redux";
 import ShowMore from "@/components/showMore/ShowMore";
 import { getAuditLogContentLabel } from "@/auditLog/helpers";
+import { getAttributes as getAreaSearchAttributes } from "@/areaSearch/selectors";
 import { getAttributes as getCommentAttributes } from "@/comments/selectors";
 import { getAttributes as getContactAttributes } from "@/contacts/selectors";
 import { getAttributes as getInfillDevelopmentCompensationAttributes } from "@/infillDevelopment/selectors";
 import { getAttributes as getInvoiceAttributes } from "@/invoices/selectors";
 import { getAttributes as getLeaseAttributes } from "@/leases/selectors";
+import { getAttributes as getPlotSearchAttributes } from "@/plotSearch/selectors";
 import type { Attributes } from "types";
 type Props = {
   change: {
@@ -14,29 +16,34 @@ type Props = {
     newValue: string | null | undefined;
     oldValue: string | null | undefined;
   };
+  areaSearchAttributes: Attributes;
   commentAttributes: Attributes;
   contactAttributes: Attributes;
   contentType: string;
   infillDevelopmentCompensationAttributes: Attributes;
   invoiceAttributes: Attributes;
   leaseAttributes: Attributes;
+  plotSearchAttributes: Attributes;
 };
 
 const AuditLogTableItemChange = ({
   change,
+  areaSearchAttributes,
   commentAttributes,
   contactAttributes,
   contentType,
   infillDevelopmentCompensationAttributes,
   invoiceAttributes,
-  leaseAttributes
+  leaseAttributes,
+  plotSearchAttributes,
 }: Props) => {
   return <tr>
       <td></td>
       <td></td>
       <td></td>
       <td></td>
-      <td>{getAuditLogContentLabel(leaseAttributes, commentAttributes, contactAttributes, invoiceAttributes, infillDevelopmentCompensationAttributes, contentType, change.key) || '-'}</td>
+      <td>{getAuditLogContentLabel(areaSearchAttributes, leaseAttributes, commentAttributes, contactAttributes, invoiceAttributes, infillDevelopmentCompensationAttributes, plotSearchAttributes, contentType,change.key) || '-'}
+      </td>
       <td><ShowMore className='no-margin inside-table' text={change.oldValue || '-'} /></td>
       <td><ShowMore className='no-margin inside-table' text={change.newValue || '-'} /></td>
     </tr>;
@@ -44,10 +51,12 @@ const AuditLogTableItemChange = ({
 
 export default connect(state => {
   return {
+    areaSearchAttributes: getAreaSearchAttributes(state),
     contactAttributes: getContactAttributes(state),
     commentAttributes: getCommentAttributes(state),
     infillDevelopmentCompensationAttributes: getInfillDevelopmentCompensationAttributes(state),
     invoiceAttributes: getInvoiceAttributes(state),
-    leaseAttributes: getLeaseAttributes(state)
+    leaseAttributes: getLeaseAttributes(state),
+    plotSearchAttributes: getPlotSearchAttributes(state),
   };
 })(AuditLogTableItemChange);

--- a/src/components/auditLog/AuditLogTableItemChange.tsx
+++ b/src/components/auditLog/AuditLogTableItemChange.tsx
@@ -42,7 +42,7 @@ const AuditLogTableItemChange = ({
       <td></td>
       <td></td>
       <td></td>
-      <td>{getAuditLogContentLabel(areaSearchAttributes, leaseAttributes, commentAttributes, contactAttributes, invoiceAttributes, infillDevelopmentCompensationAttributes, plotSearchAttributes, contentType,change.key) || '-'}
+      <td>{getAuditLogContentLabel(areaSearchAttributes, leaseAttributes, commentAttributes, contactAttributes, invoiceAttributes, infillDevelopmentCompensationAttributes, plotSearchAttributes, contentType, change.key) || '-'}
       </td>
       <td><ShowMore className='no-margin inside-table' text={change.oldValue || '-'} /></td>
       <td><ShowMore className='no-margin inside-table' text={change.newValue || '-'} /></td>


### PR DESCRIPTION
Include support for areasearches and plotsearches in the auditlog view, to view the change fields.

Corresponding backend changes: https://github.com/City-of-Helsinki/mvj/pull/805