### PR TITLE
MVJ-836 Areasearch map tab without geometry

### DIFF
--- a/src/areaSearch/components/map/SingleAreaSearchMap.tsx
+++ b/src/areaSearch/components/map/SingleAreaSearchMap.tsx
@@ -61,7 +61,7 @@ class SingleAreaSearchMap extends Component<Props> {
     const { geometry, minimap = false } = this.props;
 
     if (!geometry) {
-      return <>{"Ei geometriaa."}</>;
+      return <p>{"Ei geometriaa."}</p>;
     }
 
     const center = this.getMapCenter();

--- a/src/areaSearch/components/map/SingleAreaSearchMap.tsx
+++ b/src/areaSearch/components/map/SingleAreaSearchMap.tsx
@@ -59,6 +59,11 @@ class SingleAreaSearchMap extends Component<Props> {
 
   render(): JSX.Element {
     const { geometry, minimap = false } = this.props;
+
+    if (!geometry) {
+      return <>{"Ei geometriaa."}</>;
+    }
+
     const center = this.getMapCenter();
     const bounds = this.getMapBounds();
     return (

--- a/src/util/map.ts
+++ b/src/util/map.ts
@@ -204,6 +204,10 @@ export const getCenterFromCoordinates = (
 export const getAreaFromGeoJSON = (geometry: Record<string, any>): number => {
   let area = 0;
 
+  if (!geometry || !geometry.type) {
+    return area;
+  }
+
   switch (geometry.type) {
     case "GeometryCollection":
       geometry.geometries.forEach((geometry) => {

--- a/src/util/map.ts
+++ b/src/util/map.ts
@@ -204,7 +204,7 @@ export const getCenterFromCoordinates = (
 export const getAreaFromGeoJSON = (geometry: Record<string, any>): number => {
   let area = 0;
 
-  if (!geometry || !geometry.type) {
+  if (!geometry?.type) {
     return area;
   }
 


### PR DESCRIPTION
Suggestions welcome: Is there need for a prettier presentation than plain text as a placeholder in the map tab when geometry is missing? Picture in ticket.