### PR TITLE
MVJ-840 link lease to area search application

### DIFF
--- a/src/leases/components/createLease/CreateLeaseForm.tsx
+++ b/src/leases/components/createLease/CreateLeaseForm.tsx
@@ -17,7 +17,7 @@ import ModalButtonWrapper from "@/components/modal/ModalButtonWrapper";
 import { fetchDistrictsByMunicipality } from "@/district/actions";
 import { FieldTypes, FormNames } from "@/enums";
 import { ButtonColors } from "@/components/enums";
-import { LeaseFieldPaths, LeaseFieldTitles, CreateLeaseFormFieldNames } from "@/leases/enums";
+import { LeaseFieldPaths, LeaseFieldTitles, LeaseHistoryContentTypes, CreateLeaseFormFieldNames } from "@/leases/enums";
 import { filterOptionsByLabel } from "@/components/form/filter";
 import { getDistrictOptions } from "@/district/helpers";
 import { getPayloadCreateLease } from "@/leases/helpers";
@@ -72,6 +72,10 @@ class CreateLeaseForm extends Component<Props> {
       change(CreateLeaseFormFieldNames.APPLICATION_RECEIVED_AT, formatDate(areaSearch?.received_date, "yyyy-MM-dd") || null);
       change(CreateLeaseFormFieldNames.START_DATE, formatDate(areaSearch?.start_date, "yyyy-MM-dd") || null);
       change(CreateLeaseFormFieldNames.END_DATE, formatDate(areaSearch?.end_date, "yyyy-MM-dd") || null);
+      change(CreateLeaseFormFieldNames.RELATED_PLOT_APPLICATION, {
+        object_id: areaSearch.id,
+        content_type_model: LeaseHistoryContentTypes.AREA_SEARCH,
+      });
     }
   }
 
@@ -82,6 +86,7 @@ class CreateLeaseForm extends Component<Props> {
       change(CreateLeaseFormFieldNames.APPLICATION_RECEIVED_AT, null);
       change(CreateLeaseFormFieldNames.START_DATE, null);
       change(CreateLeaseFormFieldNames.END_DATE, null);
+      change(CreateLeaseFormFieldNames.RELATED_PLOT_APPLICATION, null);
     }
   }
 

--- a/src/leases/components/createLease/CreateLeaseForm.tsx
+++ b/src/leases/components/createLease/CreateLeaseForm.tsx
@@ -17,7 +17,7 @@ import ModalButtonWrapper from "@/components/modal/ModalButtonWrapper";
 import { fetchDistrictsByMunicipality } from "@/district/actions";
 import { FieldTypes, FormNames } from "@/enums";
 import { ButtonColors } from "@/components/enums";
-import { LeaseFieldPaths, LeaseFieldTitles } from "@/leases/enums";
+import { LeaseFieldPaths, LeaseFieldTitles, CreateLeaseFormFieldNames } from "@/leases/enums";
 import { filterOptionsByLabel } from "@/components/form/filter";
 import { getDistrictOptions } from "@/district/helpers";
 import { getPayloadCreateLease } from "@/leases/helpers";
@@ -69,9 +69,9 @@ class CreateLeaseForm extends Component<Props> {
       fetchDistrictsByMunicipality(parseInt(municipality));
     }
     if (areaSearch) {
-      change("application_received_at", formatDate(areaSearch?.received_date, "yyyy-MM-dd") || null);
-      change("start_date", formatDate(areaSearch?.start_date, "yyyy-MM-dd") || null);
-      change("end_date", formatDate(areaSearch?.end_date, "yyyy-MM-dd") || null);
+      change(CreateLeaseFormFieldNames.APPLICATION_RECEIVED_AT, formatDate(areaSearch?.received_date, "yyyy-MM-dd") || null);
+      change(CreateLeaseFormFieldNames.START_DATE, formatDate(areaSearch?.start_date, "yyyy-MM-dd") || null);
+      change(CreateLeaseFormFieldNames.END_DATE, formatDate(areaSearch?.end_date, "yyyy-MM-dd") || null);
     }
   }
 
