### PR TITLE
Update to UBI9 nginx 1.26 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY --chown=default:root . /app
 RUN yarn build
 
 # =============================
-FROM registry.access.redhat.com/ubi9/nginx-120 AS production
+FROM registry.access.redhat.com/ubi9/nginx-126 AS production
 # =============================
 
 USER root


### PR DESCRIPTION
Nginx 1.20 had a critical vulnerability.