### PR TITLE
Update react-router@7.18.1 & remove react-router-dom

### DIFF
--- a/apps/landuse/src/landUse/LandUseApp.tsx
+++ b/apps/landuse/src/landUse/LandUseApp.tsx
@@ -4,7 +4,7 @@ import {
   Routes as RouterRoutes,
   Route,
   useLocation,
-} from "react-router-dom";
+} from "react-router";
 import { Footer, useOidcClient, useAuthenticatedUser } from "hds-react";
 import LoginPage from "@/landUse/auth/LoginPage";
 import { setRedirectUrlToSessionStorage } from "@/landUse/utils/storage";

--- a/apps/landuse/src/landUse/auth/CallbackPage.tsx
+++ b/apps/landuse/src/landUse/auth/CallbackPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { LoginCallbackHandler, isHandlingLoginCallbackError } from "hds-react";
 import type { OidcClientError, User } from "hds-react";
 import { getRedirectUrlFromSessionStorage } from "@/landUse/utils/storage";

--- a/apps/landuse/src/landUse/components/LandUseDetailPage.tsx
+++ b/apps/landuse/src/landUse/components/LandUseDetailPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback } from "react";
-import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router";
 import {
   Breadcrumb,
   Tabs,

--- a/apps/landuse/src/landUse/components/LandUseListPage.tsx
+++ b/apps/landuse/src/landUse/components/LandUseListPage.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 import {
   Button,
   ButtonVariant,

--- a/apps/landuse/src/landUse/components/__tests__/LandUseDetailPage.spec.tsx
+++ b/apps/landuse/src/landUse/components/__tests__/LandUseDetailPage.spec.tsx
@@ -16,7 +16,7 @@ import { LAND_USE_NEGOTIATION_PHASES } from "../../options";
 const mockNavigate = vi.fn();
 let mockLocationSearch = "";
 
-vi.mock("react-router-dom", () => ({
+vi.mock("react-router", () => ({
   useParams: () => ({ id: "LU-1" }),
   useLocation: () => ({ search: mockLocationSearch }),
   useNavigate: () => mockNavigate,

--- a/apps/landuse/src/landUse/index.tsx
+++ b/apps/landuse/src/landUse/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import * as Sentry from "@sentry/react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router";
 import { LoginProvider } from "hds-react";
 import { QueryClient } from "@tanstack/react-query";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";

--- a/apps/leasing/src/areaSearch/components/map/AreaSearchLayer.tsx
+++ b/apps/leasing/src/areaSearch/components/map/AreaSearchLayer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { FeatureGroup, GeoJSON, Popup } from "react-leaflet";
 import { flowRight } from "lodash-es";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { getRouteById, Routes } from "@/root/routes";
 import type { Attributes, LeafletGeoJson } from "types";
 import { withAreaSearchAttributes } from "@/components/attributes/AreaSearchAttributes";

--- a/apps/leasing/src/components/sideMenu/SideMenu.tsx
+++ b/apps/leasing/src/components/sideMenu/SideMenu.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import {
   withRouterLegacy,
   type WithRouterProps,

--- a/apps/leasing/src/components/sideMenu/SubMenu.tsx
+++ b/apps/leasing/src/components/sideMenu/SubMenu.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import classNames from "classnames";
 import BackIcon from "@/components/icons/BackIcon";
 import Authorization from "@/components/authorization/Authorization";

--- a/apps/leasing/src/components/topNavigation/TopNavigation.tsx
+++ b/apps/leasing/src/components/topNavigation/TopNavigation.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import classNames from "classnames";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { IconMenuDots, IconSize } from "hds-react";
 import {
   withRouterLegacy,

--- a/apps/leasing/src/index.tsx
+++ b/apps/leasing/src/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import * as Sentry from "@sentry/react";
 import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router";
 import { LoginProvider } from "hds-react";
 import configureStore from "@/root/configureStore";
 import routes from "@/root/routes";

--- a/apps/leasing/src/infillDevelopment/components/sections/basicInfo/LeaseInfo.tsx
+++ b/apps/leasing/src/infillDevelopment/components/sections/basicInfo/LeaseInfo.tsx
@@ -1,8 +1,7 @@
 import React, { Fragment } from "react";
 import { connect } from "react-redux";
 import { Row, Column } from "@/components/grid/Grid";
-import { useLocation } from "react-router";
-import { Link } from "react-router-dom";
+import { useLocation, Link } from "react-router";
 import { flowRight, get } from "lodash-es";
 import Authorization from "@/components/authorization/Authorization";
 import ExternalLink from "@/components/links/ExternalLink";

--- a/apps/leasing/src/leases/components/leaseSections/leaseArea/LeaseArea.tsx
+++ b/apps/leasing/src/leases/components/leaseSections/leaseArea/LeaseArea.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Row, Column } from "@/components/grid/Grid";
-import { useLocation } from "react-router";
-import { Link } from "react-router-dom";
+import { useLocation, Link } from "react-router";
 import { get, isEmpty } from "lodash-es";
 import Authorization from "@/components/authorization/Authorization";
 import BoxItemContainer from "@/components/content/BoxItemContainer";

--- a/apps/leasing/src/leases/components/leaseSections/leaseArea/LeaseAreaEdit.tsx
+++ b/apps/leasing/src/leases/components/leaseSections/leaseArea/LeaseAreaEdit.tsx
@@ -1,8 +1,7 @@
 import React, { ReactElement } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Row, Column } from "@/components/grid/Grid";
-import { useLocation } from "react-router";
-import { Link } from "react-router-dom";
+import { useLocation, Link } from "react-router";
 import { ActionTypes, AppConsumer } from "@/app/AppContext";
 import AddButtonSecondary from "@/components/form/AddButtonSecondary";
 import AddButtonThird from "@/components/form/AddButtonThird";

--- a/apps/leasing/src/leases/components/leaseSections/leaseArea/PlanUnitItem.tsx
+++ b/apps/leasing/src/leases/components/leaseSections/leaseArea/PlanUnitItem.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useSelector } from "react-redux";
-import { useLocation } from "react-router";
-import { Link } from "react-router-dom";
+import { useLocation, Link } from "react-router";
 import { Row, Column } from "@/components/grid/Grid";
 import { isEmpty } from "lodash-es";
 import Authorization from "@/components/authorization/Authorization";

--- a/apps/leasing/src/leases/components/leaseSections/leaseArea/PlanUnitItemEdit.tsx
+++ b/apps/leasing/src/leases/components/leaseSections/leaseArea/PlanUnitItemEdit.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { useSelector } from "react-redux";
 import { Row, Column } from "@/components/grid/Grid";
-import { useLocation } from "react-router";
-import { Link } from "react-router-dom";
+import { useLocation, Link } from "react-router";
 import { useField } from "react-final-form";
 import { isEmpty } from "lodash-es";
 import ActionButtonWrapper from "@/components/form/ActionButtonWrapper";

--- a/apps/leasing/src/leases/components/leaseSections/leaseArea/PlotItem.tsx
+++ b/apps/leasing/src/leases/components/leaseSections/leaseArea/PlotItem.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useSelector } from "react-redux";
-import { useLocation } from "react-router";
-import { Link } from "react-router-dom";
+import { useLocation, Link } from "react-router";
 import { Row, Column } from "@/components/grid/Grid";
 import { isEmpty } from "lodash-es";
 import Authorization from "@/components/authorization/Authorization";

--- a/apps/leasing/src/leases/components/leaseSections/leaseArea/PlotItemEdit.tsx
+++ b/apps/leasing/src/leases/components/leaseSections/leaseArea/PlotItemEdit.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { useSelector } from "react-redux";
 import { Row, Column } from "@/components/grid/Grid";
-import { useLocation } from "react-router";
-import { Link } from "react-router-dom";
+import { useLocation, Link } from "react-router";
 import ActionButtonWrapper from "@/components/form/ActionButtonWrapper";
 import Authorization from "@/components/authorization/Authorization";
 import BoxContentWrapper from "@/components/content/BoxContentWrapper";

--- a/apps/leasing/src/plotApplications/components/map/TargetListLayer.tsx
+++ b/apps/leasing/src/plotApplications/components/map/TargetListLayer.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { FeatureGroup, GeoJSON, Popup } from "react-leaflet";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { getRouteById, Routes } from "@/root/routes";
 import type { LeafletGeoJson } from "types";
 

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "react-dom": "18.3.1",
     "react-final-form": "6.5.9",
     "react-final-form-arrays": "4.0.0",
-    "react-router": "6.30.4",
-    "react-router-dom": "6.30.4"
+    "react-router": "7.18.1"
   },
   "devDependencies": {
     "@babel/core": "7.29.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2931,13 +2931,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.23.3":
-  version: 1.23.3
-  resolution: "@remix-run/router@npm:1.23.3"
-  checksum: 10c0/73622465dd9e9a2c5a7ced7d1151ea6e9195a8a979c99b4f70a67093eeff7f339daf03a7c6304709a9c27deb2081a8fff6737663aacb33529c1a12a0a0827a17
-  languageName: node
-  linkType: hard
-
 "@rolldown/binding-android-arm64@npm:1.1.4":
   version: 1.1.4
   resolution: "@rolldown/binding-android-arm64@npm:1.1.4"
@@ -4789,6 +4782,13 @@ __metadata:
   version: 0.7.2
   resolution: "cookie@npm:0.7.2"
   checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2
+  languageName: node
+  linkType: hard
+
+"cookie@npm:^1.0.1":
+  version: 1.1.1
+  resolution: "cookie@npm:1.1.1"
+  checksum: 10c0/79c4ddc0fcad9c4f045f826f42edf54bcc921a29586a4558b0898277fa89fb47be95bc384c2253f493af7b29500c830da28341274527328f18eba9f58afa112c
   languageName: node
   linkType: hard
 
@@ -7873,8 +7873,7 @@ __metadata:
     react-dom: "npm:18.3.1"
     react-final-form: "npm:6.5.9"
     react-final-form-arrays: "npm:4.0.0"
-    react-router: "npm:6.30.4"
-    react-router-dom: "npm:6.30.4"
+    react-router: "npm:7.18.1"
     sass: "npm:1.79.6"
     ts-node: "npm:10.9.2"
     tsconfig-paths: "npm:4.2.0"
@@ -8626,27 +8625,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:6.30.4":
-  version: 6.30.4
-  resolution: "react-router-dom@npm:6.30.4"
+"react-router@npm:7.18.1":
+  version: 7.18.1
+  resolution: "react-router@npm:7.18.1"
   dependencies:
-    "@remix-run/router": "npm:1.23.3"
-    react-router: "npm:6.30.4"
+    cookie: "npm:^1.0.1"
+    set-cookie-parser: "npm:^2.6.0"
   peerDependencies:
-    react: ">=16.8"
-    react-dom: ">=16.8"
-  checksum: 10c0/1b25ab26a288da852f7b58eec5c14b3f37919e6773a557cd846d3a05d7a7d890c8d49bda93c0a7f497f240df1df8b0ad50635f990aafb55f2fc545ad8269a822
-  languageName: node
-  linkType: hard
-
-"react-router@npm:6.30.4":
-  version: 6.30.4
-  resolution: "react-router@npm:6.30.4"
-  dependencies:
-    "@remix-run/router": "npm:1.23.3"
-  peerDependencies:
-    react: ">=16.8"
-  checksum: 10c0/fb6de7d1002bcab9ea12c4072d93792eca494f1e4f30cfec334ccb6523756d23ce3e093c7c1241399296cebed94789a3fb89f96ee76004e0e746458a8f6bab33
+    react: ">=18"
+    react-dom: ">=18"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+  checksum: 10c0/1a559de58d656bad5565f2232e4f4fab7e9f5282dfaf95bc24f195a06e7e85b281077fe5c21ed3ff527e3d90d930447e0d0bb0f0713950d2a56ad0f0377a7d09
   languageName: node
   linkType: hard
 
@@ -9388,6 +9379,13 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10c0/b1f3127a5be8125a94f37188b361c212466c292c6910adce3ec106cff5dc211ccaedc4739c11bb70fda59d6fc1f040a9bca289f4e093451521a2372e5231fe0c
+  languageName: node
+  linkType: hard
+
+"set-cookie-parser@npm:^2.6.0":
+  version: 2.7.2
+  resolution: "set-cookie-parser@npm:2.7.2"
+  checksum: 10c0/4381a9eb7ee951dfe393fe7aacf76b9a3b4e93a684d2162ab35594fa4053cc82a4d7d7582bf397718012c9adcf839b8cd8f57c6c42901ea9effe33c752da4a45
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Turns out we were not using any of the features receiving breaking changes. Except react-router-dom itself which is now fully included in react-router.
Updating to v8 was not possible, as it requires React 19+