### PR TITLE
set state.value to prop.selected in AreaSearchInput

### DIFF
--- a/src/components/address-search/AddressSearchInput.tsx
+++ b/src/components/address-search/AddressSearchInput.tsx
@@ -73,7 +73,7 @@ class AddressSearchInput extends Component<Props, State> {
     isLoading: false,
     menuOpen: false,
     selectedAddress: null,
-    value: "",
+    value: this.props.selected || "",
   };
   static defaultProps = {
     language: "fi",


### PR DESCRIPTION
Behavior was that onblur this component sets its value from state.value. And if on initialization the value in state is `""`, it will always remove whatever WAS selected in the component, once user exits the focus.
Particularly this is a problem when users try to copy-paste.