### PR TITLE
Fix stale values in LeasePage

### DIFF
--- a/apps/leasing/src/leases/components/LeasePage.tsx
+++ b/apps/leasing/src/leases/components/LeasePage.tsx
@@ -353,6 +353,16 @@ const LeasePage: React.FC<Props> = (props) => {
     basisOfRentsFormValues,
     leaseId,
     isFormValidFlags,
+    isEditMode,
+    summaryFormState,
+    tenantsFormState,
+    constructabilityFormState,
+    contractsFormState,
+    decisionsFormState,
+    inspectionsFormState,
+    leaseAreasFormState,
+    rentsFormState,
+    rentCalculatorFormState,
   });
   currentValuesRef.current = {
     contractsFormValues,
@@ -363,6 +373,16 @@ const LeasePage: React.FC<Props> = (props) => {
     basisOfRentsFormValues,
     leaseId,
     isFormValidFlags,
+    isEditMode,
+    summaryFormState,
+    tenantsFormState,
+    constructabilityFormState,
+    contractsFormState,
+    decisionsFormState,
+    inspectionsFormState,
+    leaseAreasFormState,
+    rentsFormState,
+    rentCalculatorFormState,
   };
 
   const timerAutoSave = useRef<NodeJS.Timeout>();
@@ -675,6 +695,8 @@ const LeasePage: React.FC<Props> = (props) => {
   };
 
   const handleLeavePage = (e) => {
+    const { isEditMode } = currentValuesRef.current;
+
     if (isAnyFormDirty() && isEditMode) {
       const confirmationMessage = "";
       e.returnValue = confirmationMessage; // Gecko, Trident, Chrome 34+
@@ -939,6 +961,14 @@ const LeasePage: React.FC<Props> = (props) => {
       isFormValidFlags,
       isBasisOfRentsFormDirty,
       basisOfRentsFormValues,
+      summaryFormState,
+      tenantsFormState,
+      constructabilityFormState,
+      contractsFormState,
+      decisionsFormState,
+      inspectionsFormState,
+      leaseAreasFormState,
+      rentsFormState,
     } = currentValuesRef.current;
 
     let isDirty = false;
@@ -984,7 +1014,10 @@ const LeasePage: React.FC<Props> = (props) => {
     }
 
     if (leaseAreasFormState.dirty) {
-      setSessionStorageItem(FormNames.LEASE_AREAS, areasFormValues);
+      setSessionStorageItem(
+        FormNames.LEASE_AREAS,
+        leaseAreasFormRef.current.getState().values,
+      );
       isDirty = true;
     } else {
       removeSessionStorageItem(FormNames.LEASE_AREAS);
@@ -1162,6 +1195,18 @@ const LeasePage: React.FC<Props> = (props) => {
   };
 
   const isAnyFormDirty = () => {
+    const {
+      isBasisOfRentsFormDirty,
+      summaryFormState,
+      tenantsFormState,
+      constructabilityFormState,
+      contractsFormState,
+      decisionsFormState,
+      inspectionsFormState,
+      leaseAreasFormState,
+      rentsFormState,
+    } = currentValuesRef.current;
+
     return (
       constructabilityFormState.dirty ||
       contractsFormState.dirty ||


### PR DESCRIPTION
Also fixes lease area form session storage saving


For some reason a bunch of issues relating to dirty states popped up again. Adding the required values to the refs helped to fix almost all of these. These issues caused the dirty states to display incorrectly and cause session storage functionality to occasionally not store any values.