### PR TITLE
Mvj 1192 lease area plan units changes

### DIFF
--- a/src/leases/components/LeasePage.tsx
+++ b/src/leases/components/LeasePage.tsx
@@ -909,11 +909,8 @@ const LeasePage: React.FC<Props> = (props) => {
       removeSessionStorageItem(FormNames.LEASE_INSPECTIONS);
     }
 
-    if (leaseAreasFormState.dirty) {
-      setSessionStorageItem(
-        FormNames.LEASE_AREAS,
-        leaseAreasFormRef.current.getState().values,
-      );
+    if (leaseAreasFormRef.current.getState().dirty) {
+      setSessionStorageItem(FormNames.LEASE_AREAS, areasFormValues);
       isDirty = true;
     } else {
       removeSessionStorageItem(FormNames.LEASE_AREAS);

--- a/src/leases/components/leaseSections/leaseArea/LeaseAreaEdit.tsx
+++ b/src/leases/components/leaseSections/leaseArea/LeaseAreaEdit.tsx
@@ -142,7 +142,6 @@ const PlanUnits = ({
 
                   return (
                     <PlanUnitItemEdit
-                      formApi={formApi}
                       key={index}
                       field={planunit}
                       onRemove={handleRemove}

--- a/src/leases/components/leaseSections/leaseArea/LeaseAreaEdit.tsx
+++ b/src/leases/components/leaseSections/leaseArea/LeaseAreaEdit.tsx
@@ -13,6 +13,7 @@ import Collapse from "@/components/collapse/Collapse";
 import FieldAndRemoveButtonWrapper from "@/components/form/FieldAndRemoveButtonWrapper";
 import FormText from "@/components/form/FormText";
 import FormTextTitle from "@/components/form/FormTextTitle";
+import PlanUnitItem from "./PlanUnitItem";
 import PlanUnitItemEdit from "./PlanUnitItemEdit";
 import PlotItemEdit from "./PlotItemEdit";
 import RemoveButton from "@/components/form/RemoveButton";
@@ -61,7 +62,6 @@ import { useField } from "react-final-form";
 import { FormApi } from "final-form";
 
 type PlanUnitsProps = {
-  formApi: FormApi;
   buttonTitle: string;
   collapseState: boolean;
   errors: Record<string, any>;
@@ -70,12 +70,14 @@ type PlanUnitsProps = {
   onCollapseToggle: (...args: Array<any>) => any;
   title: string;
   uiDataKey: string;
+  areas: Record<string, any>;
+  isMasterData: boolean;
+  isActive: boolean;
 };
 
 const formName = FormNames.LEASE_AREAS;
 
 const PlanUnits = ({
-  formApi,
   buttonTitle,
   collapseState,
   errors,
@@ -85,6 +87,9 @@ const PlanUnits = ({
   onCollapseToggle,
   title,
   uiDataKey,
+  areas,
+  isMasterData,
+  isActive,
 }: PlanUnitsProps): ReactElement => {
   const attributes: Attributes = useSelector(getAttributes);
   const isSaveClicked: boolean = useSelector(getIsSaveClicked);
@@ -139,34 +144,44 @@ const PlanUnits = ({
                         ConfirmationModalTexts.DELETE_PLAN_UNIT.TITLE,
                     });
                   };
-
-                  return (
-                    <PlanUnitItemEdit
-                      key={index}
-                      field={planunit}
-                      onRemove={handleRemove}
-                    />
-                  );
+                  if (isMasterData) {
+                    return (
+                      <PlanUnitItem
+                        key={index}
+                        planUnit={areas[index]}
+                        areaArchived={!isActive}
+                      />
+                    );
+                  } else {
+                    return (
+                      <PlanUnitItemEdit
+                        key={index}
+                        field={planunit}
+                        onRemove={handleRemove}
+                      />
+                    );
+                  }
                 })}
               </BoxItemContainer>
             )}
-
-            <Authorization
-              allow={hasPermissions(
-                usersPermissions,
-                UsersPermissions.ADD_PLANUNIT,
-              )}
-            >
-              <Row>
-                <Column>
-                  <AddButtonSecondary
-                    className={!fields.length ? "no-top-margin" : ""}
-                    label={buttonTitle}
-                    onClick={handleAdd}
-                  />
-                </Column>
-              </Row>
-            </Authorization>
+            {!isMasterData && (
+              <Authorization
+                allow={hasPermissions(
+                  usersPermissions,
+                  UsersPermissions.ADD_PLANUNIT,
+                )}
+              >
+                <Row>
+                  <Column>
+                    <AddButtonSecondary
+                      className={!fields.length ? "no-top-margin" : ""}
+                      label={buttonTitle}
+                      onClick={handleAdd}
+                    />
+                  </Column>
+                </Row>
+              </Authorization>
+            )}
           </Collapse>
         );
       }}
