### PR TITLE
MVJ-203 Unselect areasearch preparer when lessor is changed

### DIFF
--- a/src/areaSearch/components/AreaSearchApplicationEdit.tsx
+++ b/src/areaSearch/components/AreaSearchApplicationEdit.tsx
@@ -5,7 +5,7 @@ import flowRight from "lodash/flowRight";
 import orderBy from "lodash/orderBy";
 import get from "lodash/get";
 import { Column, Row } from "react-foundation";
-import { reduxForm } from "redux-form";
+import { reduxForm, change, getFormValues } from "redux-form";
 import { getAttributes, getCurrentAreaSearch } from "@/areaSearch/selectors";
 import ApplicationAnswersSection from "@/application/components/ApplicationAnswersSection";
 import {
@@ -67,10 +67,12 @@ type Props = {
   isFetchingFormAttributes: boolean;
   isPerformingFileOperation: boolean;
   formAttributes: Attributes;
+  formValues: Record<string, any> | null | undefined;
   areaSearchAttributes: Attributes;
   initialize: (...args: Array<any>) => any;
   uploadAttachment: (...args: Array<any>) => any;
   setAreaSearchAttachments: (...args: Array<any>) => any;
+  change: (...args: Array<any>) => any;
 };
 type State = {
   // The Leaflet element doesn't initialize correctly if it's invisible in a collapsed section element,
@@ -132,6 +134,14 @@ class AreaSearchApplicationEdit extends Component<Props, State> {
           setAreaSearchAttachments([...currentFiles, newFile]);
         },
       });
+    }
+  };
+
+  handleLessorChange = (newLessor: string) => {
+    const { change, formValues } = this.props;
+    const lessorWasChanged = formValues?.lessor !== newLessor;
+    if (lessorWasChanged) {
+      change("preparer", null);
     }
   };
 
@@ -219,6 +229,7 @@ class AreaSearchApplicationEdit extends Component<Props, State> {
                       overrideValues={{
                         label: AreaSearchFieldTitles.LESSOR,
                       }}
+                      onChange={this.handleLessorChange}
                     />
                   </Column>
                   <Column small={6} medium={6} large={3}>
@@ -386,6 +397,7 @@ class AreaSearchApplicationEdit extends Component<Props, State> {
                       overrideValues={{
                         label: AreaSearchFieldTitles.LESSOR,
                       }}
+                      onChange={this.handleLessorChange}
                     />
                   </Column>
                   <Column small={6} medium={4} large={3}>
@@ -463,12 +475,14 @@ export default flowRight(
       areaSearch: getCurrentAreaSearch(state),
       areaSearchAttributes: getAttributes(state),
       formAttributes: getFormAttributes(state),
+      formValues: getFormValues(FormNames.AREA_SEARCH)(state),
       isFetchingFormAttributes: getIsFetchingFormAttributes(state),
       isPerformingFileOperation: getIsPerformingFileOperation(state),
     }),
     {
       uploadAttachment,
       setAreaSearchAttachments,
+      change,
     },
   ),
   reduxForm({

--- a/src/areaSearch/components/AreaSearchApplicationListPage.tsx
+++ b/src/areaSearch/components/AreaSearchApplicationListPage.tsx
@@ -366,7 +366,7 @@ class AreaSearchApplicationListPage extends PureComponent<Props, State> {
     const { editAreaSearch } = this.props;
     editAreaSearch({
       id: data.id,
-      preparer: data.preparer?.id || null,
+      preparer: data.preparer?.value || null,
       lessor: data.lessor,
       area_search_status: {
         status_notes: data.status_notes

--- a/src/areaSearch/components/EditAreaSearchPreparerForm.tsx
+++ b/src/areaSearch/components/EditAreaSearchPreparerForm.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { flowRight } from "lodash/util";
-import { getFormValues, reduxForm } from "redux-form";
+import { getFormValues, reduxForm, change } from "redux-form";
 import { connect } from "react-redux";
 import { Column, Row } from "react-foundation";
 import get from "lodash/get";
@@ -26,6 +26,7 @@ type Props = OwnProps & {
   areaSearchAttributes: Attributes;
   initialize: (...args: Array<any>) => any;
   formValues: Record<string, any> | null | undefined;
+  change: (...args: Array<any>) => any;
 };
 
 class EditAreaSearchPreparerForm extends Component<Props> {
@@ -51,6 +52,14 @@ class EditAreaSearchPreparerForm extends Component<Props> {
     }
   };
 
+  handleLessorChange = (newLessor: string) => {
+    const { change, formValues } = this.props;
+    const lessorWasChanged = formValues?.lessor !== newLessor;
+    if (lessorWasChanged) {
+      change("preparer", null);
+    }
+  };
+
   render(): JSX.Element {
     const {
       areaSearchAttributes,
@@ -70,6 +79,7 @@ class EditAreaSearchPreparerForm extends Component<Props> {
                 label: AreaSearchFieldTitles.LESSOR,
               }}
               setRefForField={this.setRefForFirstField}
+              onChange={this.handleLessorChange}
             />
           </Column>
           <Column small={6} medium={4} large={4}>
@@ -131,6 +141,7 @@ export default flowRight(
     }),
     {
       editAreaSearch,
+      change,
     },
     null,
     {

--- a/src/areaSearch/helpers.ts
+++ b/src/areaSearch/helpers.ts
@@ -124,7 +124,7 @@ export const prepareAreaSearchForSubmission = (
     id: data.id,
     state: data.state,
     lessor: data.lessor,
-    preparer: data.preparer?.id,
+    preparer: data.preparer?.value || null,
     area_search_status: {
       decline_reason: data.decline_reason,
       status_notes: data.status_notes

--- a/vite.config.js
+++ b/vite.config.js
@@ -64,6 +64,7 @@ export default defineConfig({
   },
   server: {
     port: 3000,
+    sourcemap: true,
   },
   test: {
     globals: true,


### PR DESCRIPTION
The requested change was implemented, but includes a bug: preparer is unset even if nothing is changed in the form.

This bug was present in the list view editing modal already, but now added to the areasearch details edit form. TODO