### PR TITLE
create contact in area search application: fix country field default value

### DIFF
--- a/src/areaSearch/helpers.ts
+++ b/src/areaSearch/helpers.ts
@@ -262,12 +262,16 @@ export const getContactFromAnswerFields = (
       EMPTY_DEFAULT_FIELD,
     )?.value;
 
-    const { address_protection, language, postal_code } =
+    const { address_protection, country, language, postal_code } =
       MapFormAnswerFieldsToContactFields;
 
     switch (MapFormAnswerFieldsToContactFields[key]) {
       case address_protection: {
         contact.address_protection = getAddressProtection(value);
+        break;
+      }
+      case country: {
+        contact.country = value?.toLowerCase() === "suomi" ? "FI" : null;
         break;
       }
       case language: {


### PR DESCRIPTION
Fix the issue of having a wrong kind of string in the country field. The country field in the application form is a text field, and has the string "Suomi" there by default in the mvj-ui-public. However, in the leasing_contact, it is a field that expects country codes. 

This workaround resolves the string "suomi" (case insensitive) as "FI", so the default value is Finland in the create contact form in most cases. If the string is something else, the default value becomes null, and needs to be set manually in the create contact form, or the contact will have the country field as empty when it is created.

There is a bug ticket for fixing the country and language fields for the application forms so that the string mappings match those of contacts.