### PR TITLE
Remove range option from rent calculator

### DIFF
--- a/apps/leasing/src/components/constants.ts
+++ b/apps/leasing/src/components/constants.ts
@@ -11,10 +11,6 @@ export const RentCalculatorTypeOptions = [
     label: "Vuosi",
   },
   {
-    value: RentCalculatorTypes.RANGE,
-    label: "Aikaväli",
-  },
-  {
     value: RentCalculatorTypes.BILLING_PERIOD,
     label: "Laskutuskausi",
   },

--- a/apps/leasing/src/components/enums.ts
+++ b/apps/leasing/src/components/enums.ts
@@ -28,7 +28,6 @@ export const ButtonLabels = {
  */
 export const RentCalculatorTypes = {
   YEAR: "year",
-  RANGE: "range",
   BILLING_PERIOD: "billing_period",
 };
 

--- a/apps/leasing/src/components/formValidations.ts
+++ b/apps/leasing/src/components/formValidations.ts
@@ -10,22 +10,6 @@ export const validateRentCalculatorForm = (values: Record<string, any>) => {
       else if (year(values.year)) errors.yearErrors = year(values.year);
       break;
 
-    case RentCalculatorTypes.RANGE:
-      if (!values.billing_start_date || !values.billing_end_date) {
-        errors.rangeErrors = "Alku- ja loppupvm ovat pakollisia";
-      } else if (
-        new Date(values.billing_start_date).getFullYear() !==
-        new Date(values.billing_end_date).getFullYear()
-      ) {
-        errors.rangeErrors =
-          "Alku- ja loppupäivämäärän tulee olla samana vuonna";
-      } else if (values.billing_end_date < values.billing_start_date) {
-        errors.rangeErrors =
-          "Loppupäivämäärän tulee olla alkupäivämäärän jälkeen";
-      }
-
-      break;
-
     case RentCalculatorTypes.BILLING_PERIOD:
       if (isEmptyValue(values.billing_period))
         errors.billingPeriodErrors = "Laskutuskausi on pakollinen";

--- a/apps/leasing/src/components/rent-calculator/RentCalculator.tsx
+++ b/apps/leasing/src/components/rent-calculator/RentCalculator.tsx
@@ -74,8 +74,6 @@ const RentCalculator: React.FC<Props> = ({ formApi }) => {
   }, [formApi]);
 
   const billingPeriod = formValues.billing_period;
-  const endDate = formValues.billing_end_date;
-  const startDate = formValues.billing_start_date;
   const type: RentCalculatorType = formValues.type;
   const year = formValues.year;
 
@@ -152,11 +150,6 @@ const RentCalculator: React.FC<Props> = ({ formApi }) => {
         requestEndDate = tempEndDate;
         break;
       }
-
-      case RentCalculatorTypes.RANGE:
-        requestStartDate = startDate;
-        requestEndDate = endDate;
-        break;
 
       case RentCalculatorTypes.BILLING_PERIOD:
         if (billingPeriods.length > billingPeriod) {

--- a/apps/leasing/src/components/rent-calculator/RentCalculatorForm.tsx
+++ b/apps/leasing/src/components/rent-calculator/RentCalculatorForm.tsx
@@ -112,59 +112,6 @@ const RentCalculatorForm: React.FC<Props> = ({
         },
       },
       {
-        value: RentCalculatorTypes.RANGE,
-        label: "Aikaväli",
-        labelStyles: {
-          minWidth: "115px",
-        },
-        field: (
-          <Row>
-            <Column small={6}>
-              <FormField
-                fieldAttributes={{
-                  label: "Alkupvm",
-                  type: "date",
-                  read_only: false,
-                }}
-                name="billing_start_date"
-                disabled={type !== RentCalculatorTypes.RANGE}
-                disableDirty
-                invisibleLabel
-              />
-            </Column>
-            <Column small={6}>
-              <FormField
-                className="with-dash"
-                fieldAttributes={{
-                  label: "Loppupvm",
-                  type: "date",
-                  read_only: false,
-                }}
-                name="billing_end_date"
-                disabled={type !== RentCalculatorTypes.RANGE}
-                disableDirty
-                invisibleLabel
-              />
-            </Column>
-          </Row>
-        ),
-        fieldStyles: {
-          width: "180px",
-        },
-        errorField: (
-          <ErrorField
-            showError={showErrors && !!errors.rangeErrors}
-            meta={{ error: errors.rangeErrors }}
-            style={{
-              marginTop: "-10px",
-            }}
-          />
-        ),
-        errorFieldStyles: {
-          width: "180px",
-        },
-      },
-      {
         value: RentCalculatorTypes.BILLING_PERIOD,
         label: "Laskutuskausi",
         labelStyles: {

--- a/apps/leasing/src/components/rent-calculator/RentForPeriod.tsx
+++ b/apps/leasing/src/components/rent-calculator/RentForPeriod.tsx
@@ -19,7 +19,6 @@ const RentForPeriod = ({ onRemove, rentForPeriod }: Props) => {
       case RentCalculatorTypes.YEAR:
         return `${getLabelOfOption(RentCalculatorTypeOptions, rentForPeriod.rentCalculatorType) || ""} ${new Date(rentForPeriod.start_date).getFullYear()}`;
 
-      case RentCalculatorTypes.RANGE:
       case RentCalculatorTypes.BILLING_PERIOD:
         return `${getLabelOfOption(RentCalculatorTypeOptions, rentForPeriod.rentCalculatorType) || ""} ${formatDateRange(rentForPeriod.start_date, rentForPeriod.end_date)}`;
     }

--- a/apps/leasing/src/leases/components/LeasePage.tsx
+++ b/apps/leasing/src/leases/components/LeasePage.tsx
@@ -801,8 +801,6 @@ const LeasePage: React.FC<Props> = (props) => {
     leaseRentCalculatorFormRef.current.initialize({
       type: RentCalculatorTypes.YEAR,
       year: currentYear,
-      billing_start_date: `${currentYear}-01-01`,
-      billing_end_date: `${currentYear}-12-31`,
     });
     initialize(FormNames.LEASE_BASIS_OF_RENTS, {
       basis_of_rents: getContentBasisOfRents(lease).filter(

--- a/apps/leasing/src/leases/components/leaseSections/rent/Rents.tsx
+++ b/apps/leasing/src/leases/components/leaseSections/rent/Rents.tsx
@@ -63,8 +63,6 @@ const Rents: React.FC = () => {
       initialValues: {
         type: RentCalculatorTypes.YEAR,
         year: currentYear,
-        billing_start_date: `${currentYear}-01-01`,
-        billing_end_date: `${currentYear}-12-31`,
       },
     }),
   );


### PR DESCRIPTION
Likely doesn't require any changes to API, as the other options call the same endpoint with same parameters.