@@ -585,6 +600,7 @@ type Props = {
   index: number;
   savedArea: Record<string, any>;
   areaId: number;
+  isActive: boolean;
 };
 
 const LeaseAreaEdit: React.FC<Props> = ({
@@ -593,6 +609,7 @@ const LeaseAreaEdit: React.FC<Props> = ({
   index,
   field,
   savedArea,
+  isActive,
 }) => {
   const dispatch = useDispatch();
 
@@ -864,7 +881,6 @@ const LeaseAreaEdit: React.FC<Props> = ({
               {(fieldArrayProps) =>
                 PlanUnits({
                   ...fieldArrayProps,
-                  formApi,
                   buttonTitle: "Lisää kaavayksikkö",
                   collapseState: planUnitsContractCollapseState,
                   errors: { errors },
@@ -874,6 +890,9 @@ const LeaseAreaEdit: React.FC<Props> = ({
                   uiDataKey: getUiDataLeaseKey(
                     LeasePlanUnitsFieldPaths.PLAN_UNITS_CONTRACT,
                   ),
+                  isMasterData: false,
+                  areas: savedArea.plan_units_contract,
+                  isActive,
                 })
               }
             </FieldArray>
@@ -883,7 +902,6 @@ const LeaseAreaEdit: React.FC<Props> = ({
               {(fieldArrayProps) =>
                 PlanUnits({
                   ...fieldArrayProps,
-                  formApi,
                   buttonTitle: "Lisää kaavayksikkö",
                   collapseState: planUnitsCurrentCollapseState,
                   errors: { errors },
@@ -893,6 +911,9 @@ const LeaseAreaEdit: React.FC<Props> = ({
                   uiDataKey: getUiDataLeaseKey(
                     LeasePlanUnitsFieldPaths.PLAN_UNITS,
                   ),
+                  isMasterData: true,
+                  areas: savedArea.plan_units_current,
+                  isActive,
                 })
               }
             </FieldArray>
@@ -903,7 +924,6 @@ const LeaseAreaEdit: React.FC<Props> = ({
               {(fieldArrayProps) =>
                 PlanUnits({
                   ...fieldArrayProps,
-                  formApi,
                   buttonTitle: "Vireillä olevat kaavayksiköt",
                   collapseState: planUnitsCurrentCollapseState,
                   errors: { errors },
@@ -911,6 +931,9 @@ const LeaseAreaEdit: React.FC<Props> = ({
                   onCollapseToggle: handlePlanUnitCurrentCollapseToggle,
                   title: "Vireillä olevat kaavayksiköt",
                   uiDataKey: null, // No uiDataKey
+                  isMasterData: true,
+                  areas: savedArea.plan_units_pending,
+                  isActive,
                 })
               }
             </FieldArray>

--- a/src/leases/components/leaseSections/leaseArea/LeaseAreaWithArchiveInfoEdit.tsx
+++ b/src/leases/components/leaseSections/leaseArea/LeaseAreaWithArchiveInfoEdit.tsx
@@ -236,6 +236,7 @@ const LeaseAreaWithArchiveInfoEdit = ({
           index={index}
           areaId={areaId}
           savedArea={savedArea}
+          isActive={isActive}
         />
       )}
 

--- a/src/leases/components/leaseSections/leaseArea/LeaseAreasEdit.tsx
+++ b/src/leases/components/leaseSections/leaseArea/LeaseAreasEdit.tsx
@@ -1,4 +1,11 @@
-import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { FieldArray } from "react-final-form-arrays";
 import { Row, Column } from "react-foundation";
@@ -187,6 +194,8 @@ const LeaseAreasEdit: React.FC<Props> = ({ formApi }) => {
     };
   }, [currentLease]);
 
+  const isFirstRender = useRef(true);
+
   useEffect(() => {
     const addContractItemsToArea = (area: Record<string, any>) => {
       const savedArea = getLeaseAreaById(currentLease, area.id);
@@ -201,6 +210,11 @@ const LeaseAreasEdit: React.FC<Props> = ({ formApi }) => {
 
       return { ...area, plan_units_contract: [], plots_contract: [] };
     };
+
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
 
     if (formApi.getFieldState(ATTR_LEASE_AREAS_ACTIVE)?.value) {
       formApi.change(

--- a/src/leases/components/leaseSections/leaseArea/PlanUnitItem.tsx
+++ b/src/leases/components/leaseSections/leaseArea/PlanUnitItem.tsx
@@ -89,25 +89,7 @@ const PlanUnitItem: React.FC<OwnProps> = ({ areaArchived, planUnit }) => {
             </>
           </Authorization>
         </Column>
-        <Column small={12} medium={2} large={2}>
-          <Authorization
-            allow={isFieldAllowedToRead(
-              attributes,
-              LeasePlanUnitsFieldPaths.IS_MASTER,
-            )}
-          >
-            <>
-              <FormTextTitle
-                uiDataKey={getUiDataLeaseKey(
-                  LeasePlanUnitsFieldPaths.IS_MASTER,
-                )}
-              >
-                {LeasePlanUnitsFieldTitles.IS_MASTER}
-              </FormTextTitle>
-              <FormText>{planUnit.is_master ? "Kyllä" : "Ei"}</FormText>
-            </>
-          </Authorization>
-        </Column>
+
         <Column small={12} medium={3} large={3}>
           <Authorization
             allow={isFieldAllowedToRead(

--- a/src/leases/components/leaseSections/leaseArea/PlanUnitItemEdit.tsx
+++ b/src/leases/components/leaseSections/leaseArea/PlanUnitItemEdit.tsx
@@ -38,7 +38,6 @@ const PlanUnitItemEdit: React.FC<Props> = ({ field, onRemove }) => {
   const isSaveClicked: boolean = useSelector(getIsSaveClicked);
   const usersPermissions: UsersPermissionsType =
     useSelector(getUsersPermissions);
-  const form = useForm();
   const location = useLocation();
 
   const {
@@ -101,115 +100,6 @@ const PlanUnitItemEdit: React.FC<Props> = ({ field, onRemove }) => {
     input: { value: is_master },
   } = useField(`${field}.is_master`, { subscription: { value: true } });
 
-  // Snapshot of values
-  const initialValuesRef = useRef({
-    identifier,
-    area,
-    section_area,
-    detailed_plan_identifier,
-    detailed_plan_latest_processing_date,
-    detailed_plan_latest_processing_date_note,
-    plot_division_identifier,
-    plot_division_state,
-    plot_division_effective_date,
-    plan_unit_type,
-    plan_unit_state,
-    plan_unit_intended_use,
-    is_master,
-  });
-
-  const prevValuesRef = useRef({
-    identifier,
-    area,
-    section_area,
-    detailed_plan_identifier,
-    detailed_plan_latest_processing_date,
-    detailed_plan_latest_processing_date_note,
-    plot_division_identifier,
-    plot_division_state,
-    plot_division_effective_date,
-    plan_unit_type,
-    plan_unit_state,
-    plan_unit_intended_use,
-  });
-
-  const isFirstRenderRef = useRef(true);
-
-  useEffect(() => {
-    const initial = initialValuesRef.current;
-    const prev = prevValuesRef.current;
-    const currentValues = {
-      identifier,
-      area,
-      section_area,
-      detailed_plan_identifier,
-      detailed_plan_latest_processing_date,
-      detailed_plan_latest_processing_date_note,
-      plot_division_identifier,
-      plot_division_state,
-      plot_division_effective_date,
-      plan_unit_type,
-      plan_unit_state,
-      plan_unit_intended_use,
-    };
-
-    if (isFirstRenderRef.current) {
-      isFirstRenderRef.current = false;
-      return;
-    }
-
-    if (initial.is_master) {
-      prevValuesRef.current = currentValues;
-      return;
-    }
-
-    if (
-      initial.identifier == identifier &&
-      initial.area == area &&
-      initial.section_area == section_area &&
-      initial.detailed_plan_identifier == detailed_plan_identifier &&
-      initial.detailed_plan_latest_processing_date ==
-        detailed_plan_latest_processing_date &&
-      initial.detailed_plan_latest_processing_date_note ==
-        detailed_plan_latest_processing_date_note &&
-      initial.plot_division_identifier == plot_division_identifier &&
-      initial.plot_division_state == plot_division_state &&
-      initial.plot_division_effective_date == plot_division_effective_date &&
-      initial.plan_unit_type == plan_unit_type &&
-      initial.plan_unit_state == plan_unit_state &&
-      initial.plan_unit_intended_use == plan_unit_intended_use
-    ) {
-      form.change(`${field}.is_master`, false);
-      prevValuesRef.current = currentValues;
-      return;
-    }
-
-    if (is_master) {
-      prevValuesRef.current = currentValues;
-      return;
-    }
-
-    if (
-      prev.identifier != identifier ||
-      prev.area != area ||
-      prev.section_area != section_area ||
-      prev.detailed_plan_identifier != detailed_plan_identifier ||
-      prev.detailed_plan_latest_processing_date !=
-        detailed_plan_latest_processing_date ||
-      prev.detailed_plan_latest_processing_date_note !=
-        detailed_plan_latest_processing_date_note ||
-      prev.plot_division_identifier != plot_division_identifier ||
-      prev.plot_division_state != plot_division_state ||
-      prev.plot_division_effective_date != plot_division_effective_date ||
-      prev.plan_unit_type != plan_unit_type ||
-      prev.plan_unit_state != plan_unit_state ||
-      prev.plan_unit_intended_use != plan_unit_intended_use
-    ) {
-      form.change(`${field}.is_master`, true);
-    }
-    prevValuesRef.current = currentValues;
-  });
-
   const getMapLinkUrl = () => {
     const { pathname, search } = location;
     const searchQuery = getUrlParams(search);
@@ -254,31 +144,6 @@ const PlanUnitItemEdit: React.FC<Props> = ({ field, onRemove }) => {
                 enableUiDataEdit
                 uiDataKey={getUiDataLeaseKey(
                   LeasePlanUnitsFieldPaths.IDENTIFIER,
-                )}
-              />
-            </Authorization>
-          </Column>
-          <Column small={12} medium={2} large={2}>
-            <Authorization
-              allow={isFieldAllowedToRead(
-                attributes,
-                LeasePlanUnitsFieldPaths.IS_MASTER,
-              )}
-            >
-              <FormField
-                disableTouched={isSaveClicked}
-                fieldAttributes={getFieldAttributes(
-                  attributes,
-                  LeasePlanUnitsFieldPaths.IS_MASTER,
-                )}
-                name={`${field}.is_master`}
-                overrideValues={{
-                  label: LeasePlanUnitsFieldTitles.IS_MASTER,
-                  disabled: true,
-                }}
-                enableUiDataEdit
-                uiDataKey={getUiDataLeaseKey(
-                  LeasePlanUnitsFieldPaths.IS_MASTER,
                 )}
               />
             </Authorization>

--- a/src/leases/components/leaseSections/leaseArea/PlanUnitItemEdit.tsx
+++ b/src/leases/components/leaseSections/leaseArea/PlanUnitItemEdit.tsx
@@ -1,8 +1,8 @@
-import React, { useRef, useEffect } from "react";
+import React from "react";
 import { useSelector } from "react-redux";
 import { Row, Column } from "react-foundation";
 import { Link, useLocation } from "react-router-dom";
-import { useField, useForm } from "react-final-form";
+import { useField } from "react-final-form";
 import isEmpty from "lodash/isEmpty";
 import ActionButtonWrapper from "@/components/form/ActionButtonWrapper";
 import Authorization from "@/components/authorization/Authorization";
@@ -46,59 +46,6 @@ const PlanUnitItemEdit: React.FC<Props> = ({ field, onRemove }) => {
   const {
     input: { value: geometry },
   } = useField(`${field}.geometry`, { subscription: { value: true } });
-  const {
-    input: { value: identifier },
-  } = useField(`${field}.identifier`, { subscription: { value: true } });
-  const {
-    input: { value: area },
-  } = useField(`${field}.area`, { subscription: { value: true } });
-  const {
-    input: { value: section_area },
-  } = useField(`${field}.section_area`, { subscription: { value: true } });
-  const {
-    input: { value: detailed_plan_identifier },
-  } = useField(`${field}.detailed_plan_identifier`, {
-    subscription: { value: true },
-  });
-  const {
-    input: { value: detailed_plan_latest_processing_date },
-  } = useField(`${field}.detailed_plan_latest_processing_date`, {
-    subscription: { value: true },
-  });
-  const {
-    input: { value: detailed_plan_latest_processing_date_note },
-  } = useField(`${field}.detailed_plan_latest_processing_date_note`, {
-    subscription: { value: true },
-  });
-  const {
-    input: { value: plot_division_identifier },
-  } = useField(`${field}.plot_division_identifier`, {
-    subscription: { value: true },
-  });
-  const {
-    input: { value: plot_division_state },
-  } = useField(`${field}.plot_division_state`, {
-    subscription: { value: true },
-  });
-  const {
-    input: { value: plot_division_effective_date },
-  } = useField(`${field}.plot_division_effective_date`, {
-    subscription: { value: true },
-  });
-  const {
-    input: { value: plan_unit_type },
-  } = useField(`${field}.plan_unit_type`, { subscription: { value: true } });
-  const {
-    input: { value: plan_unit_state },
-  } = useField(`${field}.plan_unit_state`, { subscription: { value: true } });
-  const {
-    input: { value: plan_unit_intended_use },
-  } = useField(`${field}.plan_unit_intended_use`, {
-    subscription: { value: true },
-  });
-  const {
-    input: { value: is_master },
-  } = useField(`${field}.is_master`, { subscription: { value: true } });
 
   const getMapLinkUrl = () => {
     const { pathname, search } = location;

--- a/src/leases/components/leaseSections/leaseArea/PlanUnitItemEdit.tsx
+++ b/src/leases/components/leaseSections/leaseArea/PlanUnitItemEdit.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useRef } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import React, { useRef, useEffect } from "react";
+import { useSelector } from "react-redux";
 import { Row, Column } from "react-foundation";
 import { Link, useLocation } from "react-router-dom";
+import { useField, useForm } from "react-final-form";
 import isEmpty from "lodash/isEmpty";
 import ActionButtonWrapper from "@/components/form/ActionButtonWrapper";
 import Authorization from "@/components/authorization/Authorization";
@@ -9,7 +10,6 @@ import BoxContentWrapper from "@/components/content/BoxContentWrapper";
 import BoxItem from "@/components/content/BoxItem";
 import FormField from "@/components/form/final-form/FormField";
 import RemoveButton from "@/components/form/RemoveButton";
-import { FormNames } from "@/enums";
 import {
   LeasePlanUnitsFieldPaths,
   LeasePlanUnitsFieldTitles,
@@ -27,62 +27,98 @@ import { getAttributes, getIsSaveClicked } from "@/leases/selectors";
 import { getUsersPermissions } from "@/usersPermissions/selectors";
 import type { Attributes } from "types";
 import type { UsersPermissions as UsersPermissionsType } from "@/usersPermissions/types";
-import { FormApi } from "final-form";
 
 type Props = {
-  formApi: FormApi;
   field: string;
   onRemove: (...args: Array<any>) => any;
 };
 
-const PlanUnitItemEdit: React.FC<Props> = ({
-  formApi,
-  field,
-  onRemove,
-}: Props) => {
-  const dispatch = useDispatch();
-
+const PlanUnitItemEdit: React.FC<Props> = ({ field, onRemove }) => {
   const attributes: Attributes = useSelector(getAttributes);
-  const isSaveClicked = useSelector(getIsSaveClicked);
+  const isSaveClicked: boolean = useSelector(getIsSaveClicked);
   const usersPermissions: UsersPermissionsType =
     useSelector(getUsersPermissions);
+  const form = useForm();
   const location = useLocation();
 
-  const geometry = formApi.getFieldState(`${field}.geometry`)?.value;
-  const id = formApi.getFieldState(`${field}.id`)?.value;
-  const identifier = formApi.getFieldState(`${field}.identifier`)?.value;
-  const area = formApi.getFieldState(`${field}.area`)?.value;
-  const section_area = formApi.getFieldState(`${field}.section_area`)?.value;
-  const detailed_plan_identifier = formApi.getFieldState(
-    `${field}.detailed_plan_identifier`,
-  )?.value;
-  const detailed_plan_latest_processing_date = formApi.getFieldState(
-    `${field}.detailed_plan_latest_processing_date`,
-  )?.value;
-  const detailed_plan_latest_processing_date_note = formApi.getFieldState(
-    `${field}.detailed_plan_latest_processing_date_note`,
-  )?.value;
-  const plot_division_identifier = formApi.getFieldState(
-    `${field}.plot_division_identifier`,
-  )?.value;
-  const plot_division_state = formApi.getFieldState(
-    `${field}.plot_division_state`,
-  )?.value;
-  const plot_division_effective_date = formApi.getFieldState(
-    `${field}.plot_division_effective_date`,
-  )?.value;
-  const plan_unit_type = formApi.getFieldState(
-    `${field}.plan_unit_type`,
-  )?.value;
-  const plan_unit_state = formApi.getFieldState(
-    `${field}.plan_unit_state`,
-  )?.value;
-  const plan_unit_intended_use = formApi.getFieldState(
-    `${field}.plan_unit_intended_use`,
-  )?.value;
-  const is_master = formApi.getFieldState(`${field}.is_master`)?.value;
+  const {
+    input: { value: id },
+  } = useField(`${field}.id`, { subscription: { value: true } });
+  const {
+    input: { value: geometry },
+  } = useField(`${field}.geometry`, { subscription: { value: true } });
+  const {
+    input: { value: identifier },
+  } = useField(`${field}.identifier`, { subscription: { value: true } });
+  const {
+    input: { value: area },
+  } = useField(`${field}.area`, { subscription: { value: true } });
+  const {
+    input: { value: section_area },
+  } = useField(`${field}.section_area`, { subscription: { value: true } });
+  const {
+    input: { value: detailed_plan_identifier },
+  } = useField(`${field}.detailed_plan_identifier`, {
+    subscription: { value: true },
+  });
+  const {
+    input: { value: detailed_plan_latest_processing_date },
+  } = useField(`${field}.detailed_plan_latest_processing_date`, {
+    subscription: { value: true },
+  });
+  const {
+    input: { value: detailed_plan_latest_processing_date_note },
+  } = useField(`${field}.detailed_plan_latest_processing_date_note`, {
+    subscription: { value: true },
+  });
+  const {
+    input: { value: plot_division_identifier },
+  } = useField(`${field}.plot_division_identifier`, {
+    subscription: { value: true },
+  });
+  const {
+    input: { value: plot_division_state },
+  } = useField(`${field}.plot_division_state`, {
+    subscription: { value: true },
+  });
+  const {
+    input: { value: plot_division_effective_date },
+  } = useField(`${field}.plot_division_effective_date`, {
+    subscription: { value: true },
+  });
+  const {
+    input: { value: plan_unit_type },
+  } = useField(`${field}.plan_unit_type`, { subscription: { value: true } });
+  const {
+    input: { value: plan_unit_state },
+  } = useField(`${field}.plan_unit_state`, { subscription: { value: true } });
+  const {
+    input: { value: plan_unit_intended_use },
+  } = useField(`${field}.plan_unit_intended_use`, {
+    subscription: { value: true },
+  });
+  const {
+    input: { value: is_master },
+  } = useField(`${field}.is_master`, { subscription: { value: true } });
 
+  // Snapshot of values
   const initialValuesRef = useRef({
+    identifier,
+    area,
+    section_area,
+    detailed_plan_identifier,
+    detailed_plan_latest_processing_date,
+    detailed_plan_latest_processing_date_note,
+    plot_division_identifier,
+    plot_division_state,
+    plot_division_effective_date,
+    plan_unit_type,
+    plan_unit_state,
+    plan_unit_intended_use,
+    is_master,
+  });
+
+  const prevValuesRef = useRef({
     identifier,
     area,
     section_area,
@@ -97,57 +133,92 @@ const PlanUnitItemEdit: React.FC<Props> = ({
     plan_unit_intended_use,
   });
 
+  const isFirstRenderRef = useRef(true);
+
   useEffect(() => {
-    if (is_master) return;
+    const initial = initialValuesRef.current;
+    const prev = prevValuesRef.current;
+    const currentValues = {
+      identifier,
+      area,
+      section_area,
+      detailed_plan_identifier,
+      detailed_plan_latest_processing_date,
+      detailed_plan_latest_processing_date_note,
+      plot_division_identifier,
+      plot_division_state,
+      plot_division_effective_date,
+      plan_unit_type,
+      plan_unit_state,
+      plan_unit_intended_use,
+    };
 
-    const initialValues = initialValuesRef.current;
+    if (isFirstRenderRef.current) {
+      isFirstRenderRef.current = false;
+      return;
+    }
 
-    const hasChanged =
-      initialValues.identifier != identifier ||
-      initialValues.area != area ||
-      initialValues.section_area != section_area ||
-      initialValues.detailed_plan_identifier != detailed_plan_identifier ||
-      initialValues.detailed_plan_latest_processing_date !=
+    if (initial.is_master) {
+      prevValuesRef.current = currentValues;
+      return;
+    }
+
+    if (
+      initial.identifier == identifier &&
+      initial.area == area &&
+      initial.section_area == section_area &&
+      initial.detailed_plan_identifier == detailed_plan_identifier &&
+      initial.detailed_plan_latest_processing_date ==
+        detailed_plan_latest_processing_date &&
+      initial.detailed_plan_latest_processing_date_note ==
+        detailed_plan_latest_processing_date_note &&
+      initial.plot_division_identifier == plot_division_identifier &&
+      initial.plot_division_state == plot_division_state &&
+      initial.plot_division_effective_date == plot_division_effective_date &&
+      initial.plan_unit_type == plan_unit_type &&
+      initial.plan_unit_state == plan_unit_state &&
+      initial.plan_unit_intended_use == plan_unit_intended_use
+    ) {
+      form.change(`${field}.is_master`, false);
+      prevValuesRef.current = currentValues;
+      return;
+    }
+
+    if (is_master) {
+      prevValuesRef.current = currentValues;
+      return;
+    }
+
+    if (
+      prev.identifier != identifier ||
+      prev.area != area ||
+      prev.section_area != section_area ||
+      prev.detailed_plan_identifier != detailed_plan_identifier ||
+      prev.detailed_plan_latest_processing_date !=
         detailed_plan_latest_processing_date ||
-      initialValues.detailed_plan_latest_processing_date_note !=
+      prev.detailed_plan_latest_processing_date_note !=
         detailed_plan_latest_processing_date_note ||
-      initialValues.plot_division_identifier != plot_division_identifier ||
-      initialValues.plot_division_state != plot_division_state ||
-      initialValues.plot_division_effective_date !=
-        plot_division_effective_date ||
-      initialValues.plan_unit_type != plan_unit_type ||
-      initialValues.plan_unit_state != plan_unit_state ||
-      initialValues.plan_unit_intended_use != plan_unit_intended_use;
-
-    formApi.change(`${field}.is_master`, hasChanged);
-  }, [
-    identifier,
-    area,
-    section_area,
-    detailed_plan_identifier,
-    detailed_plan_latest_processing_date,
-    detailed_plan_latest_processing_date_note,
-    plot_division_identifier,
-    plot_division_state,
-    plot_division_effective_date,
-    plan_unit_type,
-    plan_unit_state,
-    plan_unit_intended_use,
-    is_master,
-    formApi,
-    field,
-    dispatch,
-  ]);
+      prev.plot_division_identifier != plot_division_identifier ||
+      prev.plot_division_state != plot_division_state ||
+      prev.plot_division_effective_date != plot_division_effective_date ||
+      prev.plan_unit_type != plan_unit_type ||
+      prev.plan_unit_state != plan_unit_state ||
+      prev.plan_unit_intended_use != plan_unit_intended_use
+    ) {
+      form.change(`${field}.is_master`, true);
+    }
+    prevValuesRef.current = currentValues;
+  });
 
   const getMapLinkUrl = () => {
     const { pathname, search } = location;
     const searchQuery = getUrlParams(search);
     delete searchQuery.lease_area;
     delete searchQuery.plot;
-    ((searchQuery.plan_unit = id), (searchQuery.tab = 7));
+    searchQuery.plan_unit = id;
+    searchQuery.tab = 7;
     return `${pathname}${getSearchQuery(searchQuery)}`;
   };
-  const mapLinkUrl = getMapLinkUrl();
 
   return (
     <BoxItem>
@@ -220,7 +291,7 @@ const PlanUnitItemEdit: React.FC<Props> = ({
               )}
             >
               {!isEmpty(geometry) && (
-                <Link to={mapLinkUrl}>
+                <Link to={getMapLinkUrl()}>
                   {LeasePlanUnitsFieldTitles.GEOMETRY}
                 </Link>
               )}
@@ -515,5 +586,4 @@ const PlanUnitItemEdit: React.FC<Props> = ({
   );
 };
 
-const formName = FormNames.LEASE_AREAS;
 export default PlanUnitItemEdit;


### PR DESCRIPTION
This pull request is now closed, due to some git shenaninganry.

Lease Areas plan units' render logic overhauled. Now current and pending plan units are read only and rendered with `PlanUnit` -component even in edit mode (edit mode used `PlanUnitEdit`-component). Plan units in contract stays editable. Also now we have no need for the odd `is_master` -logic and it's removed.