### PR TITLE
Fixes for various invoicing page issues

### DIFF
--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -313,6 +313,7 @@
       position: relative;
       border: 1px solid variables.$blue;
       margin-bottom: rem-calc(10px);
+      overflow: visible;
 
       .scroll-head-wrapper {
         overflow: hidden;

--- a/src/invoices/saga.ts
+++ b/src/invoices/saga.ts
@@ -181,7 +181,6 @@ function* patchInvoiceSaga({
       case 200:
         yield put(fetchInvoicesByLease(bodyAsJson.lease));
         yield put(receivePatchedInvoice(bodyAsJson));
-        yield put(receiveIsEditClicked(false));
         displayUIMessage({
           title: "",
           body: "Lasku tallennettu",
@@ -200,6 +199,17 @@ function* patchInvoiceSaga({
         );
         break;
 
+      case 403:
+        yield put(notFound());
+        yield put(
+          receiveError(
+            new SubmissionError({
+              ...bodyAsJson,
+            }),
+          ),
+        );
+        break;
+
       case 500:
         yield put(notFound());
         yield put(receiveError(new Error(bodyAsJson)));
@@ -209,6 +219,8 @@ function* patchInvoiceSaga({
     console.error('Failed to edit invoice with error "%s"', error);
     yield put(notFound());
     yield put(receiveError(error));
+  } finally {
+    yield put(receiveIsEditClicked(false));
   }
 }
 

--- a/src/leaseCreateCharge/helpers.ts
+++ b/src/leaseCreateCharge/helpers.ts
@@ -62,6 +62,6 @@ export const receivableTypesFromAttributes = (
  */
 export const receivableTypeFromRows = (
   rows: Array<Record<string, any>>,
-): Number | null | undefined => {
-  return rows ? (rows[0]?.receivable_type ?? null) : null;
+): number | null => {
+  return rows?.[0]?.receivable_type ?? null;
 };

--- a/src/leaseCreateCharge/helpers.ts
+++ b/src/leaseCreateCharge/helpers.ts
@@ -63,5 +63,5 @@ export const receivableTypesFromAttributes = (
 export const receivableTypeFromRows = (
   rows: Array<Record<string, any>>,
 ): Number | null | undefined => {
-  return rows ? rows[0].receivable_type : null;
+  return rows ? (rows[0]?.receivable_type ?? null) : null;
 };

--- a/src/leases/components/leaseSections/invoice/CreateAndCreditInvoice.tsx
+++ b/src/leases/components/leaseSections/invoice/CreateAndCreditInvoice.tsx
@@ -243,7 +243,10 @@ const CreateAndCreditInvoice: React.FC<Props> = ({ invoiceToCredit }) => {
       </AppConsumer>
 
       <Authorization
-        allow={hasPermissions(usersPermissions, UsersPermissions.ADD_INVOICE)}
+        allow={
+          hasPermissions(usersPermissions, UsersPermissions.ADD_INVOICE) &&
+          isServiceUnitSameAsActiveServiceUnit()
+        }
       >
         <div ref={setCreditPanelRef}>
           {isCreditInvoicePanelOpen && (

--- a/src/leases/components/leaseSections/invoice/CreateAndCreditInvoice.tsx
+++ b/src/leases/components/leaseSections/invoice/CreateAndCreditInvoice.tsx
@@ -32,7 +32,10 @@ import {
   getIsCreateInvoicePanelOpen,
   getIsCreditInvoicePanelOpen,
 } from "@/invoices/selectors";
-import { getUsersPermissions } from "@/usersPermissions/selectors";
+import {
+  getUserActiveServiceUnit,
+  getUsersPermissions,
+} from "@/usersPermissions/selectors";
 import { AppConsumer, ActionTypes } from "@/app/AppContext";
 import { ConfirmationModalTexts } from "@/enums";
 import type { Lease } from "@/leases/types";
@@ -50,6 +53,7 @@ const CreateAndCreditInvoice: React.FC<Props> = ({ invoiceToCredit }) => {
     : null;
   const usersPermissions: UsersPermissionsType =
     useSelector(getUsersPermissions);
+  const activeServiceUnit = useSelector(getUserActiveServiceUnit);
 
   const creditPanel = useRef<HTMLDivElement | null>(null);
   const creditPanelFirstField = useRef<HTMLElement | null>(null);
@@ -57,6 +61,10 @@ const CreateAndCreditInvoice: React.FC<Props> = ({ invoiceToCredit }) => {
   const createPanelFirstField = useRef<HTMLElement | null>(null);
 
   const dispatch = useDispatch();
+
+  const isServiceUnitSameAsActiveServiceUnit = () => {
+    return activeServiceUnit?.id === currentLease?.service_unit?.id;
+  };
 
   const setCreatePanelRef = (el: HTMLDivElement | null) => {
     createPanel.current = el;
@@ -179,7 +187,10 @@ const CreateAndCreditInvoice: React.FC<Props> = ({ invoiceToCredit }) => {
   return (
     <div className="invoice__new-invoice">
       <Authorization
-        allow={hasPermissions(usersPermissions, UsersPermissions.ADD_INVOICE)}
+        allow={
+          hasPermissions(usersPermissions, UsersPermissions.ADD_INVOICE) &&
+          isServiceUnitSameAsActiveServiceUnit()
+        }
       >
         <Button
           className={`${ButtonColors.NEUTRAL} no-margin`}
@@ -209,10 +220,12 @@ const CreateAndCreditInvoice: React.FC<Props> = ({ invoiceToCredit }) => {
 
           return (
             <Authorization
-              allow={hasPermissions(
-                usersPermissions,
-                UsersPermissions.DELETE_INVOICE,
-              )}
+              allow={
+                hasPermissions(
+                  usersPermissions,
+                  UsersPermissions.DELETE_INVOICE,
+                ) && isServiceUnitSameAsActiveServiceUnit()
+              }
             >
               <Button
                 className={ButtonColors.ALERT}
@@ -246,7 +259,10 @@ const CreateAndCreditInvoice: React.FC<Props> = ({ invoiceToCredit }) => {
       </Authorization>
 
       <Authorization
-        allow={hasPermissions(usersPermissions, UsersPermissions.ADD_INVOICE)}
+        allow={
+          hasPermissions(usersPermissions, UsersPermissions.ADD_INVOICE) &&
+          isServiceUnitSameAsActiveServiceUnit()
+        }
       >
         <Row>
           <Column>
@@ -263,7 +279,10 @@ const CreateAndCreditInvoice: React.FC<Props> = ({ invoiceToCredit }) => {
       </Authorization>
 
       <Authorization
-        allow={hasPermissions(usersPermissions, UsersPermissions.ADD_INVOICE)}
+        allow={
+          hasPermissions(usersPermissions, UsersPermissions.ADD_INVOICE) &&
+          isServiceUnitSameAsActiveServiceUnit()
+        }
       >
         <div ref={setCreatePanelRef}>
           {isCreateInvoicePanelOpen && (

--- a/src/leases/components/leaseSections/invoice/InvoiceNotes.tsx
+++ b/src/leases/components/leaseSections/invoice/InvoiceNotes.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/invoiceNote/selectors";
 import { getCurrentLease } from "@/leases/selectors";
 import type { Attributes } from "types";
+import { getUserActiveServiceUnit } from "@/usersPermissions/selectors";
 type ReadOnlyProps = {
   invoiceNotes: Array<Record<string, any>>;
 };
@@ -320,6 +321,11 @@ type Props = {
 const InvoiceNotes: React.FC<Props> = ({ invoiceNotes }) => {
   const currentLease = useSelector(getCurrentLease);
   const invoiceNoteMethods = useSelector(getInvoiceNoteMethods);
+  const activeServiceUnit = useSelector(getUserActiveServiceUnit);
+
+  const isServiceUnitSameAsActiveServiceUnit = () => {
+    return activeServiceUnit?.id === currentLease?.service_unit?.id;
+  };
 
   const dispatch = useDispatch();
 
@@ -348,14 +354,18 @@ const InvoiceNotes: React.FC<Props> = ({ invoiceNotes }) => {
         <form onSubmit={handleSubmit}>
           <Authorization
             allow={
-              isMethodAllowed(invoiceNoteMethods, Methods.GET) &&
-              !isMethodAllowed(invoiceNoteMethods, Methods.PATCH)
+              (isMethodAllowed(invoiceNoteMethods, Methods.GET) &&
+                !isMethodAllowed(invoiceNoteMethods, Methods.PATCH)) ||
+              !isServiceUnitSameAsActiveServiceUnit()
             }
           >
             <InvoiceNotesReadOnly invoiceNotes={invoiceNotes} />
           </Authorization>
           <Authorization
-            allow={isMethodAllowed(invoiceNoteMethods, Methods.PATCH)}
+            allow={
+              isMethodAllowed(invoiceNoteMethods, Methods.PATCH) &&
+              isServiceUnitSameAsActiveServiceUnit()
+            }
           >
             <AppConsumer>
               {({ dispatch: appDispatch }) => {

--- a/src/leases/components/leaseSections/invoice/InvoicePanel.tsx
+++ b/src/leases/components/leaseSections/invoice/InvoicePanel.tsx
@@ -25,6 +25,7 @@ import {
   getMethods as getInvoiceMethods,
 } from "@/invoices/selectors";
 import { getCurrentLease } from "@/leases/selectors";
+import { getUserActiveServiceUnit } from "@/usersPermissions/selectors";
 import type { Methods as MethodsType } from "types";
 import type { Invoice } from "@/invoices/types";
 
@@ -43,6 +44,7 @@ const InvoicePanel = forwardRef<any, Props>(
       getInvoicesByLease(state, currentLease.id),
     );
     const isEditClicked = useSelector(getIsEditClicked);
+    const activeServiceUnit = useSelector(getUserActiveServiceUnit);
     const dispatch = useDispatch();
 
     const invoiceFormRef = useRef<FormApi>(
@@ -64,6 +66,7 @@ const InvoicePanel = forwardRef<any, Props>(
       string,
       any
     > | null>(null);
+    const [isFormValid, setIsFormValid] = useState(false);
 
     const setComponentRef = (el: HTMLDivElement | null) => {
       component.current = el;
@@ -97,11 +100,28 @@ const InvoicePanel = forwardRef<any, Props>(
       }
     }, [invoice, invoices]);
 
+    useEffect(() => {
+      if (invoice && invoiceFormRef.current) {
+        invoiceFormRef.current.initialize(invoice);
+      }
+    }, [invoice]);
+
+    useEffect(() => {
+      return invoiceFormRef.current.subscribe(
+        ({ valid }) => setIsFormValid(valid),
+        { valid: true },
+      );
+    }, []);
+
     const handleSave = () => {
       dispatch(receiveIsEditClicked(true));
       if (invoiceFormRef.current.getState().valid) {
         invoiceFormRef.current.submit();
       }
+    };
+
+    const isServiceUnitSameAsActiveServiceUnit = () => {
+      return activeServiceUnit?.id === currentLease?.service_unit?.id;
     };
 
     return (
@@ -111,7 +131,10 @@ const InvoicePanel = forwardRef<any, Props>(
           invoice &&
           !invoice.sap_id && (
             <Authorization
-              allow={isMethodAllowed(invoiceMethods, Methods.PATCH)}
+              allow={
+                isMethodAllowed(invoiceMethods, Methods.PATCH) &&
+                isServiceUnitSameAsActiveServiceUnit()
+              }
             >
               <>
                 <Button
@@ -121,9 +144,7 @@ const InvoicePanel = forwardRef<any, Props>(
                 />
                 <Button
                   className={ButtonColors.SUCCESS}
-                  disabled={
-                    isEditClicked || !invoiceFormRef.current.getState().valid
-                  }
+                  disabled={isEditClicked || !isFormValid}
                   onClick={handleSave}
                   text="Tallenna"
                 />
@@ -135,7 +156,8 @@ const InvoicePanel = forwardRef<any, Props>(
         title="Laskun tiedot"
       >
         {isMethodAllowed(invoiceMethods, Methods.PATCH) &&
-        (!invoice || !invoice.sap_id) ? (
+        !invoice?.sap_id &&
+        isServiceUnitSameAsActiveServiceUnit() ? (
           <EditInvoiceForm
             creditedInvoice={creditedInvoice}
             interestInvoiceFor={interestInvoiceFor}

--- a/src/leases/components/leaseSections/invoice/InvoiceTemplate.tsx
+++ b/src/leases/components/leaseSections/invoice/InvoiceTemplate.tsx
@@ -409,88 +409,12 @@ const InvoiceTemplate = ({
                   InvoicePaymentsFieldPaths.PAYMENTS,
                 )}
               >
-                <>
-                  {!payments.length && <FormText>Ei maksuja</FormText>}
-                  {!!payments.length && (
-                    <ListItems>
-                      <Row>
-                        <Column small={6}>
-                          <Authorization
-                            allow={isFieldAllowedToRead(
-                              invoiceAttributes,
-                              InvoicePaymentsFieldPaths.PAID_AMOUNT,
-                            )}
-                          >
-                            <FormTextTitle
-                              enableUiDataEdit
-                              relativeTo={relativeTo}
-                              uiDataKey={getUiDataInvoiceKey(
-                                InvoicePaymentsFieldPaths.PAID_AMOUNT,
-                              )}
-                            >
-                              {InvoicePaymentsFieldTitles.PAID_AMOUNT}
-                            </FormTextTitle>
-                          </Authorization>
-                        </Column>
-                        <Column small={6}>
-                          <Authorization
-                            allow={isFieldAllowedToRead(
-                              invoiceAttributes,
-                              InvoicePaymentsFieldPaths.PAID_DATE,
-                            )}
-                          >
-                            <FormTextTitle
-                              enableUiDataEdit
-                              relativeTo={relativeTo}
-                              uiDataKey={getUiDataInvoiceKey(
-                                InvoicePaymentsFieldPaths.PAID_DATE,
-                              )}
-                            >
-                              {InvoicePaymentsFieldTitles.PAID_DATE}
-                            </FormTextTitle>
-                          </Authorization>
-                        </Column>
-                      </Row>
-                      {payments.map((payment) => {
-                        return (
-                          <Row key={payment.id}>
-                            <Column small={6}>
-                              <Authorization
-                                allow={isFieldAllowedToRead(
-                                  invoiceAttributes,
-                                  InvoicePaymentsFieldPaths.PAID_AMOUNT,
-                                )}
-                              >
-                                <ListItem>
-                                  {payment.paid_amount ? (
-                                    <AmountWithVat
-                                      amount={payment.paid_amount}
-                                      date={invoice ? invoice.due_date : null}
-                                    />
-                                  ) : (
-                                    "-"
-                                  )}
-                                </ListItem>
-                              </Authorization>
-                            </Column>
-                            <Column small={6}>
-                              <Authorization
-                                allow={isFieldAllowedToRead(
-                                  invoiceAttributes,
-                                  InvoicePaymentsFieldPaths.PAID_DATE,
-                                )}
-                              >
-                                <ListItem>
-                                  {formatDate(payment.paid_date) || "-"}
-                                </ListItem>
-                              </Authorization>
-                            </Column>
-                          </Row>
-                        );
-                      })}
-                    </ListItems>
-                  )}
-                </>
+                <PaymentsReadOnly
+                  payments={payments}
+                  invoiceAttributes={invoiceAttributes}
+                  invoice={invoice}
+                  relativeTo={relativeTo}
+                />
               </Authorization>
             </Column>
             <Column small={6} medium={4}>
@@ -965,6 +889,101 @@ const InvoiceTemplate = ({
           rows={rows}
         />
       </Authorization>
+    </>
+  );
+};
+
+type PaymentsReadOnlyProps = {
+  payments: Array<Record<string, any>>;
+  invoiceAttributes: Attributes;
+  invoice: Record<string, any>;
+  relativeTo: any;
+};
+
+export const PaymentsReadOnly = ({
+  payments,
+  invoiceAttributes,
+  invoice,
+  relativeTo,
+}: PaymentsReadOnlyProps) => {
+  return (
+    <>
+      {!payments.length && <FormText>Ei maksuja</FormText>}
+      {!!payments.length && (
+        <ListItems>
+          <Row>
+            <Column small={6}>
+              <Authorization
+                allow={isFieldAllowedToRead(
+                  invoiceAttributes,
+                  InvoicePaymentsFieldPaths.PAID_AMOUNT,
+                )}
+              >
+                <FormTextTitle
+                  enableUiDataEdit
+                  relativeTo={relativeTo}
+                  uiDataKey={getUiDataInvoiceKey(
+                    InvoicePaymentsFieldPaths.PAID_AMOUNT,
+                  )}
+                >
+                  {InvoicePaymentsFieldTitles.PAID_AMOUNT}
+                </FormTextTitle>
+              </Authorization>
+            </Column>
+            <Column small={6}>
+              <Authorization
+                allow={isFieldAllowedToRead(
+                  invoiceAttributes,
+                  InvoicePaymentsFieldPaths.PAID_DATE,
+                )}
+              >
+                <FormTextTitle
+                  enableUiDataEdit
+                  relativeTo={relativeTo}
+                  uiDataKey={getUiDataInvoiceKey(
+                    InvoicePaymentsFieldPaths.PAID_DATE,
+                  )}
+                >
+                  {InvoicePaymentsFieldTitles.PAID_DATE}
+                </FormTextTitle>
+              </Authorization>
+            </Column>
+          </Row>
+          {payments.map((payment) => (
+            <Row key={payment.id}>
+              <Column small={6}>
+                <Authorization
+                  allow={isFieldAllowedToRead(
+                    invoiceAttributes,
+                    InvoicePaymentsFieldPaths.PAID_AMOUNT,
+                  )}
+                >
+                  <ListItem>
+                    {payment.paid_amount ? (
+                      <AmountWithVat
+                        amount={payment.paid_amount}
+                        date={invoice.due_date}
+                      />
+                    ) : (
+                      "-"
+                    )}
+                  </ListItem>
+                </Authorization>
+              </Column>
+              <Column small={6}>
+                <Authorization
+                  allow={isFieldAllowedToRead(
+                    invoiceAttributes,
+                    InvoicePaymentsFieldPaths.PAID_DATE,
+                  )}
+                >
+                  <ListItem>{formatDate(payment.paid_date) || "-"}</ListItem>
+                </Authorization>
+              </Column>
+            </Row>
+          ))}
+        </ListItems>
+      )}
     </>
   );
 };

--- a/src/leases/components/leaseSections/invoice/Invoices.tsx
+++ b/src/leases/components/leaseSections/invoice/Invoices.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { ActionTypes, AppConsumer } from "@/app/AppContext";
 import Authorization from "@/components/authorization/Authorization";
@@ -59,7 +59,10 @@ import {
   getCollapseStateByKey,
   getCurrentLease,
 } from "@/leases/selectors";
-import { getUsersPermissions } from "@/usersPermissions/selectors";
+import {
+  getUserActiveServiceUnit,
+  getUsersPermissions,
+} from "@/usersPermissions/selectors";
 import type { Attributes } from "types";
 import type { Lease } from "@/leases/types";
 
@@ -127,7 +130,12 @@ const Invoices: React.FC = () => {
     ),
   );
   const usersPermissions = useSelector(getUsersPermissions);
+  const activeServiceUnit = useSelector(getUserActiveServiceUnit);
   const dispatch = useDispatch();
+
+  const isServiceUnitSameAsActiveServiceUnit = () => {
+    return activeServiceUnit?.id === currentLease?.service_unit?.id;
+  };
 
   const isInvoicingEnabled = useMemo(() => {
     return currentLease ? !!currentLease.invoicing_enabled_at : null;
@@ -393,10 +401,12 @@ const Invoices: React.FC = () => {
               alignCenter
               buttonComponent={
                 <Authorization
-                  allow={hasPermissions(
-                    usersPermissions,
-                    UsersPermissions.CHANGE_LEASE_INVOICING_ENABLED_AT,
-                  )}
+                  allow={
+                    hasPermissions(
+                      usersPermissions,
+                      UsersPermissions.CHANGE_LEASE_INVOICING_ENABLED_AT,
+                    ) && isServiceUnitSameAsActiveServiceUnit()
+                  }
                 >
                   {isInvoicingEnabled ? (
                     <Button

--- a/src/leases/components/leaseSections/invoice/forms/DebtCollectionForm.tsx
+++ b/src/leases/components/leaseSections/invoice/forms/DebtCollectionForm.tsx
@@ -89,7 +89,10 @@ import {
   getAttributes as getLeaseAttributes,
   getCurrentLease,
 } from "@/leases/selectors";
-import { getUsersPermissions } from "@/usersPermissions/selectors";
+import {
+  getUserActiveServiceUnit,
+  getUsersPermissions,
+} from "@/usersPermissions/selectors";
 import { useWindowResize } from "@/components/resize/WindowResizeHandler";
 import type { Attributes } from "types";
 import type { CollectionCourtDecisionId } from "@/collectionCourtDecision/types";
@@ -173,6 +176,7 @@ const DebtCollectionForm: React.FC = () => {
   const leaseAttributes: Attributes = useSelector(getLeaseAttributes);
   const usersPermissions: UsersPermissionsType =
     useSelector(getUsersPermissions);
+  const activeServiceUnit = useSelector(getUserActiveServiceUnit);
   const largeScreen = useWindowResize();
   const dispatch = useDispatch();
 
@@ -195,6 +199,10 @@ const DebtCollectionForm: React.FC = () => {
     () => getDecisionOptions(currentLease),
     [currentLease],
   );
+
+  const isServiceUnitSameAsActiveServiceUnit = () => {
+    return activeServiceUnit?.id === currentLease?.service_unit?.id;
+  };
 
   useEffect(() => {
     if (collectionCourtDecisions) {
@@ -459,10 +467,13 @@ const DebtCollectionForm: React.FC = () => {
                                     }
                                     removeButton={
                                       <Authorization
-                                        allow={hasPermissions(
-                                          usersPermissions,
-                                          UsersPermissions.DELETE_COLLECTIONLETTER,
-                                        )}
+                                        allow={
+                                          hasPermissions(
+                                            usersPermissions,
+                                            UsersPermissions.DELETE_COLLECTIONLETTER,
+                                          ) &&
+                                          isServiceUnitSameAsActiveServiceUnit()
+                                        }
                                       >
                                         <RemoveButton
                                           className="third-level"
@@ -482,10 +493,12 @@ const DebtCollectionForm: React.FC = () => {
                         )}
 
                       <Authorization
-                        allow={hasPermissions(
-                          usersPermissions,
-                          UsersPermissions.ADD_COLLECTIONLETTER,
-                        )}
+                        allow={
+                          hasPermissions(
+                            usersPermissions,
+                            UsersPermissions.ADD_COLLECTIONLETTER,
+                          ) && isServiceUnitSameAsActiveServiceUnit()
+                        }
                       >
                         <AddFileButton
                           label="Lisää perintäkirje"
@@ -695,10 +708,13 @@ const DebtCollectionForm: React.FC = () => {
                                     }
                                     removeButton={
                                       <Authorization
-                                        allow={hasPermissions(
-                                          usersPermissions,
-                                          UsersPermissions.DELETE_COLLECTIONCOURTDECISION,
-                                        )}
+                                        allow={
+                                          hasPermissions(
+                                            usersPermissions,
+                                            UsersPermissions.DELETE_COLLECTIONCOURTDECISION,
+                                          ) &&
+                                          isServiceUnitSameAsActiveServiceUnit()
+                                        }
                                       >
                                         <RemoveButton
                                           className="third-level"
@@ -751,10 +767,13 @@ const DebtCollectionForm: React.FC = () => {
                                 return (
                                   <BoxItem key={index}>
                                     <Authorization
-                                      allow={hasPermissions(
-                                        usersPermissions,
-                                        UsersPermissions.DELETE_COLLECTIONCOURTDECISION,
-                                      )}
+                                      allow={
+                                        hasPermissions(
+                                          usersPermissions,
+                                          UsersPermissions.DELETE_COLLECTIONCOURTDECISION,
+                                        ) &&
+                                        isServiceUnitSameAsActiveServiceUnit()
+                                      }
                                     >
                                       <ActionButtonWrapper>
                                         <RemoveButton
@@ -876,10 +895,12 @@ const DebtCollectionForm: React.FC = () => {
                           </BoxItemContainer>
                         )}
                       <Authorization
-                        allow={hasPermissions(
-                          usersPermissions,
-                          UsersPermissions.ADD_COLLECTIONCOURTDECISION,
-                        )}
+                        allow={
+                          hasPermissions(
+                            usersPermissions,
+                            UsersPermissions.ADD_COLLECTIONCOURTDECISION,
+                          ) && isServiceUnitSameAsActiveServiceUnit()
+                        }
                       >
                         <>
                           <CollectionCourtDecisionPanel
@@ -1117,10 +1138,13 @@ const DebtCollectionForm: React.FC = () => {
                                   }
                                   removeButton={
                                     <Authorization
-                                      allow={hasPermissions(
-                                        usersPermissions,
-                                        UsersPermissions.DELETE_COLLECTIONNOTE,
-                                      )}
+                                      allow={
+                                        hasPermissions(
+                                          usersPermissions,
+                                          UsersPermissions.DELETE_COLLECTIONNOTE,
+                                        ) &&
+                                        isServiceUnitSameAsActiveServiceUnit()
+                                      }
                                     >
                                       <RemoveButton
                                         className="third-level"
@@ -1139,10 +1163,12 @@ const DebtCollectionForm: React.FC = () => {
                         })}
 
                       <Authorization
-                        allow={hasPermissions(
-                          usersPermissions,
-                          UsersPermissions.ADD_COLLECTIONNOTE,
-                        )}
+                        allow={
+                          hasPermissions(
+                            usersPermissions,
+                            UsersPermissions.ADD_COLLECTIONNOTE,
+                          ) && isServiceUnitSameAsActiveServiceUnit()
+                        }
                       >
                         <FieldArray name="notes">
                           {(fieldArrayProps) =>

--- a/src/leases/components/leaseSections/invoice/forms/EditInvoiceForm.tsx
+++ b/src/leases/components/leaseSections/invoice/forms/EditInvoiceForm.tsx
@@ -255,9 +255,13 @@ const EditInvoiceForm: React.FC<Props> = ({
 
   const rows = invoice ? invoice.rows : undefined;
 
-  const isSentToSap = invoice?.sent_to_sap_at || invoice?.sap_id;
-  const isCreditNote = invoice?.type === InvoiceType.CREDIT_NOTE;
-  const isGenerated = invoice?.generated;
+  const isSentToSap: boolean = Boolean(
+    invoice?.sent_to_sap_at || invoice?.sap_id,
+  );
+  const isCreditNote: boolean = Boolean(
+    invoice?.type === InvoiceType.CREDIT_NOTE,
+  );
+  const isGenerated: boolean = Boolean(invoice?.generated);
 
   const getInvoiceStateKey = () => {
     if (isSentToSap) return "sentToSap";

--- a/src/leases/components/leaseSections/invoice/forms/EditInvoiceForm.tsx
+++ b/src/leases/components/leaseSections/invoice/forms/EditInvoiceForm.tsx
@@ -13,6 +13,8 @@ import { Form } from "react-final-form";
 import { FormApi } from "final-form";
 import FormTextTitle from "@/components/form/FormTextTitle";
 import InvoiceRowsEdit from "./InvoiceRowsEdit";
+import ListItem from "@/components/content/ListItem";
+import ListItems from "@/components/content/ListItems";
 import RemoveButton from "@/components/form/RemoveButton";
 import SendupButton from "@/components/button/SendupButton";
 import SubTitle from "@/components/content/SubTitle";
@@ -219,6 +221,13 @@ const Payments = ({ fields, relativeTo }: PaymentsProps): ReactElement => {
   );
 };
 
+const INVOICE_STATE_EDITABLE_FIELDS: Record<string, Set<string> | null> = {
+  sentToSap: new Set([InvoiceFieldPaths.POSTPONE_DATE]),
+  creditNote: new Set([InvoiceFieldPaths.NOTES]),
+  generated: new Set(),
+  manual: null,
+};
+
 type Props = {
   creditedInvoice: Record<string, any> | null | undefined;
   formApi: FormApi;
@@ -244,6 +253,26 @@ const EditInvoiceForm: React.FC<Props> = ({
   const dispatch = useDispatch();
 
   const rows = invoice ? invoice.rows : undefined;
+
+  const isSentToSap = invoice?.sent_to_sap_at || invoice?.sap_id;
+  const isCreditNote = invoice?.type === InvoiceType.CREDIT_NOTE;
+  const isGenerated = invoice?.generated;
+
+  const getInvoiceStateKey = () => {
+    if (isSentToSap) return "sentToSap";
+    if (isCreditNote) return "creditNote";
+    if (isGenerated) return "generated";
+    return "manual";
+  };
+  const invoiceStateKey = getInvoiceStateKey();
+
+  const editableFieldsSet = INVOICE_STATE_EDITABLE_FIELDS[invoiceStateKey];
+
+  const paymentsEditable =
+    invoiceStateKey === "manual" || invoiceStateKey === "generated";
+
+  const isEditable = (fieldPath: string) =>
+    editableFieldsSet === null || editableFieldsSet.has(fieldPath);
 
   const handleCreditedInvoiceClick = () => {
     if (invoice) {
@@ -303,6 +332,7 @@ const EditInvoiceForm: React.FC<Props> = ({
     invoiceAttributes,
     InvoiceFieldPaths.TYPE,
   );
+  const payments = invoice ? invoice.payments : [];
   const creditInvoices = invoice ? invoice.credit_invoices : [];
   const interestInvoices = invoice ? invoice.interest_invoices : [];
   const showOldInvoiceInfo = shouldShowOldInvoiceInfo();
@@ -400,13 +430,13 @@ const EditInvoiceForm: React.FC<Props> = ({
           </Row>
           <Row>
             <Column small={4}>
-              {invoice && invoice.type !== InvoiceType.CREDIT_NOTE && (
-                <Authorization
-                  allow={isFieldAllowedToRead(
-                    invoiceAttributes,
-                    InvoiceFieldPaths.DUE_DATE,
-                  )}
-                >
+              <Authorization
+                allow={isFieldAllowedToRead(
+                  invoiceAttributes,
+                  InvoiceFieldPaths.DUE_DATE,
+                )}
+              >
+                {invoice && isEditable(InvoiceFieldPaths.DUE_DATE) ? (
                   <FormField
                     disableTouched={isEditClicked}
                     fieldAttributes={getFieldAttributes(
@@ -421,15 +451,7 @@ const EditInvoiceForm: React.FC<Props> = ({
                     relativeTo={relativeTo}
                     uiDataKey={getUiDataInvoiceKey(InvoiceFieldPaths.DUE_DATE)}
                   />
-                </Authorization>
-              )}
-              {invoice && invoice.type === InvoiceType.CREDIT_NOTE && (
-                <Authorization
-                  allow={isFieldAllowedToRead(
-                    invoiceAttributes,
-                    InvoiceFieldPaths.DUE_DATE,
-                  )}
-                >
+                ) : (
                   <>
                     <FormTextTitle
                       enableUiDataEdit
@@ -444,8 +466,8 @@ const EditInvoiceForm: React.FC<Props> = ({
                       {(invoice && formatDate(invoice.due_date)) || "-"}
                     </FormText>
                   </>
-                </Authorization>
-              )}
+                )}
+              </Authorization>
             </Column>
             <Column small={4}>
               <Authorization
@@ -535,13 +557,14 @@ const EditInvoiceForm: React.FC<Props> = ({
               </Row>
               <Row>
                 <Column small={6}>
-                  {invoice && invoice.type !== InvoiceType.CREDIT_NOTE && (
-                    <Authorization
-                      allow={isFieldAllowedToRead(
-                        invoiceAttributes,
-                        InvoiceFieldPaths.BILLING_PERIOD_START_DATE,
-                      )}
-                    >
+                  <Authorization
+                    allow={isFieldAllowedToRead(
+                      invoiceAttributes,
+                      InvoiceFieldPaths.BILLING_PERIOD_START_DATE,
+                    )}
+                  >
+                    {invoice &&
+                    isEditable(InvoiceFieldPaths.BILLING_PERIOD_START_DATE) ? (
                       <FormField
                         disableTouched={isEditClicked}
                         fieldAttributes={getFieldAttributes(
@@ -554,31 +577,24 @@ const EditInvoiceForm: React.FC<Props> = ({
                           label: InvoiceFieldTitles.BILLING_PERIOD_START_DATE,
                         }}
                       />
-                    </Authorization>
-                  )}
-                  {invoice && invoice.type === InvoiceType.CREDIT_NOTE && (
-                    <Authorization
-                      allow={isFieldAllowedToRead(
-                        invoiceAttributes,
-                        InvoiceFieldPaths.BILLING_PERIOD_START_DATE,
-                      )}
-                    >
+                    ) : (
                       <FormText>
                         {(invoice &&
                           formatDate(invoice.billing_period_start_date)) ||
                           "-"}
                       </FormText>
-                    </Authorization>
-                  )}
+                    )}
+                  </Authorization>
                 </Column>
                 <Column small={6}>
-                  {invoice && invoice.type !== InvoiceType.CREDIT_NOTE && (
-                    <Authorization
-                      allow={isFieldAllowedToRead(
-                        invoiceAttributes,
-                        InvoiceFieldPaths.BILLING_PERIOD_END_DATE,
-                      )}
-                    >
+                  <Authorization
+                    allow={isFieldAllowedToRead(
+                      invoiceAttributes,
+                      InvoiceFieldPaths.BILLING_PERIOD_END_DATE,
+                    )}
+                  >
+                    {invoice &&
+                    isEditable(InvoiceFieldPaths.BILLING_PERIOD_END_DATE) ? (
                       <FormField
                         disableTouched={isEditClicked}
                         fieldAttributes={getFieldAttributes(
@@ -591,33 +607,25 @@ const EditInvoiceForm: React.FC<Props> = ({
                           label: InvoiceFieldTitles.BILLING_PERIOD_END_DATE,
                         }}
                       />
-                    </Authorization>
-                  )}
-                  {invoice && invoice.type === InvoiceType.CREDIT_NOTE && (
-                    <Authorization
-                      allow={isFieldAllowedToRead(
-                        invoiceAttributes,
-                        InvoiceFieldPaths.BILLING_PERIOD_END_DATE,
-                      )}
-                    >
+                    ) : (
                       <FormText>
                         {(invoice &&
                           formatDate(invoice.billing_period_end_date)) ||
                           "-"}
                       </FormText>
-                    </Authorization>
-                  )}
+                    )}
+                  </Authorization>
                 </Column>
               </Row>
             </Column>
             <Column small={4}>
-              {invoice && invoice.type !== InvoiceType.CREDIT_NOTE && (
-                <Authorization
-                  allow={isFieldAllowedToRead(
-                    invoiceAttributes,
-                    InvoiceFieldPaths.POSTPONE_DATE,
-                  )}
-                >
+              <Authorization
+                allow={isFieldAllowedToRead(
+                  invoiceAttributes,
+                  InvoiceFieldPaths.POSTPONE_DATE,
+                )}
+              >
+                {invoice && isEditable(InvoiceFieldPaths.POSTPONE_DATE) ? (
                   <FormField
                     disableTouched={isEditClicked}
                     fieldAttributes={getFieldAttributes(
@@ -629,15 +637,7 @@ const EditInvoiceForm: React.FC<Props> = ({
                       label: InvoiceFieldTitles.POSTPONE_DATE,
                     }}
                   />
-                </Authorization>
-              )}
-              {invoice && invoice.type === InvoiceType.CREDIT_NOTE && (
-                <Authorization
-                  allow={isFieldAllowedToRead(
-                    invoiceAttributes,
-                    InvoiceFieldPaths.POSTPONE_DATE,
-                  )}
-                >
+                ) : (
                   <>
                     <FormTextTitle
                       enableUiDataEdit
@@ -652,8 +652,8 @@ const EditInvoiceForm: React.FC<Props> = ({
                       {(invoice && formatDate(invoice.postpone_date)) || "-"}
                     </FormText>
                   </>
-                </Authorization>
-              )}
+                )}
+              </Authorization>
             </Column>
           </Row>
           <Row>
@@ -753,14 +753,97 @@ const EditInvoiceForm: React.FC<Props> = ({
                       InvoicePaymentsFieldPaths.PAYMENTS,
                     )}
                   >
-                    <FieldArray name="payments">
-                      {(fieldArrayProps) =>
-                        Payments({
-                          ...fieldArrayProps,
-                          relativeTo: relativeTo,
-                        })
-                      }
-                    </FieldArray>
+                    {paymentsEditable ? (
+                      <FieldArray name="payments">
+                        {(fieldArrayProps) =>
+                          Payments({
+                            ...fieldArrayProps,
+                            relativeTo: relativeTo,
+                          })
+                        }
+                      </FieldArray>
+                    ) : (
+                      <>
+                        {!payments.length && <FormText>Ei maksuja</FormText>}
+                        {!!payments.length && (
+                          <ListItems>
+                            <Row>
+                              <Column small={6}>
+                                <Authorization
+                                  allow={isFieldAllowedToRead(
+                                    invoiceAttributes,
+                                    InvoicePaymentsFieldPaths.PAID_AMOUNT,
+                                  )}
+                                >
+                                  <FormTextTitle
+                                    enableUiDataEdit
+                                    relativeTo={relativeTo}
+                                    uiDataKey={getUiDataInvoiceKey(
+                                      InvoicePaymentsFieldPaths.PAID_AMOUNT,
+                                    )}
+                                  >
+                                    {InvoicePaymentsFieldTitles.PAID_AMOUNT}
+                                  </FormTextTitle>
+                                </Authorization>
+                              </Column>
+                              <Column small={6}>
+                                <Authorization
+                                  allow={isFieldAllowedToRead(
+                                    invoiceAttributes,
+                                    InvoicePaymentsFieldPaths.PAID_DATE,
+                                  )}
+                                >
+                                  <FormTextTitle
+                                    enableUiDataEdit
+                                    relativeTo={relativeTo}
+                                    uiDataKey={getUiDataInvoiceKey(
+                                      InvoicePaymentsFieldPaths.PAID_DATE,
+                                    )}
+                                  >
+                                    {InvoicePaymentsFieldTitles.PAID_DATE}
+                                  </FormTextTitle>
+                                </Authorization>
+                              </Column>
+                            </Row>
+                            {payments.map((payment) => (
+                              <Row key={payment.id}>
+                                <Column small={6}>
+                                  <Authorization
+                                    allow={isFieldAllowedToRead(
+                                      invoiceAttributes,
+                                      InvoicePaymentsFieldPaths.PAID_AMOUNT,
+                                    )}
+                                  >
+                                    <ListItem>
+                                      {payment.paid_amount ? (
+                                        <AmountWithVat
+                                          amount={payment.paid_amount}
+                                          date={invoice.due_date}
+                                        />
+                                      ) : (
+                                        "-"
+                                      )}
+                                    </ListItem>
+                                  </Authorization>
+                                </Column>
+                                <Column small={6}>
+                                  <Authorization
+                                    allow={isFieldAllowedToRead(
+                                      invoiceAttributes,
+                                      InvoicePaymentsFieldPaths.PAID_DATE,
+                                    )}
+                                  >
+                                    <ListItem>
+                                      {formatDate(payment.paid_date) || "-"}
+                                    </ListItem>
+                                  </Authorization>
+                                </Column>
+                              </Row>
+                            ))}
+                          </ListItems>
+                        )}
+                      </>
+                    )}
                   </Authorization>
                 </Column>
                 <Column small={6} medium={4}>
@@ -1014,21 +1097,34 @@ const EditInvoiceForm: React.FC<Props> = ({
                   InvoiceFieldPaths.NOTES,
                 )}
               >
-                <FormField
-                  disableTouched={isEditClicked}
-                  fieldAttributes={getFieldAttributes(
-                    invoiceAttributes,
-                    InvoiceFieldPaths.NOTES,
-                  )}
-                  name="notes"
-                  overrideValues={{
-                    label: InvoiceFieldTitles.NOTES,
-                    fieldType: FieldTypes.TEXTAREA,
-                  }}
-                  enableUiDataEdit
-                  relativeTo={relativeTo}
-                  uiDataKey={getUiDataInvoiceKey(InvoiceFieldPaths.NOTES)}
-                />
+                {isEditable(InvoiceFieldPaths.NOTES) ? (
+                  <FormField
+                    disableTouched={isEditClicked}
+                    fieldAttributes={getFieldAttributes(
+                      invoiceAttributes,
+                      InvoiceFieldPaths.NOTES,
+                    )}
+                    name="notes"
+                    overrideValues={{
+                      label: InvoiceFieldTitles.NOTES,
+                      fieldType: FieldTypes.TEXTAREA,
+                    }}
+                    enableUiDataEdit
+                    relativeTo={relativeTo}
+                    uiDataKey={getUiDataInvoiceKey(InvoiceFieldPaths.NOTES)}
+                  />
+                ) : (
+                  <>
+                    <FormTextTitle
+                      enableUiDataEdit
+                      relativeTo={relativeTo}
+                      uiDataKey={getUiDataInvoiceKey(InvoiceFieldPaths.NOTES)}
+                    >
+                      {InvoiceFieldTitles.NOTES}
+                    </FormTextTitle>
+                    <FormText>{invoice?.notes || "-"}</FormText>
+                  </>
+                )}
               </Authorization>
             </Column>
           </Row>

--- a/src/leases/components/leaseSections/invoice/forms/EditInvoiceForm.tsx
+++ b/src/leases/components/leaseSections/invoice/forms/EditInvoiceForm.tsx
@@ -13,8 +13,6 @@ import { Form } from "react-final-form";
 import { FormApi } from "final-form";
 import FormTextTitle from "@/components/form/FormTextTitle";
 import InvoiceRowsEdit from "./InvoiceRowsEdit";
-import ListItem from "@/components/content/ListItem";
-import ListItems from "@/components/content/ListItems";
 import RemoveButton from "@/components/form/RemoveButton";
 import SendupButton from "@/components/button/SendupButton";
 import SubTitle from "@/components/content/SubTitle";
@@ -59,6 +57,7 @@ import { getUsersPermissions } from "@/usersPermissions/selectors";
 import type { Attributes } from "types";
 import type { Lease } from "@/leases/types";
 import type { UsersPermissions as UsersPermissionsType } from "@/usersPermissions/types";
+import { PaymentsReadOnly } from "../InvoiceTemplate";
 type PaymentsProps = {
   fields: any;
   relativeTo: any;
@@ -221,11 +220,13 @@ const Payments = ({ fields, relativeTo }: PaymentsProps): ReactElement => {
   );
 };
 
-const INVOICE_STATE_EDITABLE_FIELDS: Record<string, Set<string> | null> = {
-  sentToSap: new Set([InvoiceFieldPaths.POSTPONE_DATE]),
-  creditNote: new Set([InvoiceFieldPaths.NOTES]),
-  generated: new Set(),
-  manual: null,
+const PAYMENTS = "payments";
+
+const INVOICE_STATE_EDITABLE_FIELDS: Record<string, Array<string>> = {
+  sentToSap: [InvoiceFieldPaths.POSTPONE_DATE],
+  creditNote: [InvoiceFieldPaths.NOTES],
+  generated: [PAYMENTS],
+  manual: [...Object.values(InvoiceFieldPaths), PAYMENTS],
 };
 
 type Props = {
@@ -268,11 +269,8 @@ const EditInvoiceForm: React.FC<Props> = ({
 
   const editableFieldsSet = INVOICE_STATE_EDITABLE_FIELDS[invoiceStateKey];
 
-  const paymentsEditable =
-    invoiceStateKey === "manual" || invoiceStateKey === "generated";
-
   const isEditable = (fieldPath: string) =>
-    editableFieldsSet === null || editableFieldsSet.has(fieldPath);
+    editableFieldsSet.includes(fieldPath);
 
   const handleCreditedInvoiceClick = () => {
     if (invoice) {
@@ -753,7 +751,7 @@ const EditInvoiceForm: React.FC<Props> = ({
                       InvoicePaymentsFieldPaths.PAYMENTS,
                     )}
                   >
-                    {paymentsEditable ? (
+                    {isEditable(PAYMENTS) ? (
                       <FieldArray name="payments">
                         {(fieldArrayProps) =>
                           Payments({
@@ -763,86 +761,12 @@ const EditInvoiceForm: React.FC<Props> = ({
                         }
                       </FieldArray>
                     ) : (
-                      <>
-                        {!payments.length && <FormText>Ei maksuja</FormText>}
-                        {!!payments.length && (
-                          <ListItems>
-                            <Row>
-                              <Column small={6}>
-                                <Authorization
-                                  allow={isFieldAllowedToRead(
-                                    invoiceAttributes,
-                                    InvoicePaymentsFieldPaths.PAID_AMOUNT,
-                                  )}
-                                >
-                                  <FormTextTitle
-                                    enableUiDataEdit
-                                    relativeTo={relativeTo}
-                                    uiDataKey={getUiDataInvoiceKey(
-                                      InvoicePaymentsFieldPaths.PAID_AMOUNT,
-                                    )}
-                                  >
-                                    {InvoicePaymentsFieldTitles.PAID_AMOUNT}
-                                  </FormTextTitle>
-                                </Authorization>
-                              </Column>
-                              <Column small={6}>
-                                <Authorization
-                                  allow={isFieldAllowedToRead(
-                                    invoiceAttributes,
-                                    InvoicePaymentsFieldPaths.PAID_DATE,
-                                  )}
-                                >
-                                  <FormTextTitle
-                                    enableUiDataEdit
-                                    relativeTo={relativeTo}
-                                    uiDataKey={getUiDataInvoiceKey(
-                                      InvoicePaymentsFieldPaths.PAID_DATE,
-                                    )}
-                                  >
-                                    {InvoicePaymentsFieldTitles.PAID_DATE}
-                                  </FormTextTitle>
-                                </Authorization>
-                              </Column>
-                            </Row>
-                            {payments.map((payment) => (
-                              <Row key={payment.id}>
-                                <Column small={6}>
-                                  <Authorization
-                                    allow={isFieldAllowedToRead(
-                                      invoiceAttributes,
-                                      InvoicePaymentsFieldPaths.PAID_AMOUNT,
-                                    )}
-                                  >
-                                    <ListItem>
-                                      {payment.paid_amount ? (
-                                        <AmountWithVat
-                                          amount={payment.paid_amount}
-                                          date={invoice.due_date}
-                                        />
-                                      ) : (
-                                        "-"
-                                      )}
-                                    </ListItem>
-                                  </Authorization>
-                                </Column>
-                                <Column small={6}>
-                                  <Authorization
-                                    allow={isFieldAllowedToRead(
-                                      invoiceAttributes,
-                                      InvoicePaymentsFieldPaths.PAID_DATE,
-                                    )}
-                                  >
-                                    <ListItem>
-                                      {formatDate(payment.paid_date) || "-"}
-                                    </ListItem>
-                                  </Authorization>
-                                </Column>
-                              </Row>
-                            ))}
-                          </ListItems>
-                        )}
-                      </>
+                      <PaymentsReadOnly
+                        payments={payments}
+                        invoiceAttributes={invoiceAttributes}
+                        invoice={invoice}
+                        relativeTo={relativeTo}
+                      />
                     )}
                   </Authorization>
                 </Column>

--- a/src/leases/saga.ts
+++ b/src/leases/saga.ts
@@ -440,6 +440,17 @@ function* patchLeaseInvoiceNotesSaga({
         );
         break;
 
+      case 403:
+        yield put(notFound());
+        yield put(
+          receiveError(
+            new SubmissionError({
+              ...bodyAsJson,
+            }),
+          ),
+        );
+        break;
+
       case 400:
         yield put(notFound());
         yield put(


### PR DESCRIPTION
-Added logic for new API errors in invoice sagas
-Made invoicing page to be read only for users in other service units.
-Fixed invoice panel validation state not updating
-Made EditInvoiceForm UI fields match API logic for updating (invoice.py InvoiceViewSet get_serializer_class)
-Fixed invoice panel rows overflowing incorrectly
-Fixed crash caused by having 0 invoice rows