### PR TITLE
Freeze lockfile for installs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-    - run: yarn
+    - run: yarn --frozen-lockfile
     - run: yarn coverage
     - run: yarn build

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,7 @@
+# Ensures yarn.lock isn't automatically updated, e.g. with `yarn install`.
+# Specific to Yarn v1.
+# In Yarn v2 and above, the option is called `enableImmutableInstalls` in .yarnrc.yml instead.
+# To upgrade dependencies, you'll need to use either of the following:
+#   1) yarn install --no-frozen-lockfile
+#   2) yarn upgrade <package-name>@<version>
+--frozen-lockfile true

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,7 +3,7 @@ FROM node:18
 WORKDIR /app
 
 COPY package.json yarn.lock ./
-RUN yarn install && yarn cache clean --force
+RUN yarn install --frozen-lockfile && yarn cache clean --force
 
 COPY . .
 


### PR DESCRIPTION
This helps avoid accidentally installing poisoned dependencies, especially in local environments.

Next step would be to pin every dependency to exact version, instead of allowing "compatible commits" with `^`.