### PR TITLE
create contact from area search application: fix name and c_o fields

### DIFF
--- a/src/areaSearch/enums.ts
+++ b/src/areaSearch/enums.ts
@@ -49,6 +49,7 @@ export const MapFormAnswerFieldsToContactFields = {
   first_name: "etunimi",
   last_name: "Sukunimi",
   name: "nimi",
+  c_o: "c_o",
   business_id: "y-tunnus",
   address: "katuosoite",
   postal_code: "postinumero",

--- a/src/areaSearch/helpers.ts
+++ b/src/areaSearch/helpers.ts
@@ -262,7 +262,7 @@ export const getContactFromAnswerFields = (
       EMPTY_DEFAULT_FIELD,
     )?.value;
 
-    const { address_protection, country, language, postal_code } =
+    const { address_protection, c_o, country, language, postal_code } =
       MapFormAnswerFieldsToContactFields;
 
     switch (MapFormAnswerFieldsToContactFields[key]) {
@@ -272,6 +272,10 @@ export const getContactFromAnswerFields = (
       }
       case country: {
         contact.country = value?.toLowerCase() === "suomi" ? "FI" : null;
+        break;
+      }
+      case c_o: {
+        contact.care_of = value ? String(value) : null;
         break;
       }
       case language: {


### PR DESCRIPTION
Copy the `c/o` field into the create contact form from the area search application.