### PR TITLE
MVJ-902 draft lease area

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -1,0 +1,174 @@
+import React, { Component } from "react";
+import { FeatureGroup, Polygon, Popup } from "react-leaflet";
+import { EditControl } from "react-leaflet-draw";
+// This is a hack to get react-leaflet-draw, the issue and solution described at:
+// https://github.com/Leaflet/Leaflet.draw/issues/1026#issuecomment-986702652
+// @ts-ignore
+window.type = true;
+import throttle from "lodash/throttle";
+import classNames from "classnames";
+import MapContainer from "@/areaNote/components/MapContainer";
+import { DEFAULT_CENTER, DEFAULT_ZOOM } from "@/util/constants";
+import { convertFeatureCollectionToFeature } from "@/areaNote/helpers";
+import { polygon } from "leaflet";
+import { convertGeoJSONArrayForLeaflet } from "./helpers";
+
+const SHAPE_COLOR = "#9c27b0";
+const SHAPE_FILL_OPACITY = 0.5;
+const SHAPE_ERROR_COLOR = "#bd2719";
+
+type Props = {
+  change?: (...args: Array<any>) => any;
+  initialValues: Record<string, any> | null | undefined;
+  isEditMode: boolean;
+  center: Array<number>;
+  bounds: Record<string, any> | null | undefined;
+  overlayLayers?: Array<Record<string, any>>;
+  hasError: boolean;
+};
+type State = {
+  isValid: boolean;
+};
+
+class MapComponent extends Component<Props, State> {
+  featureGroup: Record<string, any> | null | undefined;
+  state: State = {
+    isValid: false,
+  };
+  setFeatureGroupRef: (el: Record<string, any> | null | undefined) => void = (
+    el,
+  ) => {
+    this.featureGroup = el;
+  };
+  updateAllFeatures: () => void = throttle(
+    () => {
+      this.featureGroup?.leafletElement?.eachLayer((layer) => {
+        layer.showMeasurements();
+        layer.updateMeasurements();
+      });
+    },
+    1000 / 60,
+    {
+      leading: true,
+      trailing: true,
+    },
+  );
+  handleNonCommittedChange: () => void = () => {
+    this.updateAllFeatures();
+  };
+  handleAction: () => void = () => {
+    const { change } = this.props;
+    const features = [];
+    this.featureGroup?.leafletElement.eachLayer((layer) =>
+      features.push(layer.toGeoJSON()),
+    );
+    this.setState({
+      isValid: features.length > 0,
+    });
+    change(convertFeatureCollectionToFeature(features).geometry);
+  };
+  handleCreated: (arg0: Record<string, any>) => void = (e) => {
+    const { change } = this.props;
+    const { layer } = e;
+    layer.showMeasurements();
+    const features = [];
+    this.featureGroup?.leafletElement.eachLayer((layer) => {
+      layer.bindPopup("Alueluonnos");
+      features.push(layer.toGeoJSON());
+    });
+    this.setState({
+      isValid: features.length > 0,
+    });
+    change(convertFeatureCollectionToFeature(features).geometry);
+  };
+  initializeMap: () => void = () => {
+    const { initialValues } = this.props;
+    const featureGroup = this.featureGroup?.leafletElement;
+    const coordinates = initialValues?.geometry?.coordinates || [];
+    if (featureGroup && coordinates.length > 0) {
+      coordinates.map((selectedArea) => {
+        polygon(convertGeoJSONArrayForLeaflet(selectedArea))
+          .bindTooltip("Alueluonnos")
+          .addTo(featureGroup);
+      });
+    }
+    // this.updateAllFeatures();
+  };
+
+  render(): JSX.Element {
+    const {
+      hasError,
+      overlayLayers,
+      center,
+      bounds,
+      isEditMode,
+      initialValues,
+    } = this.props;
+    return (
+      <div
+        className={classNames("AreaSearchMap", {
+          "AreaSearchMap--has-error": hasError,
+        })}
+      >
+        <div className="map">
+          <MapContainer
+            center={center || DEFAULT_CENTER}
+            bounds={bounds}
+            zoom={DEFAULT_ZOOM}
+            overlayLayers={overlayLayers}
+          >
+            <FeatureGroup ref={this.setFeatureGroupRef}>
+              {this.featureGroup && isEditMode ? (
+                <EditControl
+                  position="topright"
+                  onCreated={this.handleCreated}
+                  onDeleted={this.handleAction}
+                  onEdited={this.handleAction}
+                  onEditMove={this.handleNonCommittedChange}
+                  onEditVertex={this.handleNonCommittedChange}
+                  onEditStop={this.handleNonCommittedChange}
+                  onDeleteStop={this.handleNonCommittedChange}
+                  onMounted={this.initializeMap}
+                  draw={{
+                    circlemarker: false,
+                    circle: false,
+                    marker: false,
+                    polyline: false,
+                    polygon: {
+                      allowIntersection: false,
+                      showArea: true,
+                      drawError: {
+                        color: SHAPE_ERROR_COLOR,
+                        timeout: 1000,
+                      },
+                      shapeOptions: {
+                        color: SHAPE_COLOR,
+                        fillOpacity: SHAPE_FILL_OPACITY,
+                      },
+                    },
+                    rectangle: {
+                      shapeOptions: {
+                        color: SHAPE_COLOR,
+                        fillOpacity: SHAPE_FILL_OPACITY,
+                      },
+                    },
+                  }}
+                />
+              ) : initialValues?.geometry ? (
+                <Polygon
+                  positions={convertGeoJSONArrayForLeaflet(
+                    initialValues.geometry.coordinates,
+                  )}
+                >
+                  <Popup>Alueluonnos</Popup>
+                </Polygon>
+              ) : null}
+            </FeatureGroup>
+          </MapContainer>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default MapComponent;

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -1,0 +1,164 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import L from "leaflet";
+import {
+  LayersControl,
+  LayerGroup,
+  Map,
+  WMSTileLayer,
+  ZoomControl,
+} from "react-leaflet";
+const { BaseLayer, Overlay } = LayersControl;
+import FullscreenControl from "react-leaflet-fullscreen";
+import proj4 from "proj4";
+import "proj4leaflet";
+import GeoSearch from "@/components/map/GeoSearch";
+import Loader from "@/components/loader/Loader";
+import LoaderWrapper from "@/components/loader/LoaderWrapper";
+import ZoomBox from "@/components/map/ZoomBox";
+import { MIN_ZOOM, MAX_ZOOM } from "@/util/constants";
+const bounds = L.bounds([25440000, 6630000], [25571072, 6761072]);
+const CRS = new L.Proj.CRS(
+  "EPSG:3879",
+  "+proj=tmerc +lat_0=0 +lon_0=25 +k=1 +x_0=25500000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs",
+  {
+    resolutions: [
+      256, 128, 64, 32, 16, 8, 4, 2, 1, 0.5, 0.25, 0.125, 0.0625, 0.03125,
+    ],
+    bounds,
+  },
+);
+proj4.defs(
+  "EPSG:3879",
+  "+proj=tmerc +lat_0=0 +lon_0=25 +k=1 +x_0=25500000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs",
+);
+proj4.defs(
+  "WGS84",
+  "+title=WGS 84 (long/lat) +proj=longlat +ellps=WGS84 +datum=WGS84 +units=degrees",
+);
+type Props = {
+  bounds?: Record<string, any>;
+  center: Record<string, any>;
+  children: Record<string, any>;
+  isLoading?: boolean;
+  onMapDidMount?: (...args: Array<any>) => any;
+  onViewportChanged?: (...args: Array<any>) => any;
+  overlayLayers?: Array<Record<string, any>>;
+  zoom: number;
+  enableSearch?: boolean;
+  onMapRefAvailable?: (...args: Array<any>) => any;
+};
+
+class MapContainer extends Component<Props> {
+  map: any;
+  static contextTypes: Record<string, any> = {
+    router: PropTypes.object,
+  };
+  setMapRef: (arg0: any) => void = (el) => {
+    this.map = el;
+    this.props.onMapRefAvailable?.(el);
+  };
+  componentDidMount: () => void = () => {
+    const { onMapDidMount } = this.props;
+
+    if (this.map && onMapDidMount) {
+      onMapDidMount(this.getMapValues());
+    }
+  };
+  handleViewportChanged: () => void = () => {
+    const { onViewportChanged } = this.props;
+
+    if (this.map && onViewportChanged) {
+      onViewportChanged(this.getMapValues());
+    }
+  };
+  getMapValues: () => Record<string, any> = () => {
+    return {
+      bBox: this.map.leafletElement.getBounds().toBBoxString(),
+      zoom: this.map.leafletElement.getZoom(),
+    };
+  };
+
+  render(): JSX.Element {
+    const {
+      bounds,
+      center,
+      children,
+      isLoading,
+      overlayLayers,
+      zoom,
+      enableSearch = true,
+    } = this.props;
+    return (
+      <Map
+        ref={this.setMapRef}
+        attributionControl={false}
+        center={center ? center : undefined}
+        bounds={bounds ? bounds : undefined}
+        maxBoundsViscosity={0}
+        minZoom={MIN_ZOOM}
+        maxZoom={MAX_ZOOM}
+        zoom={zoom}
+        zoomControl={false}
+        crs={CRS}
+        boxZoom={false}
+        onViewportChanged={this.handleViewportChanged}
+      >
+        {isLoading && (
+          <LoaderWrapper className="relative-overlay-wrapper">
+            <Loader isLoading={true} />
+          </LoaderWrapper>
+        )}
+        <LayersControl position="topright">
+          <BaseLayer checked name="Karttasarja">
+            <WMSTileLayer
+              url={"https://kartta.hel.fi/ws/geoserver/avoindata/wms?"}
+              layers={"avoindata:Karttasarja"}
+              format={"image/png"}
+              transparent={true}
+            />
+          </BaseLayer>
+          <BaseLayer name="Ortoilmakuva">
+            <WMSTileLayer
+              url={"https://kartta.hel.fi/ws/geoserver/avoindata/wms?"}
+              layers={"avoindata:Ortoilmakuva"}
+              format={"image/png"}
+              transparent={true}
+            />
+          </BaseLayer>
+          <BaseLayer name="Asemakaava">
+            <WMSTileLayer
+              url={"https://kartta.hel.fi/ws/geoserver/avoindata/wms?"}
+              layers={"avoindata:Ajantasa_asemakaava"}
+              format={"image/png"}
+              transparent={true}
+            />
+          </BaseLayer>
+          {!!overlayLayers &&
+            overlayLayers.length &&
+            overlayLayers.map((layer, index) => (
+              <Overlay checked={layer.checked} name={layer.name} key={index}>
+                <LayerGroup>{layer.component}</LayerGroup>
+              </Overlay>
+            ))}
+        </LayersControl>
+
+        {enableSearch && <GeoSearch />}
+        <FullscreenControl position="topright" title="Koko näytön tila" />
+        <ZoomControl
+          position="topright"
+          zoomInTitle="Lähennä"
+          zoomOutTitle="Loitonna"
+        />
+        <ZoomBox
+          position="topright"
+          modal={true}
+          title="Tarkenna valittuun alueeseen"
+        />
+        {children}
+      </Map>
+    );
+  }
+}
+
+export default MapContainer;

--- a/src/components/map/helpers.ts
+++ b/src/components/map/helpers.ts
@@ -1,0 +1,26 @@
+import { LatLngTuple } from "leaflet";
+import { Position, RecursivePosition } from "@/types/geojson";
+
+export const convertGeoJSONArrayForLeaflet = (
+  coordinates: Position[][],
+): LatLngTuple[][] => {
+  const reverseLngLat = ([
+    longitude,
+    latitude,
+    altitude,
+  ]: Position): LatLngTuple => [latitude, longitude, altitude];
+
+  const transformCoordinates = (
+    items: RecursivePosition,
+  ): LatLngTuple | LatLngTuple[] => {
+    if (!items.length) return [];
+    if (typeof items[0] === 'number') {
+      return reverseLngLat(items as Position);
+    } else {
+      return (items as RecursivePosition[]).map(
+        transformCoordinates,
+      ) as LatLngTuple[];
+    }
+  };
+  return coordinates.map(transformCoordinates) as LatLngTuple[][];
+};

--- a/src/enums.tsx
+++ b/src/enums.tsx
@@ -470,6 +470,7 @@ export const FormNames = {
   CONTACT: "contact-form",
   CONTACT_SEARCH: "contact-search-form",
   CREDIT_DECISION_SEARCH: "credit-info-search-form",
+  LEASE_AREA_DRAFT: "draft-lease-area-form",
   INFILL_DEVELOPMENT: "infill-development-form",
   INFILL_DEVELOPMENT_SEARCH: "infill-development-search-form",
   INVOICE_NOTE_CREATE: "create-invoice-note-form",

--- a/src/leases/components/leaseSections/map/SingleLeaseMap.tsx
+++ b/src/leases/components/leaseSections/map/SingleLeaseMap.tsx
@@ -4,7 +4,7 @@ import { withRouter } from "react-router";
 import flowRight from "lodash/flowRight";
 import isEmpty from "lodash/isEmpty";
 import AreaNotesLayer from "@/areaNote/components/AreaNotesLayer";
-import AreaNotesEditMap from "@/areaNote/components/AreaNotesEditMap";
+import MapComponent from "@/components/map/Map";
 import AreasLayer from "./AreasLayer";
 import Divider from "@/components/content/Divider";
 import PlanUnitsLayer from "./PlanUnitsLayer";
@@ -22,6 +22,7 @@ import {
 import { UsersPermissions } from "@/usersPermissions/enums";
 import {
   getContentAreasGeoJson,
+  getContentLeaseAreaDraft,
   getContentPlanUnitsGeoJson,
   getContentPlotsGeoJson,
   getLeaseCoordinates,
@@ -41,18 +42,28 @@ import {
   getIsEditMode,
 } from "@/leases/selectors";
 import { getUsersPermissions } from "@/usersPermissions/selectors";
-import type { Attributes, LeafletGeoJson } from "types";
+import type { Attributes, LeafletFeatureGeometry, LeafletGeoJson } from "types";
 import type { Lease } from "@/leases/types";
 import type { AreaNoteList } from "@/areaNote/types";
 import type { UsersPermissions as UsersPermissionsType } from "@/usersPermissions/types";
+import {
+  change,
+  formValueSelector,
+  reduxForm,
+} from "redux-form";
+import { FormNames } from "@/enums";
+
 type Props = {
   areaNotes: AreaNoteList;
+  change: (...args: Array<any>) => any;
   currentLease: Lease;
   fetchAreaNoteList: (...args: Array<any>) => any;
   isEditMode: boolean;
   leaseAttributes: Attributes;
   location: Record<string, any>;
   usersPermissions: UsersPermissionsType;
+  leaseAreaDraftFromForm: Record<string, any> | null | undefined;
+  leaseAreaDraftFromState: Record<string, any> | null | undefined;
 };
 type State = {
   areasGeoJson: LeafletGeoJson;
@@ -292,28 +303,31 @@ class SingleLeaseMap extends PureComponent<Props, State> {
       });
     }
 
-    {
+    if (
       hasPermissions(usersPermissions, UsersPermissions.VIEW_AREANOTE) &&
-        !isEmpty(areaNotes) &&
-        layers.push({
-          checked: false,
-          component: (
-            <AreaNotesLayer
-              key="area_notes"
-              allowToEdit={false}
-              areaNotes={areaNotes}
-            />
-          ),
-          name: "Muistettavat ehdot",
-        });
+      !isEmpty(areaNotes)
+    ) {
+      layers.push({
+        checked: false,
+        component: (
+          <AreaNotesLayer
+            key="area_notes"
+            allowToEdit={false}
+            areaNotes={areaNotes}
+          />
+        ),
+        name: "Muistettavat ehdot",
+      });
     }
+
     return layers;
   };
 
   render() {
-    const { isEditMode } = this.props;
+    const { isEditMode, change, leaseAreaDraftFromForm, leaseAreaDraftFromState } = this.props;
     const { bounds, center } = this.state;
     const overlayLayers = this.getOverlayLayers();
+    const initialValues = isEditMode ? leaseAreaDraftFromForm : leaseAreaDraftFromState || {};
     return (
       <Fragment>
         <Title
@@ -323,32 +337,46 @@ class SingleLeaseMap extends PureComponent<Props, State> {
           {LeaseFieldTitles.MAP}
         </Title>
         <Divider />
-
-        <AreaNotesEditMap
-          allowToEdit={false}
+        <MapComponent
+          change={(features: LeafletFeatureGeometry) => {
+            change("lease_area_draft.geometry", features);
+          }}
+          initialValues={initialValues}
+          isEditMode={isEditMode}
           bounds={bounds}
           center={center}
           overlayLayers={overlayLayers}
+          hasError={false}
         />
       </Fragment>
     );
   }
 }
 
+const formName = FormNames.LEASE_AREA_DRAFT;
+const selector = formValueSelector(formName);
 export default flowRight(
   withRouter,
   connect(
     (state) => {
+      const currentLease = getCurrentLease(state);
       return {
         areaNotes: getAreaNoteList(state),
-        currentLease: getCurrentLease(state),
+        currentLease: currentLease,
         isEditMode: getIsEditMode(state),
         leaseAttributes: getLeaseAttributes(state),
         usersPermissions: getUsersPermissions(state),
+        leaseAreaDraftFromForm: selector(state, "lease_area_draft"),
+        leaseAreaDraftFromState: getContentLeaseAreaDraft(currentLease),
       };
     },
     {
       fetchAreaNoteList,
     },
   ),
+  reduxForm({
+    form: formName,
+    destroyOnUnmount: false,
+    change,
+  }),
 )(SingleLeaseMap) as React.ComponentType<any>;

--- a/src/leases/helpers.ts
+++ b/src/leases/helpers.ts
@@ -61,9 +61,15 @@ import type {
   IntendedUse,
   PeriodicRentAdjustmentType,
   CreateLeaseFormValues,
+  LeaseAreaDraft,
 } from "./types";
 import type { CommentList } from "@/comments/types";
-import type { Attributes, LeafletFeature, LeafletGeoJson } from "types";
+import type {
+  Attributes,
+  LeafletFeature,
+  LeafletFeatureGeometry,
+  LeafletGeoJson,
+} from "types";
 import type { RootState } from "@/root/types";
 import type { LeaseList, DueDate } from "@/leases/types";
 import type { IndexPointFigureYearly } from "@/oldDwellingsInHousingCompaniesPriceIndex/types";
@@ -2620,6 +2626,18 @@ export const getContentAreasGeoJson = (lease: Lease): LeafletGeoJson => {
 };
 
 /**
+ * Get content lease area draft
+ * @param {Object} lease
+ * @returns {Object}
+ */
+export const getContentLeaseAreaDraft = (
+  lease: Lease,
+): LeaseAreaDraft | null => {
+  const leaseAreaDraft = get(lease, "lease_area_draft", null);
+  return leaseAreaDraft;
+};
+
+/**
  * Get content lease plots features for geojson data
  * @param {Object[]} plots
  * @returns {Object[]}
@@ -3255,6 +3273,30 @@ export const addConstructabilityFormValuesToPayload = (
       );
     });
   }
+
+  return payload;
+};
+
+export const addLeaseAreaDraftFormValuesToPayload = (
+  payload: Record<string, any>,
+  formValues: LeafletFeatureGeometry | null,
+): Record<string, any> => {
+  const leaseAreaDraft = get(formValues, "lease_area_draft", null);
+  if (!leaseAreaDraft) {
+    return payload;
+  }
+  const { identifier, geometry, area, location, address, postal_code, city } =
+    leaseAreaDraft;
+
+  payload.lease_area_draft = {
+    geometry: geometry,
+    identifier: identifier || "XYZ-XYZ-XYZ",
+    area: area || 1000,
+    location: location || "surface",
+    address: address || "",
+    postal_code: postal_code || "",
+    city: city || "",
+  };
 
   return payload;
 };

--- a/src/leases/types.ts
+++ b/src/leases/types.ts
@@ -58,6 +58,7 @@ export type Lease = {
   rent_info_completed_at: string | null;
   is_subject_to_vat: boolean;
   lease_areas: Array<LeaseArea>;
+  lease_area_draft: LeaseAreaDraft | null;
   lessor: Record<string, any>;
   management: Record<string, any> | null;
   matching_basis_of_rents: Array<Record<string, any>>;
@@ -139,6 +140,35 @@ export type LeaseAreaAddress = {
   city: string | null;
   is_primary: boolean;
 };
+
+// Lease area draft object as expected from API response
+/**
+ * Vuokra-alueen pakolliset kentät:
+ * 
+ * Kohteen tunnus luodaan jo päätöstä valmistellessa, 
+ *    saattaa kuitenkin muuttua ennen lopullista sopimusta
+ * Sijainti (Yläpuolella default)
+ * osoite (Aluehaun komponentti hakee pinta-alan 
+ *    ja osoitteen automaattisesti)
+ * pinta-ala
+ */
+
+type LeaseAreaDraftGeometry = {
+  type: "Polygon" | "MultiPolygon";
+  coordinates: Array<Array<Array<Array<number>>>>;
+};
+
+export type LeaseAreaDraft = {
+  id: number;
+  identifier: string;
+  area: number;
+  geometry: LeaseAreaDraftGeometry | null;
+  location: string;
+  address: string | null;
+  postal_code: string | null;
+  city: string | null;
+};
+
 export type CreateChargePayload = {
   leaseId: LeaseId;
   data: Record<string, any>;


### PR DESCRIPTION
Officer can draw a draft lease area in the map tab if there is no existing area imported already.

Work in progress. Now I am working on how to draw an area for draft areas that already exist and are therefore fetched and drawn when the map component is mounted and rendered.

Key questions:
- How to draw areas programmatically on mount and render?
- Do I get the lat-long long-lat reversal right when transitioning between the GeoJSON and Leaflet? This and other data type transformations are easy to miss and demand special attention when handling the geometry data.