### PR TITLE
fix chicken-egg problem with plotsearch subtype by removing (parent)t…

### DIFF
--- a/src/components/attributes/PlotSearchAttributes.tsx
+++ b/src/components/attributes/PlotSearchAttributes.tsx
@@ -17,6 +17,7 @@ import {
   getIsFetchingFormAttributes,
 } from "@/application/selectors";
 import { fetchFormAttributes } from "@/application/actions";
+import type { PlotSearchSubType } from "@/plotSearch/types";
 import type { Attributes, Methods } from "types";
 
 function PlotSearchAttributes(WrappedComponent: any) {
@@ -30,7 +31,7 @@ function PlotSearchAttributes(WrappedComponent: any) {
     isFetchingFormAttributes: boolean;
     plotSearchAttributes: Attributes;
     plotSearchMethods: Methods;
-    plotSearchSubTypes: Record<string, any>;
+    plotSearchSubTypes: Array<PlotSearchSubType>;
   };
   return class PlotSearchAttributes extends PureComponent<Props> {
     componentDidMount() {
@@ -47,7 +48,7 @@ function PlotSearchAttributes(WrappedComponent: any) {
         fetchPlotSearchAttributes();
       }
 
-      if (!isFetching && !plotSearchSubTypes) {
+      if (!isFetching && (!plotSearchSubTypes || !plotSearchSubTypes.length)) {
         fetchPlotSearchSubtypes();
       }
     }

--- a/src/plotApplications/actions.ts
+++ b/src/plotApplications/actions.ts
@@ -117,7 +117,7 @@ export const plotSearchSubtypesNotFound =
   (): PlotSearchSubtypesNotFoundAction =>
     createAction("mvj/plotApplications/PLOT_SEARCH_SUB_TYPES_NOT_FOUND")();
 export const receivePlotSearchSubtypes = (
-  subTypes: Record<string, any>,
+  subTypes: ReceivePlotSearchSubtypesAction["payload"],
 ): ReceivePlotSearchSubtypesAction =>
   createAction("mvj/plotApplications/RECEIVE_PLOT_SEARCH_SUB_TYPES")(subTypes);
 export const receivePlotApplicationSaved = (

--- a/src/plotApplications/components/PlotApplicationsListPage.tsx
+++ b/src/plotApplications/components/PlotApplicationsListPage.tsx
@@ -61,6 +61,7 @@ import {
 import ApplicationListMap from "@/plotApplications/components/map/ApplicationListMap";
 import { getPlotApplicationsListByBBox } from "@/plotApplications/selectors";
 import PlotApplicationsListOpeningModal from "@/plotApplications/components/PlotApplicationsListOpeningModal";
+import type { PlotSearchSubType } from "@/plotSearch/types";
 const VisualizationTypes = {
   MAP: "map",
   TABLE: "table",
@@ -92,7 +93,7 @@ type Props = {
   plotApplicationsListData: Record<string, any>;
   plotApplicationsMapData: Record<string, any>;
   initialize: (...args: Array<any>) => any;
-  plotSearchSubtypes: Record<string, any>;
+  plotSearchSubtypes: Array<PlotSearchSubType>;
 };
 type State = {
   activePage: number;

--- a/src/plotApplications/plotApplications.spec.ts
+++ b/src/plotApplications/plotApplications.spec.ts
@@ -33,7 +33,7 @@ const baseState: PlotApplicationsState = {
   isFormValidById: {
     "plot-application": true,
   },
-  subTypes: null,
+  subTypes: [],
   plotSearch: null,
   isFetchingTargetInfoCheckAttributes: false,
   targetInfoCheckAttributes: null,

--- a/src/plotApplications/reducer.ts
+++ b/src/plotApplications/reducer.ts
@@ -130,17 +130,18 @@ const isFormValidByIdReducer: Reducer<Record<string, any>> = handleActions(
     [FormNames.PLOT_APPLICATION]: true,
   },
 );
-const subTypesReducer: Reducer<Record<string, any>> = handleActions(
-  {
-    ["mvj/plotApplications/RECEIVE_PLOT_SEARCH_SUB_TYPES"]: (
-      state: Record<string, any>,
-      { payload: subTypes }: ReceivePlotSearchSubtypesAction,
-    ) => {
-      return subTypes;
+const subTypesReducer: Reducer<PlotApplicationsState["subTypes"]> =
+  handleActions(
+    {
+      ["mvj/plotApplications/RECEIVE_PLOT_SEARCH_SUB_TYPES"]: (
+        _state: PlotApplicationsState["subTypes"],
+        { payload: subTypes }: ReceivePlotSearchSubtypesAction,
+      ) => {
+        return subTypes;
+      },
     },
-  },
-  null,
-);
+    [],
+  );
 const isFetchingSubTypesReducer: Reducer<boolean> = handleActions(
   {
     ["mvj/plotApplications/FETCH_PLOT_SEARCH_SUB_TYPES"]: () => true,

--- a/src/plotApplications/selectors.ts
+++ b/src/plotApplications/selectors.ts
@@ -7,7 +7,7 @@ import type {
   PlotApplication,
   PlotApplicationsList,
 } from "@/plotApplications/types";
-import type { PlotSearch } from "@/plotSearch/types";
+import type { PlotSearch, PlotSearchSubType } from "@/plotSearch/types";
 export const getApplicationsByBBox: Selector<PlotApplicationsList, void> = (
   state: RootState,
 ): PlotApplicationsList => state.plotApplications.listByBBox;
@@ -65,9 +65,9 @@ export const getErrorsByFormName: Selector<
 
   return null;
 };
-export const getPlotSearchSubTypes: Selector<Record<string, any>, void> = (
+export const getPlotSearchSubTypes: Selector<Array<PlotSearchSubType>, void> = (
   state: RootState,
-): Record<string, any> => state.plotApplications.subTypes;
+): Array<PlotSearchSubType> => state.plotApplications.subTypes || [];
 export const getIsFetchingApplicationRelatedForm: Selector<boolean, void> = (
   state: RootState,
 ): boolean => state.plotApplications.isFetchingForm;

--- a/src/plotApplications/types.ts
+++ b/src/plotApplications/types.ts
@@ -1,5 +1,5 @@
 import type { Action, Attributes } from "types";
-import type { PlotSearch } from "@/plotSearch/types";
+import type { PlotSearch, PlotSearchSubType } from "@/plotSearch/types";
 import type { ApplicationFormSection } from "@/application/types";
 export type PlotApplicationsState = {
   isFetching: boolean;
@@ -11,7 +11,7 @@ export type PlotApplicationsState = {
   isSaving: boolean;
   collapseStates: Record<string, any>;
   isFormValidById: Record<string, any>;
-  subTypes: Array<Record<string, any>> | null | undefined;
+  subTypes: Array<PlotSearchSubType>;
   isFetchingSubTypes: boolean;
   isPerformingFileOperation: boolean;
   currentEditorTargets: Array<Record<string, any>>;
@@ -69,7 +69,7 @@ export type ReceivePlotApplicationSaveFailedAction = Action<string, void>;
 export type FetchPlotSearchSubtypesAction = Action<string, void>;
 export type ReceivePlotSearchSubtypesAction = Action<
   string,
-  Record<string, any>
+  Array<PlotSearchSubType>
 >;
 export type PlotSearchSubtypesNotFoundAction = Action<string, void>;
 export type FetchApplicationRelatedFormAction = Action<string, void>;

--- a/src/plotSearch/actions.ts
+++ b/src/plotSearch/actions.ts
@@ -183,7 +183,7 @@ export const plotSearchSubtypesNotFound =
   (): PlotSearchSubtypesNotFoundAction =>
     createAction("mvj/plotSearch/PLOT_SEARCH_SUB_TYPES_NOT_FOUND")();
 export const receivePlotSearchSubtype = (
-  subTypes: Record<string, any>,
+  subTypes: ReceivePlotSearchSubtypesAction["payload"],
 ): ReceivePlotSearchSubtypesAction =>
   createAction("mvj/plotSearch/RECEIVE_PLOT_SEARCH_SUB_TYPES")(subTypes);
 export const nullPlanUnits = (): NullPlanUnitsAction =>

--- a/src/plotSearch/components/plotSearchSections/basicInfo/BasicInfoEdit.tsx
+++ b/src/plotSearch/components/plotSearchSections/basicInfo/BasicInfoEdit.tsx
@@ -49,7 +49,6 @@ import {
   getPlotSearchSubTypes,
   getDecisionCandidates,
 } from "@/plotSearch/selectors";
-import { filterSubTypes } from "@/plotSearch/helpers";
 import PlotSearchSiteEdit from "@/plotSearch/components/plotSearchSections/basicInfo/PlotSearchSiteEdit";
 import type { Attributes } from "types";
 import { hasMinimumRequiredFieldsFilled } from "@/plotSearch/helpers";
@@ -64,6 +63,8 @@ import PlotSearchTargetListing from "@/plotSearch/components/plotSearchSections/
 import { AUTOMATIC_PLOT_SEARCH_STAGES } from "@/plotSearch/constants";
 import { PlotSearchStageTypes } from "@/plotSearch/enums";
 import PlotSearchApplicationsOpeningSection from "@/plotSearch/components/plotSearchSections/basicInfo/PlotSearchApplicationsOpeningSection";
+import type { PlotSearchSubType } from "@/plotSearch/types";
+
 type DecisionsProps = {
   attributes: Attributes;
   disabled: boolean;
@@ -295,8 +296,7 @@ type Props = {
   errors: Record<string, any> | null | undefined;
   formName: string;
   isSaveClicked: boolean;
-  plotSearchSubTypes: Record<string, any>;
-  type: string;
+  plotSearchSubTypes: Array<PlotSearchSubType>;
   receiveFormValidFlags: (...args: Array<any>) => any;
   valid: boolean;
   hasMinimumRequiredFieldsFilled: boolean;
@@ -409,7 +409,6 @@ class BasicInfoEdit extends PureComponent<Props, State> {
       attributes,
       errors,
       plotSearchSubTypes,
-      type,
       decisionCandidates,
       selectedDecisions,
       hasMinimumRequiredFieldsFilled,
@@ -418,7 +417,12 @@ class BasicInfoEdit extends PureComponent<Props, State> {
       isLockedForModifications,
       stages,
     } = this.props;
-    const subTypeOptions = filterSubTypes(plotSearchSubTypes, type);
+
+    const subTypeOptions = plotSearchSubTypes.map((subType) => ({
+      value: subType.id,
+      label: `${subType.name}: ${subType.plot_search_type.name}`,
+    }));
+
     const hasUnidentifiedDecisions = selectedDecisions.some(
       (decision) => decision?.id && !decision?.relatedPlanUnitId,
     );

--- a/src/plotSearch/helpers.ts
+++ b/src/plotSearch/helpers.ts
@@ -195,26 +195,6 @@ export const cleanDecisions = (
   };
 };
 
-/**
- * filter Sub Types
- * @param {Object} subTypes
- * @param {string} type
- * @returns {Object}
- */
-export const filterSubTypes = (
-  subTypes: Record<string, any>,
-  type: string,
-): Record<string, any> => {
-  if (isEmpty(subTypes)) return [];
-  const filteredSubTypes = subTypes.filter(
-    (subType) => subType.plot_search_type.id === type,
-  );
-  const subTypesAsOptions = filteredSubTypes.map((subType) => ({
-    value: subType.id,
-    label: subType.name,
-  }));
-  return subTypesAsOptions;
-};
 export const hasMinimumRequiredFieldsFilled = (
   state: PlotSearchState,
 ): boolean => {

--- a/src/plotSearch/plotSearch.spec.ts
+++ b/src/plotSearch/plotSearch.spec.ts
@@ -66,7 +66,7 @@ const baseState: PlotSearchState = {
   isFetchingPlanUnitAttributes: false,
   pendingCustomDetailedPlanFetches: [],
   isFetchingCustomDetailedPlanAttributes: false,
-  subTypes: null,
+  subTypes: [],
   isFetchingForm: false,
   isFetchingTemplateForms: false,
   form: null,

--- a/src/plotSearch/reducer.ts
+++ b/src/plotSearch/reducer.ts
@@ -10,6 +10,7 @@ import type {
   PlotSearch,
   PlotSearchList,
   PlotSearchState,
+  PlotSearchSubType,
   ReceiveAttributesAction,
   ReceiveCollapseStatesAction,
   ReceiveFormAction,
@@ -255,16 +256,16 @@ const isFormValidByIdReducer: Reducer<Record<string, any>> = handleActions(
     [FormNames.PLOT_SEARCH_APPLICATION]: true,
   },
 );
-const subTypesReducer: Reducer<Record<string, any>> = handleActions(
+const subTypesReducer: Reducer<Array<PlotSearchSubType>> = handleActions(
   {
     ["mvj/plotSearch/RECEIVE_PLOT_SEARCH_SUB_TYPES"]: (
-      state: Record<string, any>,
+      _state: Array<PlotSearchSubType>,
       { payload: subTypes }: ReceivePlotSearchSubtypesAction,
     ) => {
       return subTypes;
     },
   },
-  null,
+  [],
 );
 const isFetchingTemplateFormsReducer: Reducer<boolean> = handleActions(
   {
@@ -445,7 +446,7 @@ const isFetchingRelatedApplicationsReducer: Reducer<boolean> = handleActions(
   },
   false,
 );
-export default combineReducers<Record<string, any>, any>({
+export default combineReducers<PlotSearchState, any>({
   attributes: attributesReducer,
   collapseStates: collapseStatesReducer,
   current: currentPlotSearchReducer,
@@ -484,4 +485,4 @@ export default combineReducers<Record<string, any>, any>({
   sectionEditorCollapseStates: sectionEditorCollapseStatesReducer,
   relatedApplications: relatedApplicationsReducer,
   isFetchingRelatedApplications: isFetchingRelatedApplicationsReducer,
-}) as any;
+});

--- a/src/plotSearch/selectors.ts
+++ b/src/plotSearch/selectors.ts
@@ -7,6 +7,7 @@ import type {
   PlanUnit,
   PlotSearch,
   PlotSearchList,
+  PlotSearchSubType,
 } from "@/plotSearch/types";
 import { formValueSelector } from "redux-form";
 import { FormNames } from "@/enums";
@@ -97,9 +98,9 @@ export const getIsFetchingPlanUnitAttributes: Selector<boolean, void> = (
 export const getIsFetchingSubtypes: Selector<boolean, void> = (
   state: RootState,
 ): boolean => state.plotSearch.isFetchingSubtypes;
-export const getPlotSearchSubTypes: Selector<Record<string, any>, void> = (
+export const getPlotSearchSubTypes: Selector<Array<PlotSearchSubType>, void> = (
   state: RootState,
-): Record<string, any> => state.plotSearch.subTypes;
+): Array<PlotSearchSubType> => state.plotSearch.subTypes || [];
 export const getIsFetchingTemplateForms: Selector<boolean, void> = (
   state: RootState,
 ): boolean => state.plotSearch.isFetchingTemplateForms;

--- a/src/plotSearch/types.ts
+++ b/src/plotSearch/types.ts
@@ -119,7 +119,7 @@ export type ReceiveCustomDetailedPlanAttributesAction = Action<
 export type FetchPlotSearchSubtypesAction = Action<string, void>;
 export type ReceivePlotSearchSubtypesAction = Action<
   string,
-  Record<string, any>
+  Array<PlotSearchSubType>
 >;
 export type PlotSearchSubtypesNotFoundAction = Action<string, void>;
 export type NullPlanUnitsAction = Action<string, void>;

--- a/src/plotSearch/types.ts
+++ b/src/plotSearch/types.ts
@@ -1,4 +1,21 @@
 import type { Action, Attributes, Methods } from "types";
+
+type PlotSearchType = {
+  id: number;
+  name: string;
+  ordering: number;
+};
+
+export type PlotSearchSubType = {
+  id: number;
+  name: string;
+  plot_search_type: PlotSearchType;
+  show_districts: boolean;
+  target_selection: boolean;
+  require_opening_record: boolean;
+  ordering: number;
+};
+
 export type PlotSearchState = {
   attributes: Attributes;
   current: PlotSearch;
@@ -19,7 +36,7 @@ export type PlotSearchState = {
   pendingPlanUnitFetches: Array<number>;
   isFetchingPlanUnitAttributes: boolean;
   isFetchingSubtypes: boolean;
-  subTypes: Record<string, any>;
+  subTypes: Array<PlotSearchSubType>;
   isFetchingForm: boolean;
   isFetchingTemplateForms: boolean;
   form: Record<string, any>;


### PR DESCRIPTION
…ype filter

- this blocked creating new plotsearches and setting forms on them
- subtype list was being filtered by type, but since type is not defined on plotsearch it is only set by subtype. this leads to the issue that no subtypes can be returned until a subtype is selected, because otherwise there is no `type` set to filter with.
- allows not selecting a subtype that shows its (parent)type in the select, since there is no other way to set a (parent)type