### PR TITLE
CreateLeaseModal in AreaSearchApplicationEdit

### DIFF
--- a/src/areaSearch/components/AreaSearchApplicationEdit.tsx
+++ b/src/areaSearch/components/AreaSearchApplicationEdit.tsx
@@ -60,6 +60,7 @@ import AddButtonSecondary from "@/components/form/AddButtonSecondary";
 import CreateLeaseModal from '@/leases/components/createLease/CreateLeaseModal';
 import { createLease, fetchAttributes as fetchLeaseAttributes } from "@/leases/actions";
 import { getAttributes as getLeaseAttributes, getIsFetchingAttributes as getIsFetchingLeaseAttributes } from "@/leases/selectors";
+import { ButtonLabels } from "@/components/enums";
 
 type Props = {
   areaSearch: AreaSearch | null;
@@ -218,9 +219,9 @@ class AreaSearchApplicationEdit extends Component<Props, State> {
             onSubmit={createLease}
         />
         <div className="AreaSearchApplication__header">
-          <Title>Hakemus</Title>
+          <Title className="AreaSearchApplication__header__title">Hakemus</Title>
           <AddButtonSecondary
-            label="Luo vuokraustunnus"
+            label={ButtonLabels.CREATE_LEASE}
             onClick={this.showCreateLeaseModal}
           />
         </div>

--- a/src/areaSearch/components/AreaSearchApplicationEdit.tsx
+++ b/src/areaSearch/components/AreaSearchApplicationEdit.tsx
@@ -56,18 +56,26 @@ import {
   uploadAttachment,
   setAreaSearchAttachments,
 } from "@/areaSearch/actions";
+import AddButtonSecondary from "@/components/form/AddButtonSecondary";
+import CreateLeaseModal from '@/leases/components/createLease/CreateLeaseModal';
+import { createLease, fetchAttributes as fetchLeaseAttributes } from "@/leases/actions";
+import { getAttributes as getLeaseAttributes, getIsFetchingAttributes as getIsFetchingLeaseAttributes } from "@/leases/selectors";
 
 type Props = {
   areaSearch: AreaSearch | null;
-  isFetchingFormAttributes: boolean;
-  isPerformingFileOperation: boolean;
+  areaSearchAttributes: Attributes;
+  change: (...args: Array<any>) => any;
+  createLease: (...args: Array<any>) => any;
+  initialize: (...args: Array<any>) => any;
+  fetchLeaseAttributes: (...args: Array<any>) => any;
   formAttributes: Attributes;
   formValues: Record<string, any> | null | undefined;
-  areaSearchAttributes: Attributes;
-  initialize: (...args: Array<any>) => any;
-  uploadAttachment: (...args: Array<any>) => any;
+  isFetchingFormAttributes: boolean;
+  isFetchingLeaseAttributes: boolean;
+  isPerformingFileOperation: boolean;
+  leaseAttributes: Attributes;
   setAreaSearchAttachments: (...args: Array<any>) => any;
-  change: (...args: Array<any>) => any;
+  uploadAttachment: (...args: Array<any>) => any;
 };
 type State = {
   // The Leaflet element doesn't initialize correctly if it's invisible in a collapsed section element,
@@ -76,14 +84,20 @@ type State = {
   // circumvent this by forcing it to rerender with a key whenever that section is opened; during
   // the opening transition, the initialization works properly.
   selectedAreaSectionRefreshKey: number;
+  isModalOpen: boolean;
 };
 
 class AreaSearchApplicationEdit extends Component<Props, State> {
   state: any = {
     selectedAreaSectionRefreshKey: 0,
+    isModalOpen: false,
   };
 
   componentDidMount() {
+    const { leaseAttributes, fetchLeaseAttributes, isFetchingLeaseAttributes } = this.props;
+    if (!isFetchingLeaseAttributes && !leaseAttributes) {
+      fetchLeaseAttributes();
+    }
     this.initializeForm();
   }
 
@@ -140,15 +154,28 @@ class AreaSearchApplicationEdit extends Component<Props, State> {
     }
   };
 
+  showCreateLeaseModal = () => {
+    this.setState({
+      isModalOpen: true,
+    });
+  };
+
+  hideCreateLeaseModal = () => {
+    this.setState({
+      isModalOpen: false,
+    });
+  };
+
   render(): JSX.Element {
     const {
       areaSearch,
+      createLease,
       isFetchingFormAttributes,
       isPerformingFileOperation,
       formAttributes,
       areaSearchAttributes,
     } = this.props;
-    const { selectedAreaSectionRefreshKey } = this.state;
+    const { selectedAreaSectionRefreshKey, isModalOpen } = this.state;
     const fieldTypes = getFieldAttributes(
       formAttributes,
       "sections.child.children.fields.child.children.type.choices",
@@ -185,7 +212,18 @@ class AreaSearchApplicationEdit extends Component<Props, State> {
     );
     return (
       <div className="AreaSearchApplication">
-        <Title>Hakemus</Title>
+        <CreateLeaseModal
+            isOpen={isModalOpen}
+            onClose={this.hideCreateLeaseModal}
+            onSubmit={createLease}
+        />
+        <div className="AreaSearchApplication__header">
+          <Title>Hakemus</Title>
+          <AddButtonSecondary
+            label="Luo vuokraustunnus"
+            onClick={this.showCreateLeaseModal}
+          />
+        </div>
         <Divider />
         {!(
           form &&
@@ -459,9 +497,13 @@ export default flowRight(
       formAttributes: getFormAttributes(state),
       formValues: getFormValues(FormNames.AREA_SEARCH)(state),
       isFetchingFormAttributes: getIsFetchingFormAttributes(state),
+      isFetchingLeaseAttributes: getIsFetchingLeaseAttributes(state),
       isPerformingFileOperation: getIsPerformingFileOperation(state),
+      leaseAttributes: getLeaseAttributes(state),
     }),
     {
+      createLease,
+      fetchLeaseAttributes,
       uploadAttachment,
       setAreaSearchAttachments,
       change,

--- a/src/areaSearch/components/_area-search-application.scss
+++ b/src/areaSearch/components/_area-search-application.scss
@@ -1,4 +1,8 @@
 .AreaSearchApplication {
+  &__header {
+    display: flex;
+    align-items: center;
+  }
   .AreaSearchApplication__description {
     white-space: pre-wrap;
   }

--- a/src/areaSearch/components/_area-search-application.scss
+++ b/src/areaSearch/components/_area-search-application.scss
@@ -2,6 +2,10 @@
   &__header {
     display: flex;
     align-items: center;
+
+    .content__title {
+      margin-right: 0.5rem;
+    }
   }
   .AreaSearchApplication__description {
     white-space: pre-wrap;

--- a/src/components/enums.ts
+++ b/src/components/enums.ts
@@ -12,6 +12,16 @@ export const ButtonColors = {
 };
 
 /**
+ * Button label enumerable.
+ * @readonly
+ * @enum {string}
+ */
+export const ButtonLabels = {
+  CREATE_LEASE_IDENTIFIER: "Luo vuokraustunnus",
+  CREATE_LEASE: "Luo vuokraus",
+};
+
+/**
  * Rent calculator type enumerable.
  * @readonly
  * @enum {string}

--- a/src/leases/components/LeaseListPage.tsx
+++ b/src/leases/components/LeaseListPage.tsx
@@ -99,6 +99,7 @@ import type {
   UsersPermissions as UsersPermissionsType,
   UserServiceUnit,
 } from "@/usersPermissions/types";
+import { ButtonLabels } from "@/components/enums";
 
 const VisualizationTypes = {
   MAP: "map",
@@ -785,7 +786,7 @@ class LeaseListPage extends PureComponent<Props, State> {
             <Authorization allow={isMethodAllowed(leaseMethods, Methods.POST)}>
               <AddButtonSecondary
                 className="no-top-margin"
-                label="Luo vuokraustunnus"
+                label={ButtonLabels.CREATE_LEASE_IDENTIFIER}
                 onClick={this.showCreateLeaseModal}
               />
             </Authorization>

--- a/src/leases/components/createLease/CreateLeaseModal.tsx
+++ b/src/leases/components/createLease/CreateLeaseModal.tsx
@@ -2,6 +2,7 @@ import { $Shape } from "utility-types";
 import React, { Component } from "react";
 import CreateLeaseForm from "./CreateLeaseForm";
 import Modal from "@/components/modal/Modal";
+import { ButtonLabels } from "@/components/enums";
 type Props = {
   allowToChangeRelateTo?: boolean;
   isOpen: boolean;
@@ -28,7 +29,7 @@ class CreateLease extends Component<Props> {
   render(): JSX.Element {
     const { allowToChangeRelateTo, isOpen, onClose, onSubmit } = this.props;
     return (
-      <Modal isOpen={isOpen} onClose={onClose} title="Luo vuokraustunnus">
+      <Modal isOpen={isOpen} onClose={onClose} title={ButtonLabels.CREATE_LEASE_IDENTIFIER}>
         <CreateLeaseForm
           ref={this.setRefForForm}
           allowToChangeRelateTo={allowToChangeRelateTo}

--- a/src/leases/components/leaseSections/summary/LeaseHistoryEdit.tsx
+++ b/src/leases/components/leaseSections/summary/LeaseHistoryEdit.tsx
@@ -22,7 +22,7 @@ import {
   deleteRelatedPlotApplication,
 } from "@/relatedLease/actions";
 import { ConfirmationModalTexts, FormNames, Methods } from "@/enums";
-import { ButtonColors } from "@/components/enums";
+import { ButtonColors, ButtonLabels } from "@/components/enums";
 import {
   LeaseFieldPaths,
   LeaseFieldTitles,
@@ -414,7 +414,7 @@ class LeaseHistoryEdit extends Component<Props, State> {
               >
                 <AddButtonSecondary
                   className="no-top-margin"
-                  label="Luo vuokraustunnus"
+                  label={ButtonLabels.CREATE_LEASE_IDENTIFIER}
                   onClick={this.showCreateLeaseModal}
                 />
               </Authorization>


### PR DESCRIPTION
A modal for creating a lease in an area search application view.

No data from the areasearch is yet transferred into the new lease. Those are implemented in the upcoming PRs.

I also created an enum for the create lease button. I followed the wording "Luo vuokraus" for the button in the area search application view as is specified on the ticket. I kept the "Luo vuokraustunnus" wording for other locations.