@@ -79,9 +79,9 @@ class CreateLeaseForm extends Component<Props> {
     const { areaSearch } = this.props;
     if (areaSearch) {
       const { change } = this.props;
-      change("application_received_at", null);
-      change("start_date", null);
-      change("end_date", null);
+      change(CreateLeaseFormFieldNames.APPLICATION_RECEIVED_AT, null);
+      change(CreateLeaseFormFieldNames.START_DATE, null);
+      change(CreateLeaseFormFieldNames.END_DATE, null);
     }
   }
 
@@ -91,9 +91,9 @@ class CreateLeaseForm extends Component<Props> {
 
       if (nextProps.municipality) {
         fetchDistrictsByMunicipality(nextProps.municipality);
-        change("district", "");
+        change(CreateLeaseFormFieldNames.DISTRICT, "");
       } else {
-        change("district", "");
+        change(CreateLeaseFormFieldNames.DISTRICT, "");
       }
     }
   }
@@ -102,7 +102,7 @@ class CreateLeaseForm extends Component<Props> {
     const { areaSearch, change, formValues, userActiveServiceUnit } = this.props;
 
     if (userActiveServiceUnit && formValues && !formValues.service_unit) {
-      change("service_unit", userActiveServiceUnit.id);
+      change(CreateLeaseFormFieldNames.SERVICE_UNIT, userActiveServiceUnit.id);
     }
   }
 
@@ -115,7 +115,7 @@ class CreateLeaseForm extends Component<Props> {
     }
   };
   handleCreate = () => {
-    const { formValues, onSubmit } = this.props;
+    const { areaSearch, formValues, onSubmit } = this.props;
     onSubmit(getPayloadCreateLease(formValues));
   };
 
@@ -148,7 +148,7 @@ class CreateLeaseForm extends Component<Props> {
                   leaseAttributes,
                   LeaseFieldPaths.STATE,
                 )}
-                name="state"
+                name={CreateLeaseFormFieldNames.STATE}
                 setRefForField={this.setRefForFirstField}
                 overrideValues={{
                   label: LeaseFieldTitles.STATE,
@@ -193,7 +193,7 @@ class CreateLeaseForm extends Component<Props> {
                   leaseAttributes,
                   LeaseFieldPaths.TYPE,
                 )}
-                name="type"
+                name={CreateLeaseFormFieldNames.TYPE}
                 overrideValues={{
                   label: LeaseFieldTitles.TYPE,
                 }}
@@ -214,7 +214,7 @@ class CreateLeaseForm extends Component<Props> {
                   leaseAttributes,
                   LeaseFieldPaths.MUNICIPALITY,
                 )}
-                name="municipality"
+                name={CreateLeaseFormFieldNames.MUNICIPALITY}
                 overrideValues={{
                   label: LeaseFieldTitles.MUNICIPALITY,
                 }}
@@ -236,7 +236,7 @@ class CreateLeaseForm extends Component<Props> {
                   LeaseFieldPaths.DISTRICT,
                 )}
                 filterOption={filterOptionsByLabel}
