### PR TITLE
statistic report: 3 decimals for subvention_amount

### DIFF
--- a/src/leaseStatisticReport/components/LeaseInvoicingConfirmationReport.tsx
+++ b/src/leaseStatisticReport/components/LeaseInvoicingConfirmationReport.tsx
@@ -19,7 +19,7 @@ import {
   sortStringByKeyAsc,
   sortStringByKeyDesc,
 } from "@/util/helpers";
-import { LeaseStatisticReportFormatOptions } from "@/leaseStatisticReport/enums";
+import { LeaseStatisticReportFieldLabels, LeaseStatisticReportFormatOptions } from "@/leaseStatisticReport/enums";
 import {
   getDisplayName,
   getFormattedValue,
@@ -113,16 +113,21 @@ class LeaseInvoicingConfirmationReport extends PureComponent<Props, State> {
         renderer: (value: any) => {
           let isBold = false;
           let outputValue = value || "-";
-
-          if (field.key == "lease_identifier") {
+          let decimals: number | null | undefined;
+          
+          if (field.key == LeaseStatisticReportFieldLabels.LEASE_IDENTIFIER) {
             const { id, identifier } = value;
             outputValue = renderLeaseIdentifier(id, identifier);
           }
-
+          
+          if (field.key === LeaseStatisticReportFieldLabels.SUBVENTION_EUROS_PER_YEAR) {
+            decimals = 3;
+          }
+          
           if (field.choices && value) {
             outputValue = getDisplayName(field.choices, value);
           } else if (field.format && value) {
-            outputValue = getFormattedValue(field.format, value);
+            outputValue = getFormattedValue(field.format, value, decimals);
             isBold =
               field.format === LeaseStatisticReportFormatOptions.BOLD ||
               field.format === LeaseStatisticReportFormatOptions.BOLD_MONEY;

--- a/src/leaseStatisticReport/enums.ts
+++ b/src/leaseStatisticReport/enums.ts
@@ -142,3 +142,13 @@ export const LeaseStatisticReportFormatOptions = {
   MONEY: "money",
   PERCENTAGE: "percentage",
 };
+
+/**
+ * Lease statistics report field label enumerable
+ * @readonly
+ * @enum {string}
+ */
+export const LeaseStatisticReportFieldLabels = {
+  LEASE_IDENTIFIER: "lease_identifier",
+  SUBVENTION_EUROS_PER_YEAR: "subvention_euros_per_year",
+};

--- a/src/leaseStatisticReport/helpers.ts
+++ b/src/leaseStatisticReport/helpers.ts
@@ -86,11 +86,13 @@ export const getDisplayName = (
  * Get formatted value
  * @param {string} formatType
  * @param {string} value
+ * @param {number} decimals
  * @return {string}
  */
 export const getFormattedValue = (
   formatType: string,
   value: string,
+  decimals: number | null | undefined = 2,
 ): string => {
   switch (formatType) {
     case LeaseStatisticReportFormatOptions.DATE:
@@ -98,13 +100,13 @@ export const getFormattedValue = (
 
     case LeaseStatisticReportFormatOptions.MONEY:
     case LeaseStatisticReportFormatOptions.BOLD_MONEY:
-      return `${formatNumber(value)} €`;
+      return `${formatNumber(value, decimals)} €`;
 
     case LeaseStatisticReportFormatOptions.PERCENTAGE:
-      return `${formatNumber(value)} %`;
+      return `${formatNumber(value, decimals)} %`;
 
     case LeaseStatisticReportFormatOptions.AREA:
-      return `${formatNumber(value)} m²`;
+      return `${formatNumber(value, decimals)} m²`;
 
     default:
       return value;


### PR DESCRIPTION
Show `subvention_euros_per_year` (`Subventio euroina / vuosi`) in 3 decimals, as it is in the Vuokrat tab.

Add enums to handle special cases of rendering certain field values.

Related API changes: https://github.com/City-of-Helsinki/mvj/pull/873