### PR TITLE
credit decision search form: fix rendering issue

### DIFF
--- a/src/creditDecision/components/SearchForm.tsx
+++ b/src/creditDecision/components/SearchForm.tsx
@@ -24,7 +24,6 @@ const SearchForm: React.FC<Props> = ({ onSearch, initialValues }) => {
       <Form
         onSubmit={onSearch}
         initialValues={initialValues}
-        subscription={{}}
         render={({ handleSubmit, values }) => (
           <form onSubmit={handleSubmit}>
             <SearchRow
@@ -53,7 +52,6 @@ const SearchForm: React.FC<Props> = ({ onSearch, initialValues }) => {
                         read_only: false,
                       }}
                       invisibleLabel
-                      name="contact_type"
                       overrideValues={{
                         options: [
                           {
@@ -71,7 +69,7 @@ const SearchForm: React.FC<Props> = ({ onSearch, initialValues }) => {
                 </Field>
               </SearchInputColumn>
             </SearchRow>
-            {values.contact_type && (
+            {values?.contact_type && (
               <Fragment>
                 <SearchRow
                   style={{
@@ -106,7 +104,6 @@ const SearchForm: React.FC<Props> = ({ onSearch, initialValues }) => {
                             read_only: false,
                           }}
                           invisibleLabel
-                          name="keyword"
                         />
                       )}
                     </Field>
@@ -130,4 +127,4 @@ const SearchForm: React.FC<Props> = ({ onSearch, initialValues }) => {
   );
 };
 
-export default flowRight(SearchForm) as React.ComponentType<any>;
+export default SearchForm as React.ComponentType<any>;


### PR DESCRIPTION
By removing the empty `subscription` object (and thus enabling subscription), the form now re-renders on changes. Secondly, make `values.contact_type` as conditionally chained, we ensure that there will be no error in case that the values object happens to be undefined.