-                name="district"
+                name={CreateLeaseFormFieldNames.DISTRICT}
                 overrideValues={{
                   label: LeaseFieldTitles.DISTRICT,
                   options: districtOptions,
@@ -262,7 +262,7 @@ class CreateLeaseForm extends Component<Props> {
                     leaseAttributes,
                     LeaseFieldPaths.REFERENCE_NUMBER,
                   )}
-                  name="reference_number"
+                  name={CreateLeaseFormFieldNames.REFERENCE_NUMBER}
                   validate={referenceNumber}
                   overrideValues={{
                     label: LeaseFieldTitles.REFERENCE_NUMBER,
@@ -286,7 +286,7 @@ class CreateLeaseForm extends Component<Props> {
                     leaseAttributes,
                     LeaseFieldPaths.NOTE,
                   )}
-                  name="note"
+                  name={CreateLeaseFormFieldNames.NOTE}
                   overrideValues={{
                     label: LeaseFieldTitles.NOTE,
                     fieldType: FieldTypes.TEXTAREA,
@@ -311,7 +311,7 @@ class CreateLeaseForm extends Component<Props> {
                   leaseAttributes,
                   LeaseFieldPaths.APPLICATION_RECEIVED_AT,
                 )}
-                name="application_received_at"
+                name={CreateLeaseFormFieldNames.APPLICATION_RECEIVED_AT}
                 overrideValues={{
                   fieldType: FieldTypes.DATE,
                   label: LeaseFieldTitles.APPLICATION_RECEIVED_AT,
@@ -338,7 +338,7 @@ class CreateLeaseForm extends Component<Props> {
                     leaseAttributes,
                     LeaseFieldPaths.RELATE_TO,
                   )}
-                  name="relate_to"
+                  name={CreateLeaseFormFieldNames.RELATE_TO}
                   overrideValues={{
                     fieldType: FieldTypes.LEASE,
                     label: LeaseFieldTitles.RELATE_TO,

--- a/src/leases/components/createLease/CreateLeaseForm.tsx
+++ b/src/leases/components/createLease/CreateLeaseForm.tsx
@@ -105,7 +105,7 @@ class CreateLeaseForm extends Component<Props> {
   }
 
   componentDidUpdate() {
-    const { areaSearch, change, formValues, userActiveServiceUnit } = this.props;
+    const { change, formValues, userActiveServiceUnit } = this.props;
 
     if (userActiveServiceUnit && formValues && !formValues.service_unit) {
       change(CreateLeaseFormFieldNames.SERVICE_UNIT, userActiveServiceUnit.id);
@@ -121,7 +121,7 @@ class CreateLeaseForm extends Component<Props> {
     }
   };
   handleCreate = () => {
-    const { areaSearch, formValues, onSubmit } = this.props;
+    const { formValues, onSubmit } = this.props;
     onSubmit(getPayloadCreateLease(formValues));
   };
 

--- a/src/leases/components/createLease/CreateLeaseForm.tsx
+++ b/src/leases/components/createLease/CreateLeaseForm.tsx
@@ -34,6 +34,7 @@ import type { Attributes } from "types";
 import type { DistrictList } from "@/district/types";
 import type { UserServiceUnit } from "@/usersPermissions/types";
 import { AreaSearch } from "@/areaSearch/types";
+import { CreateLeaseFormValues } from "@/leases/types";
 
 type OwnProps = {
   onClose: (...args: Array<any>) => any;
@@ -42,14 +43,14 @@ type OwnProps = {
   allowToChangeReferenceNumberAndNote?: boolean;
   areaSearch: AreaSearch | null;
   confirmButtonLabel?: string;
-  ref?: Function;
+  ref?: (...args: Array<any>) => any;
 };
 
 type Props = OwnProps & {
   change: (...args: Array<any>) => any;
   districts: DistrictList;
   fetchDistrictsByMunicipality: (...args: Array<any>) => any;
-  formValues: Record<string, any>;
+  formValues: CreateLeaseFormValues;
   leaseAttributes: Attributes;
   municipality: string;
   setRefForFirstField?: (...args: Array<any>) => any;

--- a/src/leases/enums.ts
+++ b/src/leases/enums.ts
@@ -47,6 +47,27 @@ export const ContractRentPeriods = {
 };
 
 /**
+ * Create lease form field name enumerable.
+ *
+ * @type {{}}
+ */
+export const CreateLeaseFormFieldNames = {
+  STATE: "state",
+  SERVICE_UNIT: "service_unit",
+  TYPE: "type",
+  MUNICIPALITY: "municipality",
+  DISTRICT: "district",
+  REFERENCE_NUMBER: "reference_number",
+  NOTE: "note",
+  APPLICATION_RECEIVED_AT: "application_received_at",
+  RELATE_TO: "relate_to",
+  // Invisible, and only for leases created from 
+  // an area search application (which uses the related_plot_application entity)
+  START_DATE: "start_date",
+  END_DATE: "end_date",
+};
+
+/**
  * Decision type kinds enumerable.
  *
  * @type {{}}

--- a/src/leases/enums.ts
+++ b/src/leases/enums.ts
@@ -61,10 +61,9 @@ export const CreateLeaseFormFieldNames = {
   NOTE: "note",
   APPLICATION_RECEIVED_AT: "application_received_at",
   RELATE_TO: "relate_to",
-  // Invisible, and only for leases created from 
-  // an area search application (which uses the related_plot_application entity)
   START_DATE: "start_date",
   END_DATE: "end_date",
+  RELATED_PLOT_APPLICATION: "related_plot_application",
 };
 
 /**

--- a/src/leases/helpers.ts
+++ b/src/leases/helpers.ts
@@ -2773,6 +2773,7 @@ export const getPayloadCreateLease = (lease: Lease): Record<string, any> => {
     },
     relate_to: relateTo,
     relation_type: relateTo ? RelationTypes.TRANSFER : undefined,
+    related_plot_application: lease.related_plot_application,
     service_unit: lease.service_unit,
   };
 };

--- a/src/leases/helpers.ts
+++ b/src/leases/helpers.ts
@@ -60,6 +60,7 @@ import type {
   LeaseAreaAddress,
   IntendedUse,
   PeriodicRentAdjustmentType,
+  CreateLeaseFormValues,
 } from "./types";
 import type { CommentList } from "@/comments/types";
 import type { Attributes, LeafletFeature, LeafletGeoJson } from "types";
@@ -2750,31 +2751,31 @@ export const getLeaseCoordinates = (
 
 /**
  * Get payload for lease POST request
- * @param {Object} lease
+ * @param {Object} formValues
  * @returns {Object}
  */
-export const getPayloadCreateLease = (lease: Lease): Record<string, any> => {
-  const relateTo = !isEmpty(lease.relate_to)
-    ? !isEmptyValue(lease.relate_to.value)
-      ? lease.relate_to.value
+export const getPayloadCreateLease = (formValues: CreateLeaseFormValues): Record<string, any> => {
+  const relateTo = !isEmpty(formValues.relate_to)
+    ? !isEmptyValue(formValues.relate_to.value)
+      ? formValues.relate_to.value
       : undefined
     : undefined;
   return {
-    state: lease.state,
-    type: lease.type,
-    start_date: lease?.start_date || null,
-    end_date: lease?.end_date || null,
-    municipality: lease.municipality,
-    district: lease.district,
-    reference_number: lease.reference_number,
-    note: lease.note,
+    state: formValues.state,
+    type: formValues.type,
+    start_date: formValues?.start_date || null,
+    end_date: formValues?.end_date || null,
+    municipality: formValues.municipality,
+    district: formValues.district,
+    reference_number: formValues.reference_number,
+    note: formValues.note,
     application_metadata: {
-      application_received_at: lease.application_received_at,
+      application_received_at: formValues.application_received_at,
     },
     relate_to: relateTo,
     relation_type: relateTo ? RelationTypes.TRANSFER : undefined,
-    related_plot_application: lease.related_plot_application,
-    service_unit: lease.service_unit,
+    related_plot_application: formValues.related_plot_application,
+    service_unit: formValues.service_unit,
   };
 };
 

--- a/src/leases/types.ts
+++ b/src/leases/types.ts
@@ -93,6 +93,11 @@ export type RelatedLeases = {
   related_from: Array<Record<string, any>>;
   related_to: Array<Record<string, any> & { to_lease: Lease }>;
 };
+export type RelatedPlotApplicationFormValues = {
+  object_id: number;
+  content_type_model: string;
+  // lease id not included, because it will be received after submission
+}
 // Lease area object as expected from API response
 export type LeaseArea = {
   id: number;
@@ -144,6 +149,15 @@ export type FetchSingleLeaseAfterEditPayload = {
     Record<string, any> | ((...args: Array<any>) => any)
   >;
 };
+export type CreateLeaseRelateTo = {
+  value: number;
+  label: string;
+}
+export type CreateLeaseFormValues = Lease & {
+  relate_to: CreateLeaseRelateTo;
+  application_received_at: string;
+  related_plot_application: RelatedPlotApplicationFormValues;
+}
 export type ReceivableType = {
   id: number;
   name: string;


### PR DESCRIPTION
When creating a lease from an area search application, create a link from the lease to the area search application so that it shows on the lease history in the summary tab view.

These changes are dependent on this fix in the field permissions: https://github.com/City-of-Helsinki/mvj/pull/899