### PR TITLE
fix areasearch page to work without geometry

### DIFF
--- a/src/areaSearch/components/AreaSearchApplication.tsx
+++ b/src/areaSearch/components/AreaSearchApplication.tsx
@@ -89,7 +89,10 @@ class AreaSearchApplication extends Component<Props, State> {
         formAttributes,
         [],
       );
-      area = getAreaFromGeoJSON(areaSearch.geometry);
+      if (areaSearch.geometry) {
+        area = getAreaFromGeoJSON(areaSearch.geometry);
+      }
+
       selectedAreaTitle =
         [areaSearch.address, areaSearch.district]
           .filter((part) => !!part)
@@ -187,11 +190,13 @@ class AreaSearchApplication extends Component<Props, State> {
                 }}
                 defaultOpen
               >
-                <SingleAreaSearchMap
-                  geometry={areaSearch.geometry}
-                  key={selectedAreaSectionRefreshKey}
-                  minimap
-                />
+                {areaSearch.geometry ? (
+                  <SingleAreaSearchMap
+                    geometry={areaSearch.geometry}
+                    key={selectedAreaSectionRefreshKey}
+                    minimap
+                  />
+                ) : null}
                 <Row>
                   <Column small={6} medium={3} large={2}>
                     <FormTextTitle>{AreaSearchFieldTitles.AREA}</FormTextTitle>


### PR DESCRIPTION
it is a normal use case not to have geometry, as it can be also described in a textfield instead of marking it on the map