### PR TITLE
Document issues with calculating basis of rent values in the UI

### DIFF
--- a/src/leases/components/leaseSections/rent/BasisOfRent.tsx
+++ b/src/leases/components/leaseSections/rent/BasisOfRent.tsx
@@ -80,7 +80,8 @@ type Props = {
  * The calculation logic of rents and subventions should be concentrated to the API code 
  * so that there could be a single source of truth for the calculation of these values.
  * 
- * Values like these are:
+ * Values that should be returned in an API response 
+ * instead of being calculated here are:
  * - currentAmountPerArea
  * - basicAnnualRent
  * - initialYearRent

--- a/src/leases/components/leaseSections/rent/BasisOfRent.tsx
+++ b/src/leases/components/leaseSections/rent/BasisOfRent.tsx
@@ -72,6 +72,41 @@ type Props = {
   totalDiscountedInitialYearRent: number;
 };
 
+/**
+ * There are many values in this component that are calculated with complex logic.
+ * Values like these should not be calculated in components, but rather in the API,
+ * and then fetched into the redux state to be used as readily calculated values.
+ * 
+ * The calculation logic of rents and subventions should be concentrated to the API code 
+ * so that there could be a single source of truth for the calculation of these values.
+ * 
+ * Values like these are:
+ * - currentAmountPerArea
+ * - basicAnnualRent
+ * - initialYearRent
+ * - discountedInitialYearRent
+ * - reLeaseDiscountPercent
+ * - reLeaseDiscountAmount
+ * - totalSubventionAmount
+ * - discountPercentage
+ * - temporarySubventionDiscountPercentage
+ * - subventionDiscountedInitial
+ * - zonePrice
+ * - rent 
+ *   (terminology of "rent" here is also misleading, 
+ *    because it is not a rent object but amount)
+ * - temporaryRent
+ * - temporaryRentIndexed
+ * - rentExtra
+ * - rentExtraIndexed
+ * - fieldsRent
+ * - basicAnnualFieldRentIndexed
+ * - mastAreaRent
+ * - rackAndHeightPrice
+ * - mastTotal
+ * - mastTotalIndexed
+ */
+
 const BasisOfRent = ({
   areaUnitOptions,
   basisOfRent,


### PR DESCRIPTION
I documented the issues with calculating basis of rent values in the UI code.

There is a list of values that, instead of being calculated in the UI component, could be calculated and returned in an API response instead. This could simplify the UI code, and put the calculation of these values in a proper place, where there could be a single source of truth for these values.

The refactoring is a complex operation and, after discussing with the PM, should be carried out when the focus of the sprint is on billing logic and related